### PR TITLE
Don't double-iterate during MultiDict initialization

### DIFF
--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -185,12 +185,13 @@ class MultiDict(_Base, abc.MutableMapping):
             elif hasattr(arg, 'items'):
                 items = arg.items()
             else:
+                items = []
                 for item in arg:
                     if not len(item) == 2:
                         raise TypeError(
                             "{} takes either dict or list of (key, value) "
                             "tuples".format(name))
-                items = arg
+                    items.append(item)
 
             for key, value in items:
                 method(key, value)

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -73,6 +73,15 @@ class _BaseTest(_Root):
         self.assertEqual(sorted(d.items()), [('key', 'value1'),
                                              ('key2', 'value2')])
 
+    def test_instantiate__from_generator(self):
+        d = self.make_dict((str(i), i) for i in range(2))
+
+        self.assertEqual(d, {'0': 0, '1': 1})
+        self.assertEqual(len(d), 2)
+        self.assertEqual(sorted(d.keys()), ['0', '1'])
+        self.assertEqual(sorted(d.values()), [0, 1])
+        self.assertEqual(sorted(d.items()), [('0', 0), ('1', 1)])
+
     def test_getone(self):
         d = self.make_dict([('key', 'value1')], key='value2')
         self.assertEqual(d.getone('key'), 'value1')


### PR DESCRIPTION
Previously, the MultiDict constructor iterated twice over its argument:
once as a sanity check on its contents, and once again to add those
contents to the dictionary. If a generator was passed as an argument,
the first iteration would drain it, and the resulting dictionary would
be empty.

To fix this, save the contents of the generator in another list. This
fixes #2.