### PR TITLE
Title cased

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,13 +32,13 @@ their own content.
 ``CIMultiDictProxy``) ones assumes the *keys* are case
 insensitive, e.g.::
 
-   >>> dct = CIMultiDict(a='val')
-   >>> 'A' in dct
+   >>> dct = CIMultiDict(key='val')
+   >>> 'Key' in dct
    True
-   >>> dct['A']
+   >>> dct['Key']
    'val'
 
-*Keys* should be ``str`` instances.
+*Keys* should be ``str`` or ``istr`` instances.
 
 The library has optional Cython optimization for sake of speed.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,13 +36,13 @@ their own content.
 :class:`CIMultiDictProxy`) ones assumes the *keys* are case
 insensitive, e.g.::
 
-   >>> dct = CIMultiDict(a='val')
-   >>> 'A' in dct
+   >>> dct = CIMultiDict(key='val')
+   >>> 'Key' in dct
    True
-   >>> dct['A']
+   >>> dct['Key']
    'val'
 
-*Keys* should be a :class:`str`.
+*Keys* should be either :class:`str` or :class:`istr` instance.
 
 The library has optional Cython optimization for sake of speed.
 

--- a/docs/multidict.rst
+++ b/docs/multidict.rst
@@ -300,33 +300,38 @@ CIMultiDictProxy
    The class is inherited from :class:`MultiDict`.
 
 
-upstr
-=====
+istr
+====
 
 :class:`CIMultiDict` accepts :class:`str` as *key* argument for dict
-lookups but converts it to upper case internally.
+lookups but converts it to title case internally.
 
-For more effective processing it should know if the *key* is already upper cased.
+Title case means every word in key will be capitalized,
+e.g. ``istr('content-length')`` internally will be converted to
+``'Content-Length'``.
 
-To skip the :meth:`~str.upper()` call you may want to create upper cased strings by
-hand, e.g::
+For more effective processing it should know if the *key* is already
+title cased.
 
-   >>> key = upstr('Key')
+To skip the :meth:`~str.title()` call you may want to create title
+cased strings by hands, e.g::
+
+   >>> key = istr('Key')
    >>> key
-   'KEY'
+   'Key'
    >>> mdict = CIMultiDict(key='value')
    >>> key in mdict
    True
    >>> mdict[key]
    'value'
 
-For performance you should create :class:`upstr` strings once and
+For performance you should create :class:`istr` strings once and
 store them globally, like :mod:`aiohttp.hdrs` does.
 
-.. class:: upstr(object='')
-           upstr(bytes_or_buffer[, encoding[, errors]])
+.. class:: istr(object='')
+           istr(bytes_or_buffer[, encoding[, errors]])
 
-      Create a new **upper cased** string object from the given
+      Create a new **title cased** string object from the given
       *object*. If *encoding* or *errors* are specified, then the
       object must expose a data buffer that will be decoded using the
       given encoding and error handler.
@@ -340,3 +345,11 @@ store them globally, like :mod:`aiohttp.hdrs` does.
 
       The class is inherited from :class:`str` and has all regular
       string methods.
+
+.. versionchanged:: 2.0
+
+   ``upstr`` has renamed to ``istr`` with keeping ``upstr`` alias.
+
+   The behavior remains the same with the only exception:
+   ``repr('Content-Length')`` and ``str('Content-Length')`` now
+   returns ``'Content-Length'`` instead of ``'CONTENT-LENGTH'``.

--- a/multidict/__init__.py
+++ b/multidict/__init__.py
@@ -8,7 +8,7 @@ several values for the same key.
 import os
 
 __all__ = ('MultiDictProxy', 'CIMultiDictProxy',
-           'MultiDict', 'CIMultiDict', 'upstr')
+           'MultiDict', 'CIMultiDict', 'upstr', 'istr')
 
 __version__ = '1.2.1'
 
@@ -18,17 +18,17 @@ if bool(os.environ.get('MULTIDICT_NO_EXTENSIONS')):
                                 CIMultiDictProxy,
                                 MultiDict,
                                 CIMultiDict,
-                                upstr)
+                                upstr, istr)
 else:
     try:
         from ._multidict import (MultiDictProxy,
                                  CIMultiDictProxy,
                                  MultiDict,
                                  CIMultiDict,
-                                 upstr)
+                                 upstr, istr)
     except ImportError:  # pragma: no cover
         from ._multidict_py import (MultiDictProxy,
                                     CIMultiDictProxy,
                                     MultiDict,
                                     CIMultiDict,
-                                    upstr)
+                                    upstr, istr)

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -505,7 +505,7 @@ struct __pyx_defaults {
   PyObject *__pyx_arg_encoding;
 };
 
-/* "multidict/_multidict.pyx":52
+/* "multidict/_multidict.pyx":55
  * 
  * 
  * cdef class _Pair:             # <<<<<<<<<<<<<<
@@ -519,7 +519,7 @@ struct __pyx_obj_9multidict_10_multidict__Pair {
 };
 
 
-/* "multidict/_multidict.pyx":71
+/* "multidict/_multidict.pyx":74
  *             return left._key != right._key and left._value != right._value
  * 
  * cdef class _Base:             # <<<<<<<<<<<<<<
@@ -535,7 +535,7 @@ struct __pyx_obj_9multidict_10_multidict__Base {
 };
 
 
-/* "multidict/_multidict.pyx":199
+/* "multidict/_multidict.pyx":202
  * 
  * 
  * cdef class MultiDictProxy(_Base):             # <<<<<<<<<<<<<<
@@ -547,7 +547,7 @@ struct __pyx_obj_9multidict_10_multidict_MultiDictProxy {
 };
 
 
-/* "multidict/_multidict.pyx":218
+/* "multidict/_multidict.pyx":221
  * 
  * 
  * cdef class CIMultiDictProxy(MultiDictProxy):             # <<<<<<<<<<<<<<
@@ -559,7 +559,7 @@ struct __pyx_obj_9multidict_10_multidict_CIMultiDictProxy {
 };
 
 
-/* "multidict/_multidict.pyx":243
+/* "multidict/_multidict.pyx":246
  * 
  * 
  * cdef class MultiDict(_Base):             # <<<<<<<<<<<<<<
@@ -571,7 +571,7 @@ struct __pyx_obj_9multidict_10_multidict_MultiDict {
 };
 
 
-/* "multidict/_multidict.pyx":413
+/* "multidict/_multidict.pyx":416
  * 
  * 
  * cdef class CIMultiDict(MultiDict):             # <<<<<<<<<<<<<<
@@ -583,7 +583,7 @@ struct __pyx_obj_9multidict_10_multidict_CIMultiDict {
 };
 
 
-/* "multidict/_multidict.pyx":426
+/* "multidict/_multidict.pyx":429
  * 
  * 
  * cdef class _ViewBase:             # <<<<<<<<<<<<<<
@@ -596,7 +596,7 @@ struct __pyx_obj_9multidict_10_multidict__ViewBase {
 };
 
 
-/* "multidict/_multidict.pyx":437
+/* "multidict/_multidict.pyx":440
  * 
  * 
  * cdef class _ViewBaseSet(_ViewBase):             # <<<<<<<<<<<<<<
@@ -608,7 +608,7 @@ struct __pyx_obj_9multidict_10_multidict__ViewBaseSet {
 };
 
 
-/* "multidict/_multidict.pyx":502
+/* "multidict/_multidict.pyx":505
  * 
  * 
  * cdef class _ItemsIter:             # <<<<<<<<<<<<<<
@@ -623,7 +623,7 @@ struct __pyx_obj_9multidict_10_multidict__ItemsIter {
 };
 
 
-/* "multidict/_multidict.pyx":523
+/* "multidict/_multidict.pyx":526
  * 
  * 
  * cdef class _ItemsView(_ViewBaseSet):             # <<<<<<<<<<<<<<
@@ -635,7 +635,7 @@ struct __pyx_obj_9multidict_10_multidict__ItemsView {
 };
 
 
-/* "multidict/_multidict.pyx":558
+/* "multidict/_multidict.pyx":561
  * 
  * 
  * cdef class _ValuesIter:             # <<<<<<<<<<<<<<
@@ -650,7 +650,7 @@ struct __pyx_obj_9multidict_10_multidict__ValuesIter {
 };
 
 
-/* "multidict/_multidict.pyx":579
+/* "multidict/_multidict.pyx":582
  * 
  * 
  * cdef class _ValuesView(_ViewBase):             # <<<<<<<<<<<<<<
@@ -662,7 +662,7 @@ struct __pyx_obj_9multidict_10_multidict__ValuesView {
 };
 
 
-/* "multidict/_multidict.pyx":605
+/* "multidict/_multidict.pyx":608
  * 
  * 
  * cdef class _KeysIter:             # <<<<<<<<<<<<<<
@@ -677,7 +677,7 @@ struct __pyx_obj_9multidict_10_multidict__KeysIter {
 };
 
 
-/* "multidict/_multidict.pyx":626
+/* "multidict/_multidict.pyx":629
  * 
  * 
  * cdef class _KeysView(_ViewBaseSet):             # <<<<<<<<<<<<<<
@@ -690,7 +690,7 @@ struct __pyx_obj_9multidict_10_multidict__KeysView {
 
 
 
-/* "multidict/_multidict.pyx":71
+/* "multidict/_multidict.pyx":74
  *             return left._key != right._key and left._value != right._value
  * 
  * cdef class _Base:             # <<<<<<<<<<<<<<
@@ -699,7 +699,7 @@ struct __pyx_obj_9multidict_10_multidict__KeysView {
  */
 
 struct __pyx_vtabstruct_9multidict_10_multidict__Base {
-  PyObject *(*_upper)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *);
+  PyObject *(*_title)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *);
   PyObject *(*_getall)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *, PyObject *);
   PyObject *(*_getone)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *, PyObject *);
   PyObject *(*_contains)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *);
@@ -709,7 +709,7 @@ struct __pyx_vtabstruct_9multidict_10_multidict__Base {
 static struct __pyx_vtabstruct_9multidict_10_multidict__Base *__pyx_vtabptr_9multidict_10_multidict__Base;
 
 
-/* "multidict/_multidict.pyx":199
+/* "multidict/_multidict.pyx":202
  * 
  * 
  * cdef class MultiDictProxy(_Base):             # <<<<<<<<<<<<<<
@@ -723,7 +723,7 @@ struct __pyx_vtabstruct_9multidict_10_multidict_MultiDictProxy {
 static struct __pyx_vtabstruct_9multidict_10_multidict_MultiDictProxy *__pyx_vtabptr_9multidict_10_multidict_MultiDictProxy;
 
 
-/* "multidict/_multidict.pyx":218
+/* "multidict/_multidict.pyx":221
  * 
  * 
  * cdef class CIMultiDictProxy(MultiDictProxy):             # <<<<<<<<<<<<<<
@@ -737,7 +737,7 @@ struct __pyx_vtabstruct_9multidict_10_multidict_CIMultiDictProxy {
 static struct __pyx_vtabstruct_9multidict_10_multidict_CIMultiDictProxy *__pyx_vtabptr_9multidict_10_multidict_CIMultiDictProxy;
 
 
-/* "multidict/_multidict.pyx":243
+/* "multidict/_multidict.pyx":246
  * 
  * 
  * cdef class MultiDict(_Base):             # <<<<<<<<<<<<<<
@@ -755,7 +755,7 @@ struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict {
 static struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *__pyx_vtabptr_9multidict_10_multidict_MultiDict;
 
 
-/* "multidict/_multidict.pyx":413
+/* "multidict/_multidict.pyx":416
  * 
  * 
  * cdef class CIMultiDict(MultiDict):             # <<<<<<<<<<<<<<
@@ -1203,18 +1203,18 @@ static int __Pyx_check_binary_version(void);
 /* InitStrings.proto */
 static int __Pyx_InitStrings(__Pyx_StringTabEntry *t);
 
-static PyObject *__pyx_f_9multidict_10_multidict_5_Base__upper(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_s); /* proto*/
+static PyObject *__pyx_f_9multidict_10_multidict_5_Base__title(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_s); /* proto*/
 static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_default); /* proto*/
 static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_default); /* proto*/
 static PyObject *__pyx_f_9multidict_10_multidict_5_Base__contains(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_key); /* proto*/
 static PyObject *__pyx_f_9multidict_10_multidict_5_Base_keys(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, int __pyx_skip_dispatch); /* proto*/
 static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_other); /* proto*/
-static PyObject *__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__upper(struct __pyx_obj_9multidict_10_multidict_CIMultiDictProxy *__pyx_v_self, PyObject *__pyx_v_s); /* proto*/
+static PyObject *__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__title(struct __pyx_obj_9multidict_10_multidict_CIMultiDictProxy *__pyx_v_self, PyObject *__pyx_v_s); /* proto*/
 static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx_obj_9multidict_10_multidict_MultiDict *__pyx_v_self, PyObject *__pyx_v_args, PyObject *__pyx_v_kwargs, PyObject *__pyx_v_name, int __pyx_v_do_add); /* proto*/
 static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__add(struct __pyx_obj_9multidict_10_multidict_MultiDict *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_value); /* proto*/
 static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__replace(struct __pyx_obj_9multidict_10_multidict_MultiDict *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_value); /* proto*/
 static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx_obj_9multidict_10_multidict_MultiDict *__pyx_v_self, PyObject *__pyx_v_key, int __pyx_v_raise_key_error); /* proto*/
-static PyObject *__pyx_f_9multidict_10_multidict_11CIMultiDict__upper(struct __pyx_obj_9multidict_10_multidict_CIMultiDict *__pyx_v_self, PyObject *__pyx_v_s); /* proto*/
+static PyObject *__pyx_f_9multidict_10_multidict_11CIMultiDict__title(struct __pyx_obj_9multidict_10_multidict_CIMultiDict *__pyx_v_self, PyObject *__pyx_v_s); /* proto*/
 
 /* Module declarations from 'multidict._multidict' */
 static PyTypeObject *__pyx_ptype_9multidict_10_multidict__Pair = 0;
@@ -1262,6 +1262,7 @@ static const char __pyx_k_r_r[] = "{!r}: {!r}";
 static const char __pyx_k_ret[] = "ret";
 static const char __pyx_k_sys[] = "sys";
 static const char __pyx_k_val[] = "val";
+static const char __pyx_k_istr[] = "istr";
 static const char __pyx_k_join[] = "join";
 static const char __pyx_k_keys[] = "keys";
 static const char __pyx_k_main[] = "__main__";
@@ -1272,7 +1273,7 @@ static const char __pyx_k_class[] = "__class__";
 static const char __pyx_k_clear[] = "clear";
 static const char __pyx_k_items[] = "items";
 static const char __pyx_k_range[] = "range";
-static const char __pyx_k_upper[] = "upper";
+static const char __pyx_k_title[] = "title";
 static const char __pyx_k_upstr[] = "upstr";
 static const char __pyx_k_value[] = "value";
 static const char __pyx_k_errors[] = "errors";
@@ -1286,12 +1287,12 @@ static const char __pyx_k_strict[] = "strict";
 static const char __pyx_k_update[] = "update";
 static const char __pyx_k_Mapping[] = "Mapping";
 static const char __pyx_k_default[] = "default";
+static const char __pyx_k_is_istr[] = "__is_istr__";
 static const char __pyx_k_prepare[] = "__prepare__";
 static const char __pyx_k_Iterable[] = "Iterable";
 static const char __pyx_k_KeyError[] = "KeyError";
 static const char __pyx_k_KeysView[] = "KeysView";
 static const char __pyx_k_encoding[] = "encoding";
-static const char __pyx_k_is_upstr[] = "__is_upstr__";
 static const char __pyx_k_operator[] = "operator";
 static const char __pyx_k_qualname[] = "__qualname__";
 static const char __pyx_k_register[] = "register";
@@ -1299,12 +1300,12 @@ static const char __pyx_k_ItemsView[] = "ItemsView";
 static const char __pyx_k_TypeError[] = "TypeError";
 static const char __pyx_k_metaclass[] = "__metaclass__";
 static const char __pyx_k_ValuesView[] = "ValuesView";
+static const char __pyx_k_istr___new[] = "istr.__new__";
+static const char __pyx_k_istr_title[] = "istr.title";
 static const char __pyx_k_itemgetter[] = "itemgetter";
 static const char __pyx_k_memoryview[] = "memoryview";
 static const char __pyx_k_pyx_vtable[] = "__pyx_vtable__";
 static const char __pyx_k_collections[] = "collections";
-static const char __pyx_k_upstr___new[] = "upstr.__new__";
-static const char __pyx_k_upstr_upper[] = "upstr.upper";
 static const char __pyx_k_StopIteration[] = "StopIteration";
 static const char __pyx_k_MutableMapping[] = "MutableMapping";
 static const char __pyx_k_NotImplemented[] = "NotImplemented";
@@ -1356,7 +1357,10 @@ static PyObject *__pyx_n_s_get;
 static PyObject *__pyx_n_s_getdefaultencoding;
 static PyObject *__pyx_kp_s_home_andrew_projects_multidict;
 static PyObject *__pyx_n_s_import;
-static PyObject *__pyx_n_s_is_upstr;
+static PyObject *__pyx_n_s_is_istr;
+static PyObject *__pyx_n_s_istr;
+static PyObject *__pyx_n_s_istr___new;
+static PyObject *__pyx_n_s_istr_title;
 static PyObject *__pyx_n_s_itemgetter;
 static PyObject *__pyx_n_s_items;
 static PyObject *__pyx_n_s_join;
@@ -1388,16 +1392,14 @@ static PyObject *__pyx_n_s_sys;
 static PyObject *__pyx_kp_s_takes_at_most_1_positional_argu;
 static PyObject *__pyx_kp_s_takes_either_dict_or_list_of_ke;
 static PyObject *__pyx_n_s_test;
+static PyObject *__pyx_n_s_title;
 static PyObject *__pyx_n_s_update;
-static PyObject *__pyx_n_s_upper;
 static PyObject *__pyx_n_s_upstr;
-static PyObject *__pyx_n_s_upstr___new;
-static PyObject *__pyx_n_s_upstr_upper;
 static PyObject *__pyx_n_s_val;
 static PyObject *__pyx_n_s_value;
-static PyObject *__pyx_pf_9multidict_10_multidict_5upstr_4__defaults__(CYTHON_UNUSED PyObject *__pyx_self); /* proto */
-static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_cls, PyObject *__pyx_v_val, PyObject *__pyx_v_encoding, PyObject *__pyx_v_errors); /* proto */
-static PyObject *__pyx_pf_9multidict_10_multidict_5upstr_2upper(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_9multidict_10_multidict_4istr_4__defaults__(CYTHON_UNUSED PyObject *__pyx_self); /* proto */
+static PyObject *__pyx_pf_9multidict_10_multidict_4istr___new__(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_cls, PyObject *__pyx_v_val, PyObject *__pyx_v_encoding, PyObject *__pyx_v_errors); /* proto */
+static PyObject *__pyx_pf_9multidict_10_multidict_4istr_2title(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self); /* proto */
 static int __pyx_pf_9multidict_10_multidict_5_Pair___cinit__(struct __pyx_obj_9multidict_10_multidict__Pair *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_value); /* proto */
 static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *__pyx_v_self, PyObject *__pyx_v_other, PyObject *__pyx_v_op); /* proto */
 static int __pyx_pf_9multidict_10_multidict_5_Base___cinit__(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self); /* proto */
@@ -1486,14 +1488,14 @@ static PyObject *__pyx_codeobj__10;
 static PyObject *__pyx_codeobj__12;
 
 /* "multidict/_multidict.pyx":16
- *     __is_upstr__ = True
+ *     __is_istr__ = True
  * 
  *     def __new__(cls, val='',             # <<<<<<<<<<<<<<
  *                 encoding=sys.getdefaultencoding(), errors='strict'):
- *         if getattr(val, '__is_upstr__', False):
+ *         if getattr(val, '__is_istr__', False):
  */
 
-static PyObject *__pyx_pf_9multidict_10_multidict_5upstr_4__defaults__(CYTHON_UNUSED PyObject *__pyx_self) {
+static PyObject *__pyx_pf_9multidict_10_multidict_4istr_4__defaults__(CYTHON_UNUSED PyObject *__pyx_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -1527,7 +1529,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr_4__defaults__(CYTHON_UN
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
   __Pyx_XDECREF(__pyx_t_2);
-  __Pyx_AddTraceback("multidict._multidict.upstr.__defaults__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("multidict._multidict.istr.__defaults__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -1536,9 +1538,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr_4__defaults__(CYTHON_UN
 }
 
 /* Python wrapper */
-static PyObject *__pyx_pw_9multidict_10_multidict_5upstr_1__new__(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static PyMethodDef __pyx_mdef_9multidict_10_multidict_5upstr_1__new__ = {"__new__", (PyCFunction)__pyx_pw_9multidict_10_multidict_5upstr_1__new__, METH_VARARGS|METH_KEYWORDS, 0};
-static PyObject *__pyx_pw_9multidict_10_multidict_5upstr_1__new__(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
+static PyObject *__pyx_pw_9multidict_10_multidict_4istr_1__new__(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
+static PyMethodDef __pyx_mdef_9multidict_10_multidict_4istr_1__new__ = {"__new__", (PyCFunction)__pyx_pw_9multidict_10_multidict_4istr_1__new__, METH_VARARGS|METH_KEYWORDS, 0};
+static PyObject *__pyx_pw_9multidict_10_multidict_4istr_1__new__(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_cls = 0;
   PyObject *__pyx_v_val = 0;
   PyObject *__pyx_v_encoding = 0;
@@ -1607,18 +1609,18 @@ static PyObject *__pyx_pw_9multidict_10_multidict_5upstr_1__new__(PyObject *__py
   __pyx_L5_argtuple_error:;
   __Pyx_RaiseArgtupleInvalid("__new__", 0, 1, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 16, __pyx_L3_error)
   __pyx_L3_error:;
-  __Pyx_AddTraceback("multidict._multidict.upstr.__new__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("multidict._multidict.istr.__new__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_9multidict_10_multidict_5upstr___new__(__pyx_self, __pyx_v_cls, __pyx_v_val, __pyx_v_encoding, __pyx_v_errors);
+  __pyx_r = __pyx_pf_9multidict_10_multidict_4istr___new__(__pyx_self, __pyx_v_cls, __pyx_v_val, __pyx_v_encoding, __pyx_v_errors);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_cls, PyObject *__pyx_v_val, PyObject *__pyx_v_encoding, PyObject *__pyx_v_errors) {
+static PyObject *__pyx_pf_9multidict_10_multidict_4istr___new__(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_cls, PyObject *__pyx_v_val, PyObject *__pyx_v_encoding, PyObject *__pyx_v_errors) {
   PyObject *__pyx_v_ret = NULL;
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
@@ -1637,18 +1639,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED P
   /* "multidict/_multidict.pyx":18
  *     def __new__(cls, val='',
  *                 encoding=sys.getdefaultencoding(), errors='strict'):
- *         if getattr(val, '__is_upstr__', False):             # <<<<<<<<<<<<<<
+ *         if getattr(val, '__is_istr__', False):             # <<<<<<<<<<<<<<
  *             # Faster than instance check
  *             return val
  */
-  __pyx_t_1 = __Pyx_GetAttr3(__pyx_v_val, __pyx_n_s_is_upstr, Py_False); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 18, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetAttr3(__pyx_v_val, __pyx_n_s_is_istr, Py_False); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 18, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 18, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
     /* "multidict/_multidict.pyx":20
- *         if getattr(val, '__is_upstr__', False):
+ *         if getattr(val, '__is_istr__', False):
  *             # Faster than instance check
  *             return val             # <<<<<<<<<<<<<<
  *         if isinstance(val, (bytes, bytearray, memoryview)):
@@ -1662,7 +1664,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED P
     /* "multidict/_multidict.pyx":18
  *     def __new__(cls, val='',
  *                 encoding=sys.getdefaultencoding(), errors='strict'):
- *         if getattr(val, '__is_upstr__', False):             # <<<<<<<<<<<<<<
+ *         if getattr(val, '__is_istr__', False):             # <<<<<<<<<<<<<<
  *             # Faster than instance check
  *             return val
  */
@@ -1750,7 +1752,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED P
  *             pass
  *         else:
  *             val = str(val)             # <<<<<<<<<<<<<<
- *         ret = str.__new__(cls, val.upper())
+ *         ret = str.__new__(cls, val.title())
  *         return ret
  */
   /*else*/ {
@@ -1770,13 +1772,13 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED P
   /* "multidict/_multidict.pyx":27
  *         else:
  *             val = str(val)
- *         ret = str.__new__(cls, val.upper())             # <<<<<<<<<<<<<<
+ *         ret = str.__new__(cls, val.title())             # <<<<<<<<<<<<<<
  *         return ret
  * 
  */
   __pyx_t_5 = __Pyx_PyObject_GetAttrStr(((PyObject *)(&PyString_Type)), __pyx_n_s_new); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 27, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_v_val, __pyx_n_s_upper); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 27, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_v_val, __pyx_n_s_title); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 27, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __pyx_t_8 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_7))) {
@@ -1828,10 +1830,10 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED P
 
   /* "multidict/_multidict.pyx":28
  *             val = str(val)
- *         ret = str.__new__(cls, val.upper())
+ *         ret = str.__new__(cls, val.title())
  *         return ret             # <<<<<<<<<<<<<<
  * 
- *     def upper(self):
+ *     def title(self):
  */
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(__pyx_v_ret);
@@ -1839,11 +1841,11 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED P
   goto __pyx_L0;
 
   /* "multidict/_multidict.pyx":16
- *     __is_upstr__ = True
+ *     __is_istr__ = True
  * 
  *     def __new__(cls, val='',             # <<<<<<<<<<<<<<
  *                 encoding=sys.getdefaultencoding(), errors='strict'):
- *         if getattr(val, '__is_upstr__', False):
+ *         if getattr(val, '__is_istr__', False):
  */
 
   /* function exit code */
@@ -1853,7 +1855,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED P
   __Pyx_XDECREF(__pyx_t_6);
   __Pyx_XDECREF(__pyx_t_7);
   __Pyx_XDECREF(__pyx_t_8);
-  __Pyx_AddTraceback("multidict._multidict.upstr.__new__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("multidict._multidict.istr.__new__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XDECREF(__pyx_v_ret);
@@ -1866,33 +1868,33 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr___new__(CYTHON_UNUSED P
 /* "multidict/_multidict.pyx":30
  *         return ret
  * 
- *     def upper(self):             # <<<<<<<<<<<<<<
+ *     def title(self):             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_9multidict_10_multidict_5upstr_3upper(PyObject *__pyx_self, PyObject *__pyx_v_self); /*proto*/
-static PyMethodDef __pyx_mdef_9multidict_10_multidict_5upstr_3upper = {"upper", (PyCFunction)__pyx_pw_9multidict_10_multidict_5upstr_3upper, METH_O, 0};
-static PyObject *__pyx_pw_9multidict_10_multidict_5upstr_3upper(PyObject *__pyx_self, PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_9multidict_10_multidict_4istr_3title(PyObject *__pyx_self, PyObject *__pyx_v_self); /*proto*/
+static PyMethodDef __pyx_mdef_9multidict_10_multidict_4istr_3title = {"title", (PyCFunction)__pyx_pw_9multidict_10_multidict_4istr_3title, METH_O, 0};
+static PyObject *__pyx_pw_9multidict_10_multidict_4istr_3title(PyObject *__pyx_self, PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("upper (wrapper)", 0);
-  __pyx_r = __pyx_pf_9multidict_10_multidict_5upstr_2upper(__pyx_self, ((PyObject *)__pyx_v_self));
+  __Pyx_RefNannySetupContext("title (wrapper)", 0);
+  __pyx_r = __pyx_pf_9multidict_10_multidict_4istr_2title(__pyx_self, ((PyObject *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_9multidict_10_multidict_5upstr_2upper(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self) {
+static PyObject *__pyx_pf_9multidict_10_multidict_4istr_2title(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("upper", 0);
+  __Pyx_RefNannySetupContext("title", 0);
 
   /* "multidict/_multidict.pyx":31
  * 
- *     def upper(self):
+ *     def title(self):
  *         return self             # <<<<<<<<<<<<<<
  * 
  * 
@@ -1905,7 +1907,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr_2upper(CYTHON_UNUSED Py
   /* "multidict/_multidict.pyx":30
  *         return ret
  * 
- *     def upper(self):             # <<<<<<<<<<<<<<
+ *     def title(self):             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
@@ -1917,7 +1919,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5upstr_2upper(CYTHON_UNUSED Py
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":34
+/* "multidict/_multidict.pyx":37
  * 
  * 
  * cdef _eq(self, other):             # <<<<<<<<<<<<<<
@@ -1937,7 +1939,7 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
   int __pyx_t_5;
   __Pyx_RefNannySetupContext("_eq", 0);
 
-  /* "multidict/_multidict.pyx":39
+  /* "multidict/_multidict.pyx":42
  *     cdef int is_left_base, is_right_base
  * 
  *     is_left_base = isinstance(self, _Base)             # <<<<<<<<<<<<<<
@@ -1947,7 +1949,7 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
   __pyx_t_1 = __Pyx_TypeCheck(__pyx_v_self, __pyx_ptype_9multidict_10_multidict__Base); 
   __pyx_v_is_left_base = __pyx_t_1;
 
-  /* "multidict/_multidict.pyx":40
+  /* "multidict/_multidict.pyx":43
  * 
  *     is_left_base = isinstance(self, _Base)
  *     is_right_base = isinstance(other, _Base)             # <<<<<<<<<<<<<<
@@ -1957,7 +1959,7 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
   __pyx_t_1 = __Pyx_TypeCheck(__pyx_v_other, __pyx_ptype_9multidict_10_multidict__Base); 
   __pyx_v_is_right_base = __pyx_t_1;
 
-  /* "multidict/_multidict.pyx":42
+  /* "multidict/_multidict.pyx":45
  *     is_right_base = isinstance(other, _Base)
  * 
  *     if is_left_base and is_right_base:             # <<<<<<<<<<<<<<
@@ -1975,7 +1977,7 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
   __pyx_L4_bool_binop_done:;
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":43
+    /* "multidict/_multidict.pyx":46
  * 
  *     if is_left_base and is_right_base:
  *         return (<_Base>self)._items == (<_Base>other)._items             # <<<<<<<<<<<<<<
@@ -1983,12 +1985,12 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
  *         return (<_Base>self)._eq_to_mapping(other)
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyObject_RichCompare(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self)->_items, ((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_other)->_items, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 43, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self)->_items, ((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_other)->_items, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 46, __pyx_L1_error)
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":42
+    /* "multidict/_multidict.pyx":45
  *     is_right_base = isinstance(other, _Base)
  * 
  *     if is_left_base and is_right_base:             # <<<<<<<<<<<<<<
@@ -1997,7 +1999,7 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
  */
   }
 
-  /* "multidict/_multidict.pyx":44
+  /* "multidict/_multidict.pyx":47
  *     if is_left_base and is_right_base:
  *         return (<_Base>self)._items == (<_Base>other)._items
  *     elif is_left_base and isinstance(other, abc.Mapping):             # <<<<<<<<<<<<<<
@@ -2010,19 +2012,19 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
     __pyx_t_1 = __pyx_t_2;
     goto __pyx_L6_bool_binop_done;
   }
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 44, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 47, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_Mapping); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 44, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_Mapping); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 47, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_4); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 44, __pyx_L1_error)
+  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_4); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 47, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_5 = (__pyx_t_2 != 0);
   __pyx_t_1 = __pyx_t_5;
   __pyx_L6_bool_binop_done:;
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":45
+    /* "multidict/_multidict.pyx":48
  *         return (<_Base>self)._items == (<_Base>other)._items
  *     elif is_left_base and isinstance(other, abc.Mapping):
  *         return (<_Base>self)._eq_to_mapping(other)             # <<<<<<<<<<<<<<
@@ -2030,13 +2032,13 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
  *         return (<_Base>other)._eq_to_mapping(self)
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self)->__pyx_vtab)->_eq_to_mapping(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 45, __pyx_L1_error)
+    __pyx_t_4 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self)->__pyx_vtab)->_eq_to_mapping(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 48, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __pyx_r = __pyx_t_4;
     __pyx_t_4 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":44
+    /* "multidict/_multidict.pyx":47
  *     if is_left_base and is_right_base:
  *         return (<_Base>self)._items == (<_Base>other)._items
  *     elif is_left_base and isinstance(other, abc.Mapping):             # <<<<<<<<<<<<<<
@@ -2045,7 +2047,7 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
  */
   }
 
-  /* "multidict/_multidict.pyx":46
+  /* "multidict/_multidict.pyx":49
  *     elif is_left_base and isinstance(other, abc.Mapping):
  *         return (<_Base>self)._eq_to_mapping(other)
  *     elif is_right_base and isinstance(self, abc.Mapping):             # <<<<<<<<<<<<<<
@@ -2058,19 +2060,19 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
     __pyx_t_1 = __pyx_t_5;
     goto __pyx_L8_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 46, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 49, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_Mapping); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 46, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_Mapping); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 49, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_5 = PyObject_IsInstance(__pyx_v_self, __pyx_t_3); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 46, __pyx_L1_error)
+  __pyx_t_5 = PyObject_IsInstance(__pyx_v_self, __pyx_t_3); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 49, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_2 = (__pyx_t_5 != 0);
   __pyx_t_1 = __pyx_t_2;
   __pyx_L8_bool_binop_done:;
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":47
+    /* "multidict/_multidict.pyx":50
  *         return (<_Base>self)._eq_to_mapping(other)
  *     elif is_right_base and isinstance(self, abc.Mapping):
  *         return (<_Base>other)._eq_to_mapping(self)             # <<<<<<<<<<<<<<
@@ -2078,13 +2080,13 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
  *         return NotImplemented
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_other)->__pyx_vtab)->_eq_to_mapping(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_other), __pyx_v_self); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 47, __pyx_L1_error)
+    __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_other)->__pyx_vtab)->_eq_to_mapping(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_other), __pyx_v_self); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 50, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":46
+    /* "multidict/_multidict.pyx":49
  *     elif is_left_base and isinstance(other, abc.Mapping):
  *         return (<_Base>self)._eq_to_mapping(other)
  *     elif is_right_base and isinstance(self, abc.Mapping):             # <<<<<<<<<<<<<<
@@ -2093,7 +2095,7 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
  */
   }
 
-  /* "multidict/_multidict.pyx":49
+  /* "multidict/_multidict.pyx":52
  *         return (<_Base>other)._eq_to_mapping(self)
  *     else:
  *         return NotImplemented             # <<<<<<<<<<<<<<
@@ -2107,7 +2109,7 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
     goto __pyx_L0;
   }
 
-  /* "multidict/_multidict.pyx":34
+  /* "multidict/_multidict.pyx":37
  * 
  * 
  * cdef _eq(self, other):             # <<<<<<<<<<<<<<
@@ -2127,7 +2129,7 @@ static PyObject *__pyx_f_9multidict_10_multidict__eq(PyObject *__pyx_v_self, PyO
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":56
+/* "multidict/_multidict.pyx":59
  *     cdef object _value
  * 
  *     def __cinit__(self, key, value):             # <<<<<<<<<<<<<<
@@ -2163,11 +2165,11 @@ static int __pyx_pw_9multidict_10_multidict_5_Pair_1__cinit__(PyObject *__pyx_v_
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_value)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 2, 2, 1); __PYX_ERR(0, 56, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 2, 2, 1); __PYX_ERR(0, 59, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 56, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 59, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 2) {
       goto __pyx_L5_argtuple_error;
@@ -2180,7 +2182,7 @@ static int __pyx_pw_9multidict_10_multidict_5_Pair_1__cinit__(PyObject *__pyx_v_
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 56, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 59, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict._Pair.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -2198,7 +2200,7 @@ static int __pyx_pf_9multidict_10_multidict_5_Pair___cinit__(struct __pyx_obj_9m
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "multidict/_multidict.pyx":57
+  /* "multidict/_multidict.pyx":60
  * 
  *     def __cinit__(self, key, value):
  *         self._key = key             # <<<<<<<<<<<<<<
@@ -2211,7 +2213,7 @@ static int __pyx_pf_9multidict_10_multidict_5_Pair___cinit__(struct __pyx_obj_9m
   __Pyx_DECREF(__pyx_v_self->_key);
   __pyx_v_self->_key = __pyx_v_key;
 
-  /* "multidict/_multidict.pyx":58
+  /* "multidict/_multidict.pyx":61
  *     def __cinit__(self, key, value):
  *         self._key = key
  *         self._value = value             # <<<<<<<<<<<<<<
@@ -2224,7 +2226,7 @@ static int __pyx_pf_9multidict_10_multidict_5_Pair___cinit__(struct __pyx_obj_9m
   __Pyx_DECREF(__pyx_v_self->_value);
   __pyx_v_self->_value = __pyx_v_value;
 
-  /* "multidict/_multidict.pyx":56
+  /* "multidict/_multidict.pyx":59
  *     cdef object _value
  * 
  *     def __cinit__(self, key, value):             # <<<<<<<<<<<<<<
@@ -2238,7 +2240,7 @@ static int __pyx_pf_9multidict_10_multidict_5_Pair___cinit__(struct __pyx_obj_9m
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":60
+/* "multidict/_multidict.pyx":63
  *         self._value = value
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
@@ -2253,7 +2255,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_5_Pair_3__richcmp__(PyObject *
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__richcmp__ (wrapper)", 0);
-  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(0, 60, __pyx_L3_error)
+  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(0, 63, __pyx_L3_error)
   __Pyx_GOTREF(__pyx_v_op);
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L3_error:;
@@ -2281,7 +2283,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
   PyObject *__pyx_t_5 = NULL;
   __Pyx_RefNannySetupContext("__richcmp__", 0);
 
-  /* "multidict/_multidict.pyx":62
+  /* "multidict/_multidict.pyx":65
  *     def __richcmp__(self, other, op):
  *         cdef _Pair left, right
  *         if not isinstance(self, _Pair) or not isinstance(other, _Pair):             # <<<<<<<<<<<<<<
@@ -2301,7 +2303,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
   __pyx_L4_bool_binop_done:;
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":63
+    /* "multidict/_multidict.pyx":66
  *         cdef _Pair left, right
  *         if not isinstance(self, _Pair) or not isinstance(other, _Pair):
  *             return NotImplemented             # <<<<<<<<<<<<<<
@@ -2313,7 +2315,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
     __pyx_r = __pyx_builtin_NotImplemented;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":62
+    /* "multidict/_multidict.pyx":65
  *     def __richcmp__(self, other, op):
  *         cdef _Pair left, right
  *         if not isinstance(self, _Pair) or not isinstance(other, _Pair):             # <<<<<<<<<<<<<<
@@ -2322,7 +2324,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
  */
   }
 
-  /* "multidict/_multidict.pyx":64
+  /* "multidict/_multidict.pyx":67
  *         if not isinstance(self, _Pair) or not isinstance(other, _Pair):
  *             return NotImplemented
  *         left = <_Pair>self             # <<<<<<<<<<<<<<
@@ -2334,7 +2336,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
   __pyx_v_left = ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "multidict/_multidict.pyx":65
+  /* "multidict/_multidict.pyx":68
  *             return NotImplemented
  *         left = <_Pair>self
  *         right = <_Pair>other             # <<<<<<<<<<<<<<
@@ -2346,20 +2348,20 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
   __pyx_v_right = ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "multidict/_multidict.pyx":66
+  /* "multidict/_multidict.pyx":69
  *         left = <_Pair>self
  *         right = <_Pair>other
  *         if op == 2:  # ==             # <<<<<<<<<<<<<<
  *             return left._key == right._key and left._value == right._value
  *         elif op == 3:  # !=
  */
-  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 66, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 69, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 66, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 69, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":67
+    /* "multidict/_multidict.pyx":70
  *         right = <_Pair>other
  *         if op == 2:  # ==
  *             return left._key == right._key and left._value == right._value             # <<<<<<<<<<<<<<
@@ -2367,8 +2369,8 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
  *             return left._key != right._key and left._value != right._value
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_5 = PyObject_RichCompare(__pyx_v_left->_key, __pyx_v_right->_key, Py_EQ); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 67, __pyx_L1_error)
-    __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 67, __pyx_L1_error)
+    __pyx_t_5 = PyObject_RichCompare(__pyx_v_left->_key, __pyx_v_right->_key, Py_EQ); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 70, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 70, __pyx_L1_error)
     if (__pyx_t_1) {
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     } else {
@@ -2377,7 +2379,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       goto __pyx_L7_bool_binop_done;
     }
-    __pyx_t_5 = PyObject_RichCompare(__pyx_v_left->_value, __pyx_v_right->_value, Py_EQ); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 67, __pyx_L1_error)
+    __pyx_t_5 = PyObject_RichCompare(__pyx_v_left->_value, __pyx_v_right->_value, Py_EQ); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 70, __pyx_L1_error)
     __Pyx_INCREF(__pyx_t_5);
     __pyx_t_4 = __pyx_t_5;
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
@@ -2386,7 +2388,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
     __pyx_t_4 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":66
+    /* "multidict/_multidict.pyx":69
  *         left = <_Pair>self
  *         right = <_Pair>other
  *         if op == 2:  # ==             # <<<<<<<<<<<<<<
@@ -2395,20 +2397,20 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
  */
   }
 
-  /* "multidict/_multidict.pyx":68
+  /* "multidict/_multidict.pyx":71
  *         if op == 2:  # ==
  *             return left._key == right._key and left._value == right._value
  *         elif op == 3:  # !=             # <<<<<<<<<<<<<<
  *             return left._key != right._key and left._value != right._value
  * 
  */
-  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 68, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 68, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 71, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":69
+    /* "multidict/_multidict.pyx":72
  *             return left._key == right._key and left._value == right._value
  *         elif op == 3:  # !=
  *             return left._key != right._key and left._value != right._value             # <<<<<<<<<<<<<<
@@ -2416,8 +2418,8 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
  * cdef class _Base:
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_5 = PyObject_RichCompare(__pyx_v_left->_key, __pyx_v_right->_key, Py_NE); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 69, __pyx_L1_error)
-    __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 69, __pyx_L1_error)
+    __pyx_t_5 = PyObject_RichCompare(__pyx_v_left->_key, __pyx_v_right->_key, Py_NE); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 72, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 72, __pyx_L1_error)
     if (__pyx_t_1) {
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     } else {
@@ -2426,7 +2428,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       goto __pyx_L9_bool_binop_done;
     }
-    __pyx_t_5 = PyObject_RichCompare(__pyx_v_left->_value, __pyx_v_right->_value, Py_NE); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 69, __pyx_L1_error)
+    __pyx_t_5 = PyObject_RichCompare(__pyx_v_left->_value, __pyx_v_right->_value, Py_NE); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 72, __pyx_L1_error)
     __Pyx_INCREF(__pyx_t_5);
     __pyx_t_4 = __pyx_t_5;
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
@@ -2435,7 +2437,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
     __pyx_t_4 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":68
+    /* "multidict/_multidict.pyx":71
  *         if op == 2:  # ==
  *             return left._key == right._key and left._value == right._value
  *         elif op == 3:  # !=             # <<<<<<<<<<<<<<
@@ -2444,7 +2446,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
  */
   }
 
-  /* "multidict/_multidict.pyx":60
+  /* "multidict/_multidict.pyx":63
  *         self._value = value
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
@@ -2468,7 +2470,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Pair_2__richcmp__(PyObject *
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":77
+/* "multidict/_multidict.pyx":80
  *     cdef object marker
  * 
  *     def __cinit__(self):             # <<<<<<<<<<<<<<
@@ -2498,14 +2500,14 @@ static int __pyx_pf_9multidict_10_multidict_5_Base___cinit__(struct __pyx_obj_9m
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "multidict/_multidict.pyx":78
+  /* "multidict/_multidict.pyx":81
  * 
  *     def __cinit__(self):
  *         self._upstr = upstr             # <<<<<<<<<<<<<<
  *         self.marker = _marker
  * 
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_upstr); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 78, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_upstr); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 81, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
   __Pyx_GOTREF(__pyx_v_self->_upstr);
@@ -2513,14 +2515,14 @@ static int __pyx_pf_9multidict_10_multidict_5_Base___cinit__(struct __pyx_obj_9m
   __pyx_v_self->_upstr = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":79
+  /* "multidict/_multidict.pyx":82
  *     def __cinit__(self):
  *         self._upstr = upstr
  *         self.marker = _marker             # <<<<<<<<<<<<<<
  * 
- *     cdef str _upper(self, s):
+ *     cdef str _title(self, s):
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_marker); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_marker); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 82, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
   __Pyx_GOTREF(__pyx_v_self->marker);
@@ -2528,7 +2530,7 @@ static int __pyx_pf_9multidict_10_multidict_5_Base___cinit__(struct __pyx_obj_9m
   __pyx_v_self->marker = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":77
+  /* "multidict/_multidict.pyx":80
  *     cdef object marker
  * 
  *     def __cinit__(self):             # <<<<<<<<<<<<<<
@@ -2548,24 +2550,24 @@ static int __pyx_pf_9multidict_10_multidict_5_Base___cinit__(struct __pyx_obj_9m
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":81
+/* "multidict/_multidict.pyx":84
  *         self.marker = _marker
  * 
- *     cdef str _upper(self, s):             # <<<<<<<<<<<<<<
+ *     cdef str _title(self, s):             # <<<<<<<<<<<<<<
  *         if type(s) is self._upstr:
  *             return <str>s
  */
 
-static PyObject *__pyx_f_9multidict_10_multidict_5_Base__upper(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_s) {
+static PyObject *__pyx_f_9multidict_10_multidict_5_Base__title(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_s) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
   int __pyx_t_2;
-  __Pyx_RefNannySetupContext("_upper", 0);
+  __Pyx_RefNannySetupContext("_title", 0);
 
-  /* "multidict/_multidict.pyx":82
+  /* "multidict/_multidict.pyx":85
  * 
- *     cdef str _upper(self, s):
+ *     cdef str _title(self, s):
  *         if type(s) is self._upstr:             # <<<<<<<<<<<<<<
  *             return <str>s
  *         return s
@@ -2574,8 +2576,8 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__upper(struct __pyx_obj_
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":83
- *     cdef str _upper(self, s):
+    /* "multidict/_multidict.pyx":86
+ *     cdef str _title(self, s):
  *         if type(s) is self._upstr:
  *             return <str>s             # <<<<<<<<<<<<<<
  *         return s
@@ -2586,16 +2588,16 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__upper(struct __pyx_obj_
     __pyx_r = ((PyObject*)__pyx_v_s);
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":82
+    /* "multidict/_multidict.pyx":85
  * 
- *     cdef str _upper(self, s):
+ *     cdef str _title(self, s):
  *         if type(s) is self._upstr:             # <<<<<<<<<<<<<<
  *             return <str>s
  *         return s
  */
   }
 
-  /* "multidict/_multidict.pyx":84
+  /* "multidict/_multidict.pyx":87
  *         if type(s) is self._upstr:
  *             return <str>s
  *         return s             # <<<<<<<<<<<<<<
@@ -2603,22 +2605,22 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__upper(struct __pyx_obj_
  *     def getall(self, key, default=_marker):
  */
   __Pyx_XDECREF(__pyx_r);
-  if (!(likely(PyString_CheckExact(__pyx_v_s))||((__pyx_v_s) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_v_s)->tp_name), 0))) __PYX_ERR(0, 84, __pyx_L1_error)
+  if (!(likely(PyString_CheckExact(__pyx_v_s))||((__pyx_v_s) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_v_s)->tp_name), 0))) __PYX_ERR(0, 87, __pyx_L1_error)
   __Pyx_INCREF(__pyx_v_s);
   __pyx_r = ((PyObject*)__pyx_v_s);
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":81
+  /* "multidict/_multidict.pyx":84
  *         self.marker = _marker
  * 
- *     cdef str _upper(self, s):             # <<<<<<<<<<<<<<
+ *     cdef str _title(self, s):             # <<<<<<<<<<<<<<
  *         if type(s) is self._upstr:
  *             return <str>s
  */
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("multidict._multidict._Base._upper", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("multidict._multidict._Base._title", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = 0;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -2626,12 +2628,12 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__upper(struct __pyx_obj_
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":86
+/* "multidict/_multidict.pyx":89
  *         return s
  * 
  *     def getall(self, key, default=_marker):             # <<<<<<<<<<<<<<
  *         """Return a list of all values matching the key."""
- *         return self._getall(self._upper(key), default)
+ *         return self._getall(self._title(key), default)
  */
 
 /* Python wrapper */
@@ -2668,7 +2670,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_5_Base_3getall(PyObject *__pyx
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "getall") < 0)) __PYX_ERR(0, 86, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "getall") < 0)) __PYX_ERR(0, 89, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -2683,7 +2685,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_5_Base_3getall(PyObject *__pyx
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("getall", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 86, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("getall", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 89, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict._Base.getall", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -2703,29 +2705,29 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_2getall(struct __pyx_ob
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("getall", 0);
 
-  /* "multidict/_multidict.pyx":88
+  /* "multidict/_multidict.pyx":91
  *     def getall(self, key, default=_marker):
  *         """Return a list of all values matching the key."""
- *         return self._getall(self._upper(key), default)             # <<<<<<<<<<<<<<
+ *         return self._getall(self._title(key), default)             # <<<<<<<<<<<<<<
  * 
  *     cdef _getall(self, str key, default):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_upper(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 88, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_title(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 91, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_getall(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_default); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 88, __pyx_L1_error)
+  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_getall(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_default); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 91, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":86
+  /* "multidict/_multidict.pyx":89
  *         return s
  * 
  *     def getall(self, key, default=_marker):             # <<<<<<<<<<<<<<
  *         """Return a list of all values matching the key."""
- *         return self._getall(self._upper(key), default)
+ *         return self._getall(self._title(key), default)
  */
 
   /* function exit code */
@@ -2740,8 +2742,8 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_2getall(struct __pyx_ob
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":90
- *         return self._getall(self._upper(key), default)
+/* "multidict/_multidict.pyx":93
+ *         return self._getall(self._title(key), default)
  * 
  *     cdef _getall(self, str key, default):             # <<<<<<<<<<<<<<
  *         cdef list res
@@ -2764,32 +2766,32 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
   __Pyx_RefNannySetupContext("_getall", 0);
   __Pyx_INCREF(__pyx_v_key);
 
-  /* "multidict/_multidict.pyx":93
+  /* "multidict/_multidict.pyx":96
  *         cdef list res
  *         cdef _Pair item
- *         key = self._upper(key)             # <<<<<<<<<<<<<<
+ *         key = self._title(key)             # <<<<<<<<<<<<<<
  *         res = []
  *         for i in self._items:
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_upper(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 93, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_title(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 96, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_1));
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":94
+  /* "multidict/_multidict.pyx":97
  *         cdef _Pair item
- *         key = self._upper(key)
+ *         key = self._title(key)
  *         res = []             # <<<<<<<<<<<<<<
  *         for i in self._items:
  *             item = <_Pair>i
  */
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 94, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 97, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_res = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":95
- *         key = self._upper(key)
+  /* "multidict/_multidict.pyx":98
+ *         key = self._title(key)
  *         res = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
  *             item = <_Pair>i
@@ -2797,21 +2799,21 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
  */
   if (unlikely(__pyx_v_self->_items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 95, __pyx_L1_error)
+    __PYX_ERR(0, 98, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->_items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 95, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 98, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 95, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 98, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":96
+    /* "multidict/_multidict.pyx":99
  *         res = []
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -2823,17 +2825,17 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":97
+    /* "multidict/_multidict.pyx":100
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == key:             # <<<<<<<<<<<<<<
  *                 res.append(item._value)
  *         if res:
  */
-    __pyx_t_4 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_key, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 97, __pyx_L1_error)
+    __pyx_t_4 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_key, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 100, __pyx_L1_error)
     if (__pyx_t_4) {
 
-      /* "multidict/_multidict.pyx":98
+      /* "multidict/_multidict.pyx":101
  *             item = <_Pair>i
  *             if item._key == key:
  *                 res.append(item._value)             # <<<<<<<<<<<<<<
@@ -2842,10 +2844,10 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
  */
       __pyx_t_3 = __pyx_v_item->_value;
       __Pyx_INCREF(__pyx_t_3);
-      __pyx_t_5 = __Pyx_PyList_Append(__pyx_v_res, __pyx_t_3); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 98, __pyx_L1_error)
+      __pyx_t_5 = __Pyx_PyList_Append(__pyx_v_res, __pyx_t_3); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 101, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "multidict/_multidict.pyx":97
+      /* "multidict/_multidict.pyx":100
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == key:             # <<<<<<<<<<<<<<
@@ -2854,8 +2856,8 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
  */
     }
 
-    /* "multidict/_multidict.pyx":95
- *         key = self._upper(key)
+    /* "multidict/_multidict.pyx":98
+ *         key = self._title(key)
  *         res = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
  *             item = <_Pair>i
@@ -2864,7 +2866,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":99
+  /* "multidict/_multidict.pyx":102
  *             if item._key == key:
  *                 res.append(item._value)
  *         if res:             # <<<<<<<<<<<<<<
@@ -2874,7 +2876,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
   __pyx_t_4 = (__pyx_v_res != Py_None) && (PyList_GET_SIZE(__pyx_v_res) != 0);
   if (__pyx_t_4) {
 
-    /* "multidict/_multidict.pyx":100
+    /* "multidict/_multidict.pyx":103
  *                 res.append(item._value)
  *         if res:
  *             return res             # <<<<<<<<<<<<<<
@@ -2886,7 +2888,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
     __pyx_r = __pyx_v_res;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":99
+    /* "multidict/_multidict.pyx":102
  *             if item._key == key:
  *                 res.append(item._value)
  *         if res:             # <<<<<<<<<<<<<<
@@ -2895,7 +2897,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
  */
   }
 
-  /* "multidict/_multidict.pyx":101
+  /* "multidict/_multidict.pyx":104
  *         if res:
  *             return res
  *         if not res and default is not self.marker:             # <<<<<<<<<<<<<<
@@ -2915,7 +2917,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
   __pyx_L8_bool_binop_done:;
   if (__pyx_t_4) {
 
-    /* "multidict/_multidict.pyx":102
+    /* "multidict/_multidict.pyx":105
  *             return res
  *         if not res and default is not self.marker:
  *             return default             # <<<<<<<<<<<<<<
@@ -2927,7 +2929,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
     __pyx_r = __pyx_v_default;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":101
+    /* "multidict/_multidict.pyx":104
  *         if res:
  *             return res
  *         if not res and default is not self.marker:             # <<<<<<<<<<<<<<
@@ -2936,29 +2938,29 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
  */
   }
 
-  /* "multidict/_multidict.pyx":103
+  /* "multidict/_multidict.pyx":106
  *         if not res and default is not self.marker:
  *             return default
  *         raise KeyError('Key not found: %r' % key)             # <<<<<<<<<<<<<<
  * 
  *     def getone(self, key, default=_marker):
  */
-  __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Key_not_found_r, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 103, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Key_not_found_r, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 106, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 103, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 106, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 103, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 106, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_Raise(__pyx_t_1, 0, 0, 0);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __PYX_ERR(0, 103, __pyx_L1_error)
+  __PYX_ERR(0, 106, __pyx_L1_error)
 
-  /* "multidict/_multidict.pyx":90
- *         return self._getall(self._upper(key), default)
+  /* "multidict/_multidict.pyx":93
+ *         return self._getall(self._title(key), default)
  * 
  *     cdef _getall(self, str key, default):             # <<<<<<<<<<<<<<
  *         cdef list res
@@ -2981,12 +2983,12 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getall(struct __pyx_obj
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":105
+/* "multidict/_multidict.pyx":108
  *         raise KeyError('Key not found: %r' % key)
  * 
  *     def getone(self, key, default=_marker):             # <<<<<<<<<<<<<<
  *         """Get first value matching the key."""
- *         return self._getone(self._upper(key), default)
+ *         return self._getone(self._title(key), default)
  */
 
 /* Python wrapper */
@@ -3023,7 +3025,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_5_Base_5getone(PyObject *__pyx
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "getone") < 0)) __PYX_ERR(0, 105, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "getone") < 0)) __PYX_ERR(0, 108, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -3038,7 +3040,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_5_Base_5getone(PyObject *__pyx
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("getone", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 105, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("getone", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 108, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict._Base.getone", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -3058,29 +3060,29 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_4getone(struct __pyx_ob
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("getone", 0);
 
-  /* "multidict/_multidict.pyx":107
+  /* "multidict/_multidict.pyx":110
  *     def getone(self, key, default=_marker):
  *         """Get first value matching the key."""
- *         return self._getone(self._upper(key), default)             # <<<<<<<<<<<<<<
+ *         return self._getone(self._title(key), default)             # <<<<<<<<<<<<<<
  * 
  *     cdef _getone(self, str key, default):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_upper(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 107, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_title(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 110, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_getone(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_default); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 107, __pyx_L1_error)
+  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_getone(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_default); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 110, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":105
+  /* "multidict/_multidict.pyx":108
  *         raise KeyError('Key not found: %r' % key)
  * 
  *     def getone(self, key, default=_marker):             # <<<<<<<<<<<<<<
  *         """Get first value matching the key."""
- *         return self._getone(self._upper(key), default)
+ *         return self._getone(self._title(key), default)
  */
 
   /* function exit code */
@@ -3095,12 +3097,12 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_4getone(struct __pyx_ob
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":109
- *         return self._getone(self._upper(key), default)
+/* "multidict/_multidict.pyx":112
+ *         return self._getone(self._title(key), default)
  * 
  *     cdef _getone(self, str key, default):             # <<<<<<<<<<<<<<
  *         cdef _Pair item
- *         key = self._upper(key)
+ *         key = self._title(key)
  */
 
 static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_default) {
@@ -3116,43 +3118,43 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj
   __Pyx_RefNannySetupContext("_getone", 0);
   __Pyx_INCREF(__pyx_v_key);
 
-  /* "multidict/_multidict.pyx":111
+  /* "multidict/_multidict.pyx":114
  *     cdef _getone(self, str key, default):
  *         cdef _Pair item
- *         key = self._upper(key)             # <<<<<<<<<<<<<<
+ *         key = self._title(key)             # <<<<<<<<<<<<<<
  *         for i in self._items:
  *             item = <_Pair>i
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_upper(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 111, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_title(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 114, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_1));
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":112
+  /* "multidict/_multidict.pyx":115
  *         cdef _Pair item
- *         key = self._upper(key)
+ *         key = self._title(key)
  *         for i in self._items:             # <<<<<<<<<<<<<<
  *             item = <_Pair>i
  *             if item._key == key:
  */
   if (unlikely(__pyx_v_self->_items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 112, __pyx_L1_error)
+    __PYX_ERR(0, 115, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->_items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 112, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 115, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 112, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 115, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":113
- *         key = self._upper(key)
+    /* "multidict/_multidict.pyx":116
+ *         key = self._title(key)
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
  *             if item._key == key:
@@ -3163,17 +3165,17 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":114
+    /* "multidict/_multidict.pyx":117
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == key:             # <<<<<<<<<<<<<<
  *                 return item._value
  *         if default is not self.marker:
  */
-    __pyx_t_4 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_key, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 114, __pyx_L1_error)
+    __pyx_t_4 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_key, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 117, __pyx_L1_error)
     if (__pyx_t_4) {
 
-      /* "multidict/_multidict.pyx":115
+      /* "multidict/_multidict.pyx":118
  *             item = <_Pair>i
  *             if item._key == key:
  *                 return item._value             # <<<<<<<<<<<<<<
@@ -3186,7 +3188,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":114
+      /* "multidict/_multidict.pyx":117
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == key:             # <<<<<<<<<<<<<<
@@ -3195,9 +3197,9 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj
  */
     }
 
-    /* "multidict/_multidict.pyx":112
+    /* "multidict/_multidict.pyx":115
  *         cdef _Pair item
- *         key = self._upper(key)
+ *         key = self._title(key)
  *         for i in self._items:             # <<<<<<<<<<<<<<
  *             item = <_Pair>i
  *             if item._key == key:
@@ -3205,7 +3207,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":116
+  /* "multidict/_multidict.pyx":119
  *             if item._key == key:
  *                 return item._value
  *         if default is not self.marker:             # <<<<<<<<<<<<<<
@@ -3216,7 +3218,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj
   __pyx_t_5 = (__pyx_t_4 != 0);
   if (__pyx_t_5) {
 
-    /* "multidict/_multidict.pyx":117
+    /* "multidict/_multidict.pyx":120
  *                 return item._value
  *         if default is not self.marker:
  *             return default             # <<<<<<<<<<<<<<
@@ -3228,7 +3230,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj
     __pyx_r = __pyx_v_default;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":116
+    /* "multidict/_multidict.pyx":119
  *             if item._key == key:
  *                 return item._value
  *         if default is not self.marker:             # <<<<<<<<<<<<<<
@@ -3237,33 +3239,33 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj
  */
   }
 
-  /* "multidict/_multidict.pyx":118
+  /* "multidict/_multidict.pyx":121
  *         if default is not self.marker:
  *             return default
  *         raise KeyError('Key not found: %r' % key)             # <<<<<<<<<<<<<<
  * 
  *     # Mapping interface #
  */
-  __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Key_not_found_r, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 118, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Key_not_found_r, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 121, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 118, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 121, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 118, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 121, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_Raise(__pyx_t_1, 0, 0, 0);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __PYX_ERR(0, 118, __pyx_L1_error)
+  __PYX_ERR(0, 121, __pyx_L1_error)
 
-  /* "multidict/_multidict.pyx":109
- *         return self._getone(self._upper(key), default)
+  /* "multidict/_multidict.pyx":112
+ *         return self._getone(self._title(key), default)
  * 
  *     cdef _getone(self, str key, default):             # <<<<<<<<<<<<<<
  *         cdef _Pair item
- *         key = self._upper(key)
+ *         key = self._title(key)
  */
 
   /* function exit code */
@@ -3281,11 +3283,11 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__getone(struct __pyx_obj
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":122
+/* "multidict/_multidict.pyx":125
  *     # Mapping interface #
  * 
  *     def __getitem__(self, key):             # <<<<<<<<<<<<<<
- *         return self._getone(self._upper(key), self.marker)
+ *         return self._getone(self._title(key), self.marker)
  * 
  */
 
@@ -3310,19 +3312,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_6__getitem__(struct __p
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__getitem__", 0);
 
-  /* "multidict/_multidict.pyx":123
+  /* "multidict/_multidict.pyx":126
  * 
  *     def __getitem__(self, key):
- *         return self._getone(self._upper(key), self.marker)             # <<<<<<<<<<<<<<
+ *         return self._getone(self._title(key), self.marker)             # <<<<<<<<<<<<<<
  * 
  *     def get(self, key, default=None):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_upper(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_title(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = __pyx_v_self->marker;
   __Pyx_INCREF(__pyx_t_2);
-  __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_getone(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 123, __pyx_L1_error)
+  __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_getone(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 126, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -3330,11 +3332,11 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_6__getitem__(struct __p
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":122
+  /* "multidict/_multidict.pyx":125
  *     # Mapping interface #
  * 
  *     def __getitem__(self, key):             # <<<<<<<<<<<<<<
- *         return self._getone(self._upper(key), self.marker)
+ *         return self._getone(self._title(key), self.marker)
  * 
  */
 
@@ -3351,8 +3353,8 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_6__getitem__(struct __p
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":125
- *         return self._getone(self._upper(key), self.marker)
+/* "multidict/_multidict.pyx":128
+ *         return self._getone(self._title(key), self.marker)
  * 
  *     def get(self, key, default=None):             # <<<<<<<<<<<<<<
  *         """Get first value matching the key.
@@ -3393,7 +3395,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_5_Base_9get(PyObject *__pyx_v_
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "get") < 0)) __PYX_ERR(0, 125, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "get") < 0)) __PYX_ERR(0, 128, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -3408,7 +3410,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_5_Base_9get(PyObject *__pyx_v_
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("get", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 125, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("get", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 128, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict._Base.get", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -3428,25 +3430,25 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_8get(struct __pyx_obj_9
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("get", 0);
 
-  /* "multidict/_multidict.pyx":130
+  /* "multidict/_multidict.pyx":133
  *         The method is alias for .getone().
  *         """
- *         return self._getone(self._upper(key), default)             # <<<<<<<<<<<<<<
+ *         return self._getone(self._title(key), default)             # <<<<<<<<<<<<<<
  * 
  *     def __contains__(self, key):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_upper(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 130, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_title(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 133, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_getone(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_default); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 130, __pyx_L1_error)
+  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_getone(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_default); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 133, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":125
- *         return self._getone(self._upper(key), self.marker)
+  /* "multidict/_multidict.pyx":128
+ *         return self._getone(self._title(key), self.marker)
  * 
  *     def get(self, key, default=None):             # <<<<<<<<<<<<<<
  *         """Get first value matching the key.
@@ -3465,11 +3467,11 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_8get(struct __pyx_obj_9
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":132
- *         return self._getone(self._upper(key), default)
+/* "multidict/_multidict.pyx":135
+ *         return self._getone(self._title(key), default)
  * 
  *     def __contains__(self, key):             # <<<<<<<<<<<<<<
- *         return self._contains(self._upper(key))
+ *         return self._contains(self._title(key))
  * 
  */
 
@@ -3494,28 +3496,28 @@ static int __pyx_pf_9multidict_10_multidict_5_Base_10__contains__(struct __pyx_o
   int __pyx_t_3;
   __Pyx_RefNannySetupContext("__contains__", 0);
 
-  /* "multidict/_multidict.pyx":133
+  /* "multidict/_multidict.pyx":136
  * 
  *     def __contains__(self, key):
- *         return self._contains(self._upper(key))             # <<<<<<<<<<<<<<
+ *         return self._contains(self._title(key))             # <<<<<<<<<<<<<<
  * 
  *     cdef _contains(self, str key):
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_upper(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 133, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_title(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 136, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_contains(__pyx_v_self, ((PyObject*)__pyx_t_1)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 133, __pyx_L1_error)
+  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_contains(__pyx_v_self, ((PyObject*)__pyx_t_1)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 136, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_t_2); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 133, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_t_2); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_r = __pyx_t_3;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":132
- *         return self._getone(self._upper(key), default)
+  /* "multidict/_multidict.pyx":135
+ *         return self._getone(self._title(key), default)
  * 
  *     def __contains__(self, key):             # <<<<<<<<<<<<<<
- *         return self._contains(self._upper(key))
+ *         return self._contains(self._title(key))
  * 
  */
 
@@ -3530,12 +3532,12 @@ static int __pyx_pf_9multidict_10_multidict_5_Base_10__contains__(struct __pyx_o
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":135
- *         return self._contains(self._upper(key))
+/* "multidict/_multidict.pyx":138
+ *         return self._contains(self._title(key))
  * 
  *     cdef _contains(self, str key):             # <<<<<<<<<<<<<<
  *         cdef _Pair item
- *         key = self._upper(key)
+ *         key = self._title(key)
  */
 
 static PyObject *__pyx_f_9multidict_10_multidict_5_Base__contains(struct __pyx_obj_9multidict_10_multidict__Base *__pyx_v_self, PyObject *__pyx_v_key) {
@@ -3550,43 +3552,43 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__contains(struct __pyx_o
   __Pyx_RefNannySetupContext("_contains", 0);
   __Pyx_INCREF(__pyx_v_key);
 
-  /* "multidict/_multidict.pyx":137
+  /* "multidict/_multidict.pyx":140
  *     cdef _contains(self, str key):
  *         cdef _Pair item
- *         key = self._upper(key)             # <<<<<<<<<<<<<<
+ *         key = self._title(key)             # <<<<<<<<<<<<<<
  *         for i in self._items:
  *             item = <_Pair>i
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_upper(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->_title(__pyx_v_self, __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 140, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_1));
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":138
+  /* "multidict/_multidict.pyx":141
  *         cdef _Pair item
- *         key = self._upper(key)
+ *         key = self._title(key)
  *         for i in self._items:             # <<<<<<<<<<<<<<
  *             item = <_Pair>i
  *             if item._key == key:
  */
   if (unlikely(__pyx_v_self->_items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 138, __pyx_L1_error)
+    __PYX_ERR(0, 141, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->_items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 138, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 141, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 138, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 141, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":139
- *         key = self._upper(key)
+    /* "multidict/_multidict.pyx":142
+ *         key = self._title(key)
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
  *             if item._key == key:
@@ -3597,17 +3599,17 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__contains(struct __pyx_o
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":140
+    /* "multidict/_multidict.pyx":143
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == key:             # <<<<<<<<<<<<<<
  *                 return True
  *         return False
  */
-    __pyx_t_4 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_key, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 140, __pyx_L1_error)
+    __pyx_t_4 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_key, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 143, __pyx_L1_error)
     if (__pyx_t_4) {
 
-      /* "multidict/_multidict.pyx":141
+      /* "multidict/_multidict.pyx":144
  *             item = <_Pair>i
  *             if item._key == key:
  *                 return True             # <<<<<<<<<<<<<<
@@ -3620,7 +3622,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__contains(struct __pyx_o
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":140
+      /* "multidict/_multidict.pyx":143
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == key:             # <<<<<<<<<<<<<<
@@ -3629,9 +3631,9 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__contains(struct __pyx_o
  */
     }
 
-    /* "multidict/_multidict.pyx":138
+    /* "multidict/_multidict.pyx":141
  *         cdef _Pair item
- *         key = self._upper(key)
+ *         key = self._title(key)
  *         for i in self._items:             # <<<<<<<<<<<<<<
  *             item = <_Pair>i
  *             if item._key == key:
@@ -3639,7 +3641,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__contains(struct __pyx_o
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":142
+  /* "multidict/_multidict.pyx":145
  *             if item._key == key:
  *                 return True
  *         return False             # <<<<<<<<<<<<<<
@@ -3651,12 +3653,12 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__contains(struct __pyx_o
   __pyx_r = Py_False;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":135
- *         return self._contains(self._upper(key))
+  /* "multidict/_multidict.pyx":138
+ *         return self._contains(self._title(key))
  * 
  *     cdef _contains(self, str key):             # <<<<<<<<<<<<<<
  *         cdef _Pair item
- *         key = self._upper(key)
+ *         key = self._title(key)
  */
 
   /* function exit code */
@@ -3674,7 +3676,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__contains(struct __pyx_o
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":144
+/* "multidict/_multidict.pyx":147
  *         return False
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -3702,7 +3704,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_12__iter__(struct __pyx
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__iter__", 0);
 
-  /* "multidict/_multidict.pyx":145
+  /* "multidict/_multidict.pyx":148
  * 
  *     def __iter__(self):
  *         return iter(self.keys())             # <<<<<<<<<<<<<<
@@ -3710,16 +3712,16 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_12__iter__(struct __pyx
  *     def __len__(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->keys(__pyx_v_self, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 145, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->keys(__pyx_v_self, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 148, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 145, __pyx_L1_error)
+  __pyx_t_2 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 148, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":144
+  /* "multidict/_multidict.pyx":147
  *         return False
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -3739,7 +3741,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_12__iter__(struct __pyx
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":147
+/* "multidict/_multidict.pyx":150
  *         return iter(self.keys())
  * 
  *     def __len__(self):             # <<<<<<<<<<<<<<
@@ -3767,7 +3769,7 @@ static Py_ssize_t __pyx_pf_9multidict_10_multidict_5_Base_14__len__(struct __pyx
   Py_ssize_t __pyx_t_2;
   __Pyx_RefNannySetupContext("__len__", 0);
 
-  /* "multidict/_multidict.pyx":148
+  /* "multidict/_multidict.pyx":151
  * 
  *     def __len__(self):
  *         return len(self._items)             # <<<<<<<<<<<<<<
@@ -3778,14 +3780,14 @@ static Py_ssize_t __pyx_pf_9multidict_10_multidict_5_Base_14__len__(struct __pyx
   __Pyx_INCREF(__pyx_t_1);
   if (unlikely(__pyx_t_1 == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 148, __pyx_L1_error)
+    __PYX_ERR(0, 151, __pyx_L1_error)
   }
-  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 148, __pyx_L1_error)
+  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 151, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":147
+  /* "multidict/_multidict.pyx":150
  *         return iter(self.keys())
  * 
  *     def __len__(self):             # <<<<<<<<<<<<<<
@@ -3803,7 +3805,7 @@ static Py_ssize_t __pyx_pf_9multidict_10_multidict_5_Base_14__len__(struct __pyx
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":150
+/* "multidict/_multidict.pyx":153
  *         return len(self._items)
  * 
  *     cpdef keys(self):             # <<<<<<<<<<<<<<
@@ -3824,7 +3826,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base_keys(struct __pyx_obj_9m
   if (unlikely(__pyx_skip_dispatch)) ;
   /* Check if overridden in Python */
   else if (unlikely(Py_TYPE(((PyObject *)__pyx_v_self))->tp_dictoffset != 0)) {
-    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_keys); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 150, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_keys); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 153, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     if (!PyCFunction_Check(__pyx_t_1) || (PyCFunction_GET_FUNCTION(__pyx_t_1) != (PyCFunction)__pyx_pw_9multidict_10_multidict_5_Base_17keys)) {
       __Pyx_XDECREF(__pyx_r);
@@ -3840,10 +3842,10 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base_keys(struct __pyx_obj_9m
         }
       }
       if (__pyx_t_4) {
-        __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 150, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 153, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
       } else {
-        __pyx_t_2 = __Pyx_PyObject_CallNoArg(__pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 150, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_CallNoArg(__pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 153, __pyx_L1_error)
       }
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -3855,7 +3857,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base_keys(struct __pyx_obj_9m
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   }
 
-  /* "multidict/_multidict.pyx":152
+  /* "multidict/_multidict.pyx":155
  *     cpdef keys(self):
  *         """Return a new view of the dictionary's keys."""
  *         return _KeysView.__new__(_KeysView, self._items)             # <<<<<<<<<<<<<<
@@ -3863,19 +3865,19 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base_keys(struct __pyx_obj_9m
  *     def items(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 152, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 155, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_self->_items);
   __Pyx_GIVEREF(__pyx_v_self->_items);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_self->_items);
-  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__KeysView(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__KeysView), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 152, __pyx_L1_error)
+  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__KeysView(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__KeysView), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 155, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":150
+  /* "multidict/_multidict.pyx":153
  *         return len(self._items)
  * 
  *     cpdef keys(self):             # <<<<<<<<<<<<<<
@@ -3917,7 +3919,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_16keys(struct __pyx_obj
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("keys", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_f_9multidict_10_multidict_5_Base_keys(__pyx_v_self, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 150, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_9multidict_10_multidict_5_Base_keys(__pyx_v_self, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 153, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -3934,7 +3936,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_16keys(struct __pyx_obj
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":154
+/* "multidict/_multidict.pyx":157
  *         return _KeysView.__new__(_KeysView, self._items)
  * 
  *     def items(self):             # <<<<<<<<<<<<<<
@@ -3963,7 +3965,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_18items(struct __pyx_ob
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("items", 0);
 
-  /* "multidict/_multidict.pyx":156
+  /* "multidict/_multidict.pyx":159
  *     def items(self):
  *         """Return a new view of the dictionary's items *(key, value) pairs)."""
  *         return _ItemsView.__new__(_ItemsView, self._items)             # <<<<<<<<<<<<<<
@@ -3971,19 +3973,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_18items(struct __pyx_ob
  *     def values(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 156, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 159, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_self->_items);
   __Pyx_GIVEREF(__pyx_v_self->_items);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_self->_items);
-  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__ItemsView(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__ItemsView), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 156, __pyx_L1_error)
+  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__ItemsView(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__ItemsView), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 159, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":154
+  /* "multidict/_multidict.pyx":157
  *         return _KeysView.__new__(_KeysView, self._items)
  * 
  *     def items(self):             # <<<<<<<<<<<<<<
@@ -4003,7 +4005,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_18items(struct __pyx_ob
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":158
+/* "multidict/_multidict.pyx":161
  *         return _ItemsView.__new__(_ItemsView, self._items)
  * 
  *     def values(self):             # <<<<<<<<<<<<<<
@@ -4032,7 +4034,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_20values(struct __pyx_o
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("values", 0);
 
-  /* "multidict/_multidict.pyx":160
+  /* "multidict/_multidict.pyx":163
  *     def values(self):
  *         """Return a new view of the dictionary's values."""
  *         return _ValuesView.__new__(_ValuesView, self._items)             # <<<<<<<<<<<<<<
@@ -4040,19 +4042,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_20values(struct __pyx_o
  *     def __repr__(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 163, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_self->_items);
   __Pyx_GIVEREF(__pyx_v_self->_items);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_self->_items);
-  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__ValuesView(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__ValuesView), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 160, __pyx_L1_error)
+  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__ValuesView(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__ValuesView), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 163, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":158
+  /* "multidict/_multidict.pyx":161
  *         return _ItemsView.__new__(_ItemsView, self._items)
  * 
  *     def values(self):             # <<<<<<<<<<<<<<
@@ -4072,7 +4074,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_20values(struct __pyx_o
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":162
+/* "multidict/_multidict.pyx":165
  *         return _ValuesView.__new__(_ValuesView, self._items)
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -4110,19 +4112,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
   int __pyx_t_8;
   __Pyx_RefNannySetupContext("__repr__", 0);
 
-  /* "multidict/_multidict.pyx":164
+  /* "multidict/_multidict.pyx":167
  *     def __repr__(self):
  *         cdef _Pair item
  *         lst = []             # <<<<<<<<<<<<<<
  *         for i in self._items:
  *             item = <_Pair>i
  */
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 164, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 167, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_lst = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":165
+  /* "multidict/_multidict.pyx":168
  *         cdef _Pair item
  *         lst = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -4131,21 +4133,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
  */
   if (unlikely(__pyx_v_self->_items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 165, __pyx_L1_error)
+    __PYX_ERR(0, 168, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->_items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 165, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 168, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 165, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 168, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":166
+    /* "multidict/_multidict.pyx":169
  *         lst = []
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -4157,14 +4159,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":167
+    /* "multidict/_multidict.pyx":170
  *         for i in self._items:
  *             item = <_Pair>i
  *             lst.append("'{}': {!r}".format(item._key, item._value))             # <<<<<<<<<<<<<<
  *         body = ', '.join(lst)
  *         return '<{}({})>'.format(self.__class__.__name__, body)
  */
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_r, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 167, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_r, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 170, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __pyx_t_5 = NULL;
     __pyx_t_6 = 0;
@@ -4178,7 +4180,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
         __pyx_t_6 = 1;
       }
     }
-    __pyx_t_7 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 167, __pyx_L1_error)
+    __pyx_t_7 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 170, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     if (__pyx_t_5) {
       __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_5); __pyx_t_5 = NULL;
@@ -4189,14 +4191,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
     __Pyx_INCREF(__pyx_v_item->_value);
     __Pyx_GIVEREF(__pyx_v_item->_value);
     PyTuple_SET_ITEM(__pyx_t_7, 1+__pyx_t_6, __pyx_v_item->_value);
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 167, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 170, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __pyx_t_8 = __Pyx_PyList_Append(__pyx_v_lst, __pyx_t_3); if (unlikely(__pyx_t_8 == -1)) __PYX_ERR(0, 167, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_PyList_Append(__pyx_v_lst, __pyx_t_3); if (unlikely(__pyx_t_8 == -1)) __PYX_ERR(0, 170, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":165
+    /* "multidict/_multidict.pyx":168
  *         cdef _Pair item
  *         lst = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -4206,19 +4208,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":168
+  /* "multidict/_multidict.pyx":171
  *             item = <_Pair>i
  *             lst.append("'{}': {!r}".format(item._key, item._value))
  *         body = ', '.join(lst)             # <<<<<<<<<<<<<<
  *         return '<{}({})>'.format(self.__class__.__name__, body)
  * 
  */
-  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__4, __pyx_v_lst); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 168, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__4, __pyx_v_lst); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 171, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_body = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":169
+  /* "multidict/_multidict.pyx":172
  *             lst.append("'{}': {!r}".format(item._key, item._value))
  *         body = ', '.join(lst)
  *         return '<{}({})>'.format(self.__class__.__name__, body)             # <<<<<<<<<<<<<<
@@ -4226,11 +4228,11 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
  *     cdef _eq_to_mapping(self, other):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s__5, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 169, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s__5, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 172, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 169, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 172, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_name); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 169, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_name); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 172, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_4 = NULL;
@@ -4245,7 +4247,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
       __pyx_t_2 = 1;
     }
   }
-  __pyx_t_5 = PyTuple_New(2+__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 169, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_New(2+__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 172, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   if (__pyx_t_4) {
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
@@ -4256,7 +4258,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
   __Pyx_GIVEREF(__pyx_v_body);
   PyTuple_SET_ITEM(__pyx_t_5, 1+__pyx_t_2, __pyx_v_body);
   __pyx_t_7 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 169, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 172, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -4264,7 +4266,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":162
+  /* "multidict/_multidict.pyx":165
  *         return _ValuesView.__new__(_ValuesView, self._items)
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -4291,7 +4293,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_22__repr__(struct __pyx
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":171
+/* "multidict/_multidict.pyx":174
  *         return '<{}({})>'.format(self.__class__.__name__, body)
  * 
  *     cdef _eq_to_mapping(self, other):             # <<<<<<<<<<<<<<
@@ -4317,29 +4319,29 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
   PyObject *__pyx_t_8 = NULL;
   __Pyx_RefNannySetupContext("_eq_to_mapping", 0);
 
-  /* "multidict/_multidict.pyx":173
+  /* "multidict/_multidict.pyx":176
  *     cdef _eq_to_mapping(self, other):
  *         cdef _Pair item
  *         left_keys = set(self.keys())             # <<<<<<<<<<<<<<
  *         right_keys = set(other.keys())
  *         if left_keys != right_keys:
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->keys(__pyx_v_self, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 173, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict__Base *)__pyx_v_self->__pyx_vtab)->keys(__pyx_v_self, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 176, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PySet_New(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 173, __pyx_L1_error)
+  __pyx_t_2 = PySet_New(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 176, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_left_keys = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":174
+  /* "multidict/_multidict.pyx":177
  *         cdef _Pair item
  *         left_keys = set(self.keys())
  *         right_keys = set(other.keys())             # <<<<<<<<<<<<<<
  *         if left_keys != right_keys:
  *             return False
  */
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_keys); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 174, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_keys); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 177, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_3 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_1))) {
@@ -4352,32 +4354,32 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
     }
   }
   if (__pyx_t_3) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 174, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 177, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   } else {
-    __pyx_t_2 = __Pyx_PyObject_CallNoArg(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 174, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallNoArg(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 177, __pyx_L1_error)
   }
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = PySet_New(__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 174, __pyx_L1_error)
+  __pyx_t_1 = PySet_New(__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 177, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_v_right_keys = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":175
+  /* "multidict/_multidict.pyx":178
  *         left_keys = set(self.keys())
  *         right_keys = set(other.keys())
  *         if left_keys != right_keys:             # <<<<<<<<<<<<<<
  *             return False
  *         if len(self._items) != len(right_keys):
  */
-  __pyx_t_1 = PyObject_RichCompare(__pyx_v_left_keys, __pyx_v_right_keys, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 175, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 175, __pyx_L1_error)
+  __pyx_t_1 = PyObject_RichCompare(__pyx_v_left_keys, __pyx_v_right_keys, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 178, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 178, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_4) {
 
-    /* "multidict/_multidict.pyx":176
+    /* "multidict/_multidict.pyx":179
  *         right_keys = set(other.keys())
  *         if left_keys != right_keys:
  *             return False             # <<<<<<<<<<<<<<
@@ -4389,7 +4391,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
     __pyx_r = Py_False;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":175
+    /* "multidict/_multidict.pyx":178
  *         left_keys = set(self.keys())
  *         right_keys = set(other.keys())
  *         if left_keys != right_keys:             # <<<<<<<<<<<<<<
@@ -4398,7 +4400,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
  */
   }
 
-  /* "multidict/_multidict.pyx":177
+  /* "multidict/_multidict.pyx":180
  *         if left_keys != right_keys:
  *             return False
  *         if len(self._items) != len(right_keys):             # <<<<<<<<<<<<<<
@@ -4409,15 +4411,15 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
   __Pyx_INCREF(__pyx_t_1);
   if (unlikely(__pyx_t_1 == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 177, __pyx_L1_error)
+    __PYX_ERR(0, 180, __pyx_L1_error)
   }
-  __pyx_t_5 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 177, __pyx_L1_error)
+  __pyx_t_5 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 180, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_6 = PySet_GET_SIZE(__pyx_v_right_keys); if (unlikely(__pyx_t_6 == -1)) __PYX_ERR(0, 177, __pyx_L1_error)
+  __pyx_t_6 = PySet_GET_SIZE(__pyx_v_right_keys); if (unlikely(__pyx_t_6 == -1)) __PYX_ERR(0, 180, __pyx_L1_error)
   __pyx_t_4 = ((__pyx_t_5 != __pyx_t_6) != 0);
   if (__pyx_t_4) {
 
-    /* "multidict/_multidict.pyx":178
+    /* "multidict/_multidict.pyx":181
  *             return False
  *         if len(self._items) != len(right_keys):
  *             return False             # <<<<<<<<<<<<<<
@@ -4429,7 +4431,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
     __pyx_r = Py_False;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":177
+    /* "multidict/_multidict.pyx":180
  *         if left_keys != right_keys:
  *             return False
  *         if len(self._items) != len(right_keys):             # <<<<<<<<<<<<<<
@@ -4438,7 +4440,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
  */
   }
 
-  /* "multidict/_multidict.pyx":179
+  /* "multidict/_multidict.pyx":182
  *         if len(self._items) != len(right_keys):
  *             return False
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -4447,21 +4449,21 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
  */
   if (unlikely(__pyx_v_self->_items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 179, __pyx_L1_error)
+    __PYX_ERR(0, 182, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->_items; __Pyx_INCREF(__pyx_t_1); __pyx_t_6 = 0;
   for (;;) {
     if (__pyx_t_6 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_2 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_6); __Pyx_INCREF(__pyx_t_2); __pyx_t_6++; if (unlikely(0 < 0)) __PYX_ERR(0, 179, __pyx_L1_error)
+    __pyx_t_2 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_6); __Pyx_INCREF(__pyx_t_2); __pyx_t_6++; if (unlikely(0 < 0)) __PYX_ERR(0, 182, __pyx_L1_error)
     #else
-    __pyx_t_2 = PySequence_ITEM(__pyx_t_1, __pyx_t_6); __pyx_t_6++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 179, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(__pyx_t_1, __pyx_t_6); __pyx_t_6++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 182, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_2);
     __pyx_t_2 = 0;
 
-    /* "multidict/_multidict.pyx":180
+    /* "multidict/_multidict.pyx":183
  *             return False
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -4473,14 +4475,14 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_2));
     __pyx_t_2 = 0;
 
-    /* "multidict/_multidict.pyx":181
+    /* "multidict/_multidict.pyx":184
  *         for i in self._items:
  *             item = <_Pair>i
  *             nv = other.get(item._key, self.marker)             # <<<<<<<<<<<<<<
  *             if item._value != nv:
  *                 return False
  */
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_get); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 181, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_get); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 184, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_t_7 = NULL;
     __pyx_t_5 = 0;
@@ -4494,7 +4496,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
         __pyx_t_5 = 1;
       }
     }
-    __pyx_t_8 = PyTuple_New(2+__pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 181, __pyx_L1_error)
+    __pyx_t_8 = PyTuple_New(2+__pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 184, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -4505,26 +4507,26 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
     __Pyx_INCREF(__pyx_v_self->marker);
     __Pyx_GIVEREF(__pyx_v_self->marker);
     PyTuple_SET_ITEM(__pyx_t_8, 1+__pyx_t_5, __pyx_v_self->marker);
-    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 181, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 184, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_XDECREF_SET(__pyx_v_nv, __pyx_t_2);
     __pyx_t_2 = 0;
 
-    /* "multidict/_multidict.pyx":182
+    /* "multidict/_multidict.pyx":185
  *             item = <_Pair>i
  *             nv = other.get(item._key, self.marker)
  *             if item._value != nv:             # <<<<<<<<<<<<<<
  *                 return False
  *         return True
  */
-    __pyx_t_2 = PyObject_RichCompare(__pyx_v_item->_value, __pyx_v_nv, Py_NE); __Pyx_XGOTREF(__pyx_t_2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 182, __pyx_L1_error)
-    __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_2); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 182, __pyx_L1_error)
+    __pyx_t_2 = PyObject_RichCompare(__pyx_v_item->_value, __pyx_v_nv, Py_NE); __Pyx_XGOTREF(__pyx_t_2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 185, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_2); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 185, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     if (__pyx_t_4) {
 
-      /* "multidict/_multidict.pyx":183
+      /* "multidict/_multidict.pyx":186
  *             nv = other.get(item._key, self.marker)
  *             if item._value != nv:
  *                 return False             # <<<<<<<<<<<<<<
@@ -4537,7 +4539,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":182
+      /* "multidict/_multidict.pyx":185
  *             item = <_Pair>i
  *             nv = other.get(item._key, self.marker)
  *             if item._value != nv:             # <<<<<<<<<<<<<<
@@ -4546,7 +4548,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
  */
     }
 
-    /* "multidict/_multidict.pyx":179
+    /* "multidict/_multidict.pyx":182
  *         if len(self._items) != len(right_keys):
  *             return False
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -4556,7 +4558,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":184
+  /* "multidict/_multidict.pyx":187
  *             if item._value != nv:
  *                 return False
  *         return True             # <<<<<<<<<<<<<<
@@ -4568,7 +4570,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
   __pyx_r = Py_True;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":171
+  /* "multidict/_multidict.pyx":174
  *         return '<{}({})>'.format(self.__class__.__name__, body)
  * 
  *     cdef _eq_to_mapping(self, other):             # <<<<<<<<<<<<<<
@@ -4596,7 +4598,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping(struct __
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":186
+/* "multidict/_multidict.pyx":189
  *         return True
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
@@ -4611,7 +4613,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_5_Base_25__richcmp__(PyObject 
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__richcmp__ (wrapper)", 0);
-  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(0, 186, __pyx_L3_error)
+  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(0, 189, __pyx_L3_error)
   __Pyx_GOTREF(__pyx_v_op);
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L3_error:;
@@ -4636,20 +4638,20 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
   int __pyx_t_3;
   __Pyx_RefNannySetupContext("__richcmp__", 0);
 
-  /* "multidict/_multidict.pyx":187
+  /* "multidict/_multidict.pyx":190
  * 
  *     def __richcmp__(self, other, op):
  *         if op == 2:  # ==             # <<<<<<<<<<<<<<
  *             return _eq(self, other)
  *         elif op == 3:  # !=
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 187, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 190, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 187, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 190, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":188
+    /* "multidict/_multidict.pyx":191
  *     def __richcmp__(self, other, op):
  *         if op == 2:  # ==
  *             return _eq(self, other)             # <<<<<<<<<<<<<<
@@ -4657,13 +4659,13 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
  *             ret = _eq(self, other)
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_1 = __pyx_f_9multidict_10_multidict__eq(__pyx_v_self, __pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 188, __pyx_L1_error)
+    __pyx_t_1 = __pyx_f_9multidict_10_multidict__eq(__pyx_v_self, __pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 191, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_r = __pyx_t_1;
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":187
+    /* "multidict/_multidict.pyx":190
  * 
  *     def __richcmp__(self, other, op):
  *         if op == 2:  # ==             # <<<<<<<<<<<<<<
@@ -4672,32 +4674,32 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
  */
   }
 
-  /* "multidict/_multidict.pyx":189
+  /* "multidict/_multidict.pyx":192
  *         if op == 2:  # ==
  *             return _eq(self, other)
  *         elif op == 3:  # !=             # <<<<<<<<<<<<<<
  *             ret = _eq(self, other)
  *             if ret is NotImplemented:
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 189, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 192, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 189, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 192, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":190
+    /* "multidict/_multidict.pyx":193
  *             return _eq(self, other)
  *         elif op == 3:  # !=
  *             ret = _eq(self, other)             # <<<<<<<<<<<<<<
  *             if ret is NotImplemented:
  *                 return ret
  */
-    __pyx_t_1 = __pyx_f_9multidict_10_multidict__eq(__pyx_v_self, __pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 190, __pyx_L1_error)
+    __pyx_t_1 = __pyx_f_9multidict_10_multidict__eq(__pyx_v_self, __pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 193, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_v_ret = __pyx_t_1;
     __pyx_t_1 = 0;
 
-    /* "multidict/_multidict.pyx":191
+    /* "multidict/_multidict.pyx":194
  *         elif op == 3:  # !=
  *             ret = _eq(self, other)
  *             if ret is NotImplemented:             # <<<<<<<<<<<<<<
@@ -4708,7 +4710,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
     __pyx_t_3 = (__pyx_t_2 != 0);
     if (__pyx_t_3) {
 
-      /* "multidict/_multidict.pyx":192
+      /* "multidict/_multidict.pyx":195
  *             ret = _eq(self, other)
  *             if ret is NotImplemented:
  *                 return ret             # <<<<<<<<<<<<<<
@@ -4720,7 +4722,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
       __pyx_r = __pyx_v_ret;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":191
+      /* "multidict/_multidict.pyx":194
  *         elif op == 3:  # !=
  *             ret = _eq(self, other)
  *             if ret is NotImplemented:             # <<<<<<<<<<<<<<
@@ -4729,7 +4731,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
  */
     }
 
-    /* "multidict/_multidict.pyx":194
+    /* "multidict/_multidict.pyx":197
  *                 return ret
  *             else:
  *                 return not ret             # <<<<<<<<<<<<<<
@@ -4738,15 +4740,15 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
  */
     /*else*/ {
       __Pyx_XDECREF(__pyx_r);
-      __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_v_ret); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 194, __pyx_L1_error)
-      __pyx_t_1 = __Pyx_PyBool_FromLong((!__pyx_t_3)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 194, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_v_ret); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 197, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyBool_FromLong((!__pyx_t_3)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 197, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __pyx_r = __pyx_t_1;
       __pyx_t_1 = 0;
       goto __pyx_L0;
     }
 
-    /* "multidict/_multidict.pyx":189
+    /* "multidict/_multidict.pyx":192
  *         if op == 2:  # ==
  *             return _eq(self, other)
  *         elif op == 3:  # !=             # <<<<<<<<<<<<<<
@@ -4755,7 +4757,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
  */
   }
 
-  /* "multidict/_multidict.pyx":196
+  /* "multidict/_multidict.pyx":199
  *                 return not ret
  *         else:
  *             return NotImplemented             # <<<<<<<<<<<<<<
@@ -4769,7 +4771,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
     goto __pyx_L0;
   }
 
-  /* "multidict/_multidict.pyx":186
+  /* "multidict/_multidict.pyx":189
  *         return True
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
@@ -4789,7 +4791,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_5_Base_24__richcmp__(PyObject 
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":201
+/* "multidict/_multidict.pyx":204
  * cdef class MultiDictProxy(_Base):
  * 
  *     def __init__(self, arg):             # <<<<<<<<<<<<<<
@@ -4822,7 +4824,7 @@ static int __pyx_pw_9multidict_10_multidict_14MultiDictProxy_1__init__(PyObject 
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 201, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 204, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
@@ -4833,7 +4835,7 @@ static int __pyx_pw_9multidict_10_multidict_14MultiDictProxy_1__init__(PyObject 
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__init__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 201, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__init__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 204, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict.MultiDictProxy.__init__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4858,7 +4860,7 @@ static int __pyx_pf_9multidict_10_multidict_14MultiDictProxy___init__(struct __p
   PyObject *__pyx_t_6 = NULL;
   __Pyx_RefNannySetupContext("__init__", 0);
 
-  /* "multidict/_multidict.pyx":203
+  /* "multidict/_multidict.pyx":206
  *     def __init__(self, arg):
  *         cdef MultiDict mdict
  *         if not isinstance(arg, MultiDict):             # <<<<<<<<<<<<<<
@@ -4869,17 +4871,17 @@ static int __pyx_pf_9multidict_10_multidict_14MultiDictProxy___init__(struct __p
   __pyx_t_2 = ((!(__pyx_t_1 != 0)) != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":205
+    /* "multidict/_multidict.pyx":208
  *         if not isinstance(arg, MultiDict):
  *             raise TypeError(
  *                 'MultiDictProxy requires MultiDict instance, not {}'.format(             # <<<<<<<<<<<<<<
  *                     type(arg)))
  * 
  */
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_MultiDictProxy_requires_MultiDic, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 205, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_MultiDictProxy_requires_MultiDic, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 208, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
 
-    /* "multidict/_multidict.pyx":206
+    /* "multidict/_multidict.pyx":209
  *             raise TypeError(
  *                 'MultiDictProxy requires MultiDict instance, not {}'.format(
  *                     type(arg)))             # <<<<<<<<<<<<<<
@@ -4897,41 +4899,41 @@ static int __pyx_pf_9multidict_10_multidict_14MultiDictProxy___init__(struct __p
       }
     }
     if (!__pyx_t_5) {
-      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, ((PyObject *)Py_TYPE(__pyx_v_arg))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 205, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, ((PyObject *)Py_TYPE(__pyx_v_arg))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 208, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
     } else {
-      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 205, __pyx_L1_error)
+      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 208, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5); __pyx_t_5 = NULL;
       __Pyx_INCREF(((PyObject *)Py_TYPE(__pyx_v_arg)));
       __Pyx_GIVEREF(((PyObject *)Py_TYPE(__pyx_v_arg)));
       PyTuple_SET_ITEM(__pyx_t_6, 0+1, ((PyObject *)Py_TYPE(__pyx_v_arg)));
-      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 205, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 208, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     }
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-    /* "multidict/_multidict.pyx":204
+    /* "multidict/_multidict.pyx":207
  *         cdef MultiDict mdict
  *         if not isinstance(arg, MultiDict):
  *             raise TypeError(             # <<<<<<<<<<<<<<
  *                 'MultiDictProxy requires MultiDict instance, not {}'.format(
  *                     type(arg)))
  */
-    __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 204, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 207, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_3);
     PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3);
     __pyx_t_3 = 0;
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 204, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 207, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_Raise(__pyx_t_3, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __PYX_ERR(0, 204, __pyx_L1_error)
+    __PYX_ERR(0, 207, __pyx_L1_error)
 
-    /* "multidict/_multidict.pyx":203
+    /* "multidict/_multidict.pyx":206
  *     def __init__(self, arg):
  *         cdef MultiDict mdict
  *         if not isinstance(arg, MultiDict):             # <<<<<<<<<<<<<<
@@ -4940,20 +4942,20 @@ static int __pyx_pf_9multidict_10_multidict_14MultiDictProxy___init__(struct __p
  */
   }
 
-  /* "multidict/_multidict.pyx":208
+  /* "multidict/_multidict.pyx":211
  *                     type(arg)))
  * 
  *         mdict = arg             # <<<<<<<<<<<<<<
  *         self._items = mdict._items
  * 
  */
-  if (!(likely(((__pyx_v_arg) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_arg, __pyx_ptype_9multidict_10_multidict_MultiDict))))) __PYX_ERR(0, 208, __pyx_L1_error)
+  if (!(likely(((__pyx_v_arg) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_arg, __pyx_ptype_9multidict_10_multidict_MultiDict))))) __PYX_ERR(0, 211, __pyx_L1_error)
   __pyx_t_3 = __pyx_v_arg;
   __Pyx_INCREF(__pyx_t_3);
   __pyx_v_mdict = ((struct __pyx_obj_9multidict_10_multidict_MultiDict *)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "multidict/_multidict.pyx":209
+  /* "multidict/_multidict.pyx":212
  * 
  *         mdict = arg
  *         self._items = mdict._items             # <<<<<<<<<<<<<<
@@ -4968,7 +4970,7 @@ static int __pyx_pf_9multidict_10_multidict_14MultiDictProxy___init__(struct __p
   __pyx_v_self->__pyx_base._items = ((PyObject*)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "multidict/_multidict.pyx":201
+  /* "multidict/_multidict.pyx":204
  * cdef class MultiDictProxy(_Base):
  * 
  *     def __init__(self, arg):             # <<<<<<<<<<<<<<
@@ -4992,7 +4994,7 @@ static int __pyx_pf_9multidict_10_multidict_14MultiDictProxy___init__(struct __p
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":211
+/* "multidict/_multidict.pyx":214
  *         self._items = mdict._items
  * 
  *     def copy(self):             # <<<<<<<<<<<<<<
@@ -5021,7 +5023,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_14MultiDictProxy_2copy(struct 
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("copy", 0);
 
-  /* "multidict/_multidict.pyx":213
+  /* "multidict/_multidict.pyx":216
  *     def copy(self):
  *         """Return a copy of itself."""
  *         return MultiDict(self._items)             # <<<<<<<<<<<<<<
@@ -5029,19 +5031,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_14MultiDictProxy_2copy(struct 
  * abc.Mapping.register(MultiDictProxy)
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 213, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 216, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_self->__pyx_base._items);
   __Pyx_GIVEREF(__pyx_v_self->__pyx_base._items);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_self->__pyx_base._items);
-  __pyx_t_2 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDict), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 213, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDict), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 216, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":211
+  /* "multidict/_multidict.pyx":214
  *         self._items = mdict._items
  * 
  *     def copy(self):             # <<<<<<<<<<<<<<
@@ -5061,7 +5063,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_14MultiDictProxy_2copy(struct 
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":220
+/* "multidict/_multidict.pyx":223
  * cdef class CIMultiDictProxy(MultiDictProxy):
  * 
  *     def __init__(self, arg):             # <<<<<<<<<<<<<<
@@ -5094,7 +5096,7 @@ static int __pyx_pw_9multidict_10_multidict_16CIMultiDictProxy_1__init__(PyObjec
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 220, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 223, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
@@ -5105,7 +5107,7 @@ static int __pyx_pw_9multidict_10_multidict_16CIMultiDictProxy_1__init__(PyObjec
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__init__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 220, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__init__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 223, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict.CIMultiDictProxy.__init__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -5130,7 +5132,7 @@ static int __pyx_pf_9multidict_10_multidict_16CIMultiDictProxy___init__(struct _
   PyObject *__pyx_t_6 = NULL;
   __Pyx_RefNannySetupContext("__init__", 0);
 
-  /* "multidict/_multidict.pyx":222
+  /* "multidict/_multidict.pyx":225
  *     def __init__(self, arg):
  *         cdef CIMultiDict mdict
  *         if not isinstance(arg, CIMultiDict):             # <<<<<<<<<<<<<<
@@ -5141,17 +5143,17 @@ static int __pyx_pf_9multidict_10_multidict_16CIMultiDictProxy___init__(struct _
   __pyx_t_2 = ((!(__pyx_t_1 != 0)) != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":224
+    /* "multidict/_multidict.pyx":227
  *         if not isinstance(arg, CIMultiDict):
  *             raise TypeError(
  *                 'CIMultiDictProxy requires CIMultiDict instance, not {}'.format(             # <<<<<<<<<<<<<<
  *                     type(arg)))
  * 
  */
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_CIMultiDictProxy_requires_CIMult, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 224, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_CIMultiDictProxy_requires_CIMult, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 227, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
 
-    /* "multidict/_multidict.pyx":225
+    /* "multidict/_multidict.pyx":228
  *             raise TypeError(
  *                 'CIMultiDictProxy requires CIMultiDict instance, not {}'.format(
  *                     type(arg)))             # <<<<<<<<<<<<<<
@@ -5169,41 +5171,41 @@ static int __pyx_pf_9multidict_10_multidict_16CIMultiDictProxy___init__(struct _
       }
     }
     if (!__pyx_t_5) {
-      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, ((PyObject *)Py_TYPE(__pyx_v_arg))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 224, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, ((PyObject *)Py_TYPE(__pyx_v_arg))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 227, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
     } else {
-      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 224, __pyx_L1_error)
+      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5); __pyx_t_5 = NULL;
       __Pyx_INCREF(((PyObject *)Py_TYPE(__pyx_v_arg)));
       __Pyx_GIVEREF(((PyObject *)Py_TYPE(__pyx_v_arg)));
       PyTuple_SET_ITEM(__pyx_t_6, 0+1, ((PyObject *)Py_TYPE(__pyx_v_arg)));
-      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 224, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 227, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     }
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-    /* "multidict/_multidict.pyx":223
+    /* "multidict/_multidict.pyx":226
  *         cdef CIMultiDict mdict
  *         if not isinstance(arg, CIMultiDict):
  *             raise TypeError(             # <<<<<<<<<<<<<<
  *                 'CIMultiDictProxy requires CIMultiDict instance, not {}'.format(
  *                     type(arg)))
  */
-    __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 223, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 226, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_3);
     PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3);
     __pyx_t_3 = 0;
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 223, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 226, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_Raise(__pyx_t_3, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __PYX_ERR(0, 223, __pyx_L1_error)
+    __PYX_ERR(0, 226, __pyx_L1_error)
 
-    /* "multidict/_multidict.pyx":222
+    /* "multidict/_multidict.pyx":225
  *     def __init__(self, arg):
  *         cdef CIMultiDict mdict
  *         if not isinstance(arg, CIMultiDict):             # <<<<<<<<<<<<<<
@@ -5212,25 +5214,25 @@ static int __pyx_pf_9multidict_10_multidict_16CIMultiDictProxy___init__(struct _
  */
   }
 
-  /* "multidict/_multidict.pyx":227
+  /* "multidict/_multidict.pyx":230
  *                     type(arg)))
  * 
  *         mdict = arg             # <<<<<<<<<<<<<<
  *         self._items = mdict._items
  * 
  */
-  if (!(likely(((__pyx_v_arg) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_arg, __pyx_ptype_9multidict_10_multidict_CIMultiDict))))) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (!(likely(((__pyx_v_arg) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_arg, __pyx_ptype_9multidict_10_multidict_CIMultiDict))))) __PYX_ERR(0, 230, __pyx_L1_error)
   __pyx_t_3 = __pyx_v_arg;
   __Pyx_INCREF(__pyx_t_3);
   __pyx_v_mdict = ((struct __pyx_obj_9multidict_10_multidict_CIMultiDict *)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "multidict/_multidict.pyx":228
+  /* "multidict/_multidict.pyx":231
  * 
  *         mdict = arg
  *         self._items = mdict._items             # <<<<<<<<<<<<<<
  * 
- *     cdef str _upper(self, s):
+ *     cdef str _title(self, s):
  */
   __pyx_t_3 = __pyx_v_mdict->__pyx_base.__pyx_base._items;
   __Pyx_INCREF(__pyx_t_3);
@@ -5240,7 +5242,7 @@ static int __pyx_pf_9multidict_10_multidict_16CIMultiDictProxy___init__(struct _
   __pyx_v_self->__pyx_base.__pyx_base._items = ((PyObject*)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "multidict/_multidict.pyx":220
+  /* "multidict/_multidict.pyx":223
  * cdef class CIMultiDictProxy(MultiDictProxy):
  * 
  *     def __init__(self, arg):             # <<<<<<<<<<<<<<
@@ -5264,15 +5266,15 @@ static int __pyx_pf_9multidict_10_multidict_16CIMultiDictProxy___init__(struct _
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":230
+/* "multidict/_multidict.pyx":233
  *         self._items = mdict._items
  * 
- *     cdef str _upper(self, s):             # <<<<<<<<<<<<<<
+ *     cdef str _title(self, s):             # <<<<<<<<<<<<<<
  *         if type(s) is self._upstr:
  *             return <str>s
  */
 
-static PyObject *__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__upper(struct __pyx_obj_9multidict_10_multidict_CIMultiDictProxy *__pyx_v_self, PyObject *__pyx_v_s) {
+static PyObject *__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__title(struct __pyx_obj_9multidict_10_multidict_CIMultiDictProxy *__pyx_v_self, PyObject *__pyx_v_s) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
@@ -5280,24 +5282,24 @@ static PyObject *__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__upper(struc
   PyObject *__pyx_t_3 = NULL;
   PyObject *__pyx_t_4 = NULL;
   PyObject *__pyx_t_5 = NULL;
-  __Pyx_RefNannySetupContext("_upper", 0);
+  __Pyx_RefNannySetupContext("_title", 0);
 
-  /* "multidict/_multidict.pyx":231
+  /* "multidict/_multidict.pyx":234
  * 
- *     cdef str _upper(self, s):
+ *     cdef str _title(self, s):
  *         if type(s) is self._upstr:             # <<<<<<<<<<<<<<
  *             return <str>s
- *         return s.upper()
+ *         return s.title()
  */
   __pyx_t_1 = (((PyObject *)Py_TYPE(__pyx_v_s)) == __pyx_v_self->__pyx_base.__pyx_base._upstr);
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":232
- *     cdef str _upper(self, s):
+    /* "multidict/_multidict.pyx":235
+ *     cdef str _title(self, s):
  *         if type(s) is self._upstr:
  *             return <str>s             # <<<<<<<<<<<<<<
- *         return s.upper()
+ *         return s.title()
  * 
  */
     __Pyx_XDECREF(__pyx_r);
@@ -5305,24 +5307,24 @@ static PyObject *__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__upper(struc
     __pyx_r = ((PyObject*)__pyx_v_s);
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":231
+    /* "multidict/_multidict.pyx":234
  * 
- *     cdef str _upper(self, s):
+ *     cdef str _title(self, s):
  *         if type(s) is self._upstr:             # <<<<<<<<<<<<<<
  *             return <str>s
- *         return s.upper()
+ *         return s.title()
  */
   }
 
-  /* "multidict/_multidict.pyx":233
+  /* "multidict/_multidict.pyx":236
  *         if type(s) is self._upstr:
  *             return <str>s
- *         return s.upper()             # <<<<<<<<<<<<<<
+ *         return s.title()             # <<<<<<<<<<<<<<
  * 
  *     def copy(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_s, __pyx_n_s_upper); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 233, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_s, __pyx_n_s_title); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 236, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_5 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_4))) {
@@ -5335,22 +5337,22 @@ static PyObject *__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__upper(struc
     }
   }
   if (__pyx_t_5) {
-    __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 233, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 236, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   } else {
-    __pyx_t_3 = __Pyx_PyObject_CallNoArg(__pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 233, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_CallNoArg(__pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 236, __pyx_L1_error)
   }
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  if (!(likely(PyString_CheckExact(__pyx_t_3))||((__pyx_t_3) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_t_3)->tp_name), 0))) __PYX_ERR(0, 233, __pyx_L1_error)
+  if (!(likely(PyString_CheckExact(__pyx_t_3))||((__pyx_t_3) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_t_3)->tp_name), 0))) __PYX_ERR(0, 236, __pyx_L1_error)
   __pyx_r = ((PyObject*)__pyx_t_3);
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":230
+  /* "multidict/_multidict.pyx":233
  *         self._items = mdict._items
  * 
- *     cdef str _upper(self, s):             # <<<<<<<<<<<<<<
+ *     cdef str _title(self, s):             # <<<<<<<<<<<<<<
  *         if type(s) is self._upstr:
  *             return <str>s
  */
@@ -5360,7 +5362,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__upper(struc
   __Pyx_XDECREF(__pyx_t_3);
   __Pyx_XDECREF(__pyx_t_4);
   __Pyx_XDECREF(__pyx_t_5);
-  __Pyx_AddTraceback("multidict._multidict.CIMultiDictProxy._upper", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("multidict._multidict.CIMultiDictProxy._title", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = 0;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5368,8 +5370,8 @@ static PyObject *__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__upper(struc
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":235
- *         return s.upper()
+/* "multidict/_multidict.pyx":238
+ *         return s.title()
  * 
  *     def copy(self):             # <<<<<<<<<<<<<<
  *         """Return a copy of itself."""
@@ -5397,7 +5399,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_16CIMultiDictProxy_2copy(struc
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("copy", 0);
 
-  /* "multidict/_multidict.pyx":237
+  /* "multidict/_multidict.pyx":240
  *     def copy(self):
  *         """Return a copy of itself."""
  *         return CIMultiDict(self._items)             # <<<<<<<<<<<<<<
@@ -5405,20 +5407,20 @@ static PyObject *__pyx_pf_9multidict_10_multidict_16CIMultiDictProxy_2copy(struc
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 237, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 240, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_self->__pyx_base.__pyx_base._items);
   __Pyx_GIVEREF(__pyx_v_self->__pyx_base.__pyx_base._items);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_self->__pyx_base.__pyx_base._items);
-  __pyx_t_2 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDict), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 237, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDict), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 240, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":235
- *         return s.upper()
+  /* "multidict/_multidict.pyx":238
+ *         return s.title()
  * 
  *     def copy(self):             # <<<<<<<<<<<<<<
  *         """Return a copy of itself."""
@@ -5437,7 +5439,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_16CIMultiDictProxy_2copy(struc
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":246
+/* "multidict/_multidict.pyx":249
  *     """An ordered dictionary that can have multiple values for each key."""
  * 
  *     def __init__(self, *args, **kwargs):             # <<<<<<<<<<<<<<
@@ -5474,14 +5476,14 @@ static int __pyx_pf_9multidict_10_multidict_9MultiDict___init__(struct __pyx_obj
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__init__", 0);
 
-  /* "multidict/_multidict.pyx":247
+  /* "multidict/_multidict.pyx":250
  * 
  *     def __init__(self, *args, **kwargs):
  *         self._items = []             # <<<<<<<<<<<<<<
  * 
  *         self._extend(args, kwargs, self.__class__.__name__, 1)
  */
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 247, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 250, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
   __Pyx_GOTREF(__pyx_v_self->__pyx_base._items);
@@ -5489,24 +5491,24 @@ static int __pyx_pf_9multidict_10_multidict_9MultiDict___init__(struct __pyx_obj
   __pyx_v_self->__pyx_base._items = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":249
+  /* "multidict/_multidict.pyx":252
  *         self._items = []
  * 
  *         self._extend(args, kwargs, self.__class__.__name__, 1)             # <<<<<<<<<<<<<<
  * 
  *     cdef _extend(self, tuple args, dict kwargs, name, int do_add):
  */
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 252, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_name); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_name); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 252, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_extend(__pyx_v_self, __pyx_v_args, __pyx_v_kwargs, __pyx_t_2, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_extend(__pyx_v_self, __pyx_v_args, __pyx_v_kwargs, __pyx_t_2, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 252, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":246
+  /* "multidict/_multidict.pyx":249
  *     """An ordered dictionary that can have multiple values for each key."""
  * 
  *     def __init__(self, *args, **kwargs):             # <<<<<<<<<<<<<<
@@ -5527,7 +5529,7 @@ static int __pyx_pf_9multidict_10_multidict_9MultiDict___init__(struct __pyx_obj
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":251
+/* "multidict/_multidict.pyx":254
  *         self._extend(args, kwargs, self.__class__.__name__, 1)
  * 
  *     cdef _extend(self, tuple args, dict kwargs, name, int do_add):             # <<<<<<<<<<<<<<
@@ -5556,7 +5558,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
   PyObject *(*__pyx_t_11)(PyObject *);
   __Pyx_RefNannySetupContext("_extend", 0);
 
-  /* "multidict/_multidict.pyx":255
+  /* "multidict/_multidict.pyx":258
  *         cdef str key
  * 
  *         if len(args) > 1:             # <<<<<<<<<<<<<<
@@ -5565,27 +5567,27 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  */
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 255, __pyx_L1_error)
+    __PYX_ERR(0, 258, __pyx_L1_error)
   }
-  __pyx_t_1 = PyTuple_GET_SIZE(__pyx_v_args); if (unlikely(__pyx_t_1 == -1)) __PYX_ERR(0, 255, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_GET_SIZE(__pyx_v_args); if (unlikely(__pyx_t_1 == -1)) __PYX_ERR(0, 258, __pyx_L1_error)
   __pyx_t_2 = ((__pyx_t_1 > 1) != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":257
+    /* "multidict/_multidict.pyx":260
  *         if len(args) > 1:
  *             raise TypeError("{} takes at most 1 positional argument"
  *                             " ({} given)".format(name, len(args)))             # <<<<<<<<<<<<<<
  * 
  *         if args:
  */
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_takes_at_most_1_positional_argu, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 257, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_takes_at_most_1_positional_argu, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 257, __pyx_L1_error)
+      __PYX_ERR(0, 260, __pyx_L1_error)
     }
-    __pyx_t_1 = PyTuple_GET_SIZE(__pyx_v_args); if (unlikely(__pyx_t_1 == -1)) __PYX_ERR(0, 257, __pyx_L1_error)
-    __pyx_t_5 = PyInt_FromSsize_t(__pyx_t_1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 257, __pyx_L1_error)
+    __pyx_t_1 = PyTuple_GET_SIZE(__pyx_v_args); if (unlikely(__pyx_t_1 == -1)) __PYX_ERR(0, 260, __pyx_L1_error)
+    __pyx_t_5 = PyInt_FromSsize_t(__pyx_t_1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __pyx_t_6 = NULL;
     __pyx_t_1 = 0;
@@ -5599,7 +5601,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __pyx_t_1 = 1;
       }
     }
-    __pyx_t_7 = PyTuple_New(2+__pyx_t_1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 257, __pyx_L1_error)
+    __pyx_t_7 = PyTuple_New(2+__pyx_t_1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     if (__pyx_t_6) {
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
@@ -5610,31 +5612,31 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
     __Pyx_GIVEREF(__pyx_t_5);
     PyTuple_SET_ITEM(__pyx_t_7, 1+__pyx_t_1, __pyx_t_5);
     __pyx_t_5 = 0;
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 257, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-    /* "multidict/_multidict.pyx":256
+    /* "multidict/_multidict.pyx":259
  * 
  *         if len(args) > 1:
  *             raise TypeError("{} takes at most 1 positional argument"             # <<<<<<<<<<<<<<
  *                             " ({} given)".format(name, len(args)))
  * 
  */
-    __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 256, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 259, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_3);
     PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3);
     __pyx_t_3 = 0;
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 256, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 259, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_Raise(__pyx_t_3, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __PYX_ERR(0, 256, __pyx_L1_error)
+    __PYX_ERR(0, 259, __pyx_L1_error)
 
-    /* "multidict/_multidict.pyx":255
+    /* "multidict/_multidict.pyx":258
  *         cdef str key
  * 
  *         if len(args) > 1:             # <<<<<<<<<<<<<<
@@ -5643,7 +5645,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  */
   }
 
-  /* "multidict/_multidict.pyx":259
+  /* "multidict/_multidict.pyx":262
  *                             " ({} given)".format(name, len(args)))
  * 
  *         if args:             # <<<<<<<<<<<<<<
@@ -5653,7 +5655,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
   __pyx_t_2 = (__pyx_v_args != Py_None) && (PyTuple_GET_SIZE(__pyx_v_args) != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":260
+    /* "multidict/_multidict.pyx":263
  * 
  *         if args:
  *             arg = args[0]             # <<<<<<<<<<<<<<
@@ -5662,14 +5664,14 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  */
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 260, __pyx_L1_error)
+      __PYX_ERR(0, 263, __pyx_L1_error)
     }
-    __pyx_t_3 = __Pyx_GetItemInt_Tuple(__pyx_v_args, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 260, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt_Tuple(__pyx_v_args, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 263, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_v_arg = __pyx_t_3;
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":261
+    /* "multidict/_multidict.pyx":264
  *         if args:
  *             arg = args[0]
  *             if isinstance(arg, _Base):             # <<<<<<<<<<<<<<
@@ -5680,34 +5682,34 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
     __pyx_t_8 = (__pyx_t_2 != 0);
     if (__pyx_t_8) {
 
-      /* "multidict/_multidict.pyx":262
+      /* "multidict/_multidict.pyx":265
  *             arg = args[0]
  *             if isinstance(arg, _Base):
  *                 for i in (<_Base>arg)._items:             # <<<<<<<<<<<<<<
  *                     item = <_Pair>i
- *                     key = self._upper(item._key)
+ *                     key = self._title(item._key)
  */
       if (unlikely(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_arg)->_items == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-        __PYX_ERR(0, 262, __pyx_L1_error)
+        __PYX_ERR(0, 265, __pyx_L1_error)
       }
       __pyx_t_3 = ((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_arg)->_items; __Pyx_INCREF(__pyx_t_3); __pyx_t_1 = 0;
       for (;;) {
         if (__pyx_t_1 >= PyList_GET_SIZE(__pyx_t_3)) break;
         #if CYTHON_COMPILING_IN_CPYTHON
-        __pyx_t_4 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_1); __Pyx_INCREF(__pyx_t_4); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 262, __pyx_L1_error)
+        __pyx_t_4 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_1); __Pyx_INCREF(__pyx_t_4); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 265, __pyx_L1_error)
         #else
-        __pyx_t_4 = PySequence_ITEM(__pyx_t_3, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 262, __pyx_L1_error)
+        __pyx_t_4 = PySequence_ITEM(__pyx_t_3, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 265, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         #endif
         __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_4);
         __pyx_t_4 = 0;
 
-        /* "multidict/_multidict.pyx":263
+        /* "multidict/_multidict.pyx":266
  *             if isinstance(arg, _Base):
  *                 for i in (<_Base>arg)._items:
  *                     item = <_Pair>i             # <<<<<<<<<<<<<<
- *                     key = self._upper(item._key)
+ *                     key = self._title(item._key)
  *                     value = item._value
  */
         __pyx_t_4 = __pyx_v_i;
@@ -5715,24 +5717,24 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_4));
         __pyx_t_4 = 0;
 
-        /* "multidict/_multidict.pyx":264
+        /* "multidict/_multidict.pyx":267
  *                 for i in (<_Base>arg)._items:
  *                     item = <_Pair>i
- *                     key = self._upper(item._key)             # <<<<<<<<<<<<<<
+ *                     key = self._title(item._key)             # <<<<<<<<<<<<<<
  *                     value = item._value
  *                     if do_add:
  */
         __pyx_t_4 = __pyx_v_item->_key;
         __Pyx_INCREF(__pyx_t_4);
-        __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._upper(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 264, __pyx_L1_error)
+        __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._title(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 267, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
         __Pyx_XDECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_7));
         __pyx_t_7 = 0;
 
-        /* "multidict/_multidict.pyx":265
+        /* "multidict/_multidict.pyx":268
  *                     item = <_Pair>i
- *                     key = self._upper(item._key)
+ *                     key = self._title(item._key)
  *                     value = item._value             # <<<<<<<<<<<<<<
  *                     if do_add:
  *                         self._add(key, value)
@@ -5742,8 +5744,8 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __Pyx_XDECREF_SET(__pyx_v_value, __pyx_t_7);
         __pyx_t_7 = 0;
 
-        /* "multidict/_multidict.pyx":266
- *                     key = self._upper(item._key)
+        /* "multidict/_multidict.pyx":269
+ *                     key = self._title(item._key)
  *                     value = item._value
  *                     if do_add:             # <<<<<<<<<<<<<<
  *                         self._add(key, value)
@@ -5752,19 +5754,19 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __pyx_t_8 = (__pyx_v_do_add != 0);
         if (__pyx_t_8) {
 
-          /* "multidict/_multidict.pyx":267
+          /* "multidict/_multidict.pyx":270
  *                     value = item._value
  *                     if do_add:
  *                         self._add(key, value)             # <<<<<<<<<<<<<<
  *                     else:
  *                         self._replace(key, value)
  */
-          __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 267, __pyx_L1_error)
+          __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 270, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_7);
           __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-          /* "multidict/_multidict.pyx":266
- *                     key = self._upper(item._key)
+          /* "multidict/_multidict.pyx":269
+ *                     key = self._title(item._key)
  *                     value = item._value
  *                     if do_add:             # <<<<<<<<<<<<<<
  *                         self._add(key, value)
@@ -5773,7 +5775,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
           goto __pyx_L8;
         }
 
-        /* "multidict/_multidict.pyx":269
+        /* "multidict/_multidict.pyx":272
  *                         self._add(key, value)
  *                     else:
  *                         self._replace(key, value)             # <<<<<<<<<<<<<<
@@ -5781,23 +5783,23 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  *                 for i in arg.items():
  */
         /*else*/ {
-          __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 269, __pyx_L1_error)
+          __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 272, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_7);
           __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
         }
         __pyx_L8:;
 
-        /* "multidict/_multidict.pyx":262
+        /* "multidict/_multidict.pyx":265
  *             arg = args[0]
  *             if isinstance(arg, _Base):
  *                 for i in (<_Base>arg)._items:             # <<<<<<<<<<<<<<
  *                     item = <_Pair>i
- *                     key = self._upper(item._key)
+ *                     key = self._title(item._key)
  */
       }
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "multidict/_multidict.pyx":261
+      /* "multidict/_multidict.pyx":264
  *         if args:
  *             arg = args[0]
  *             if isinstance(arg, _Base):             # <<<<<<<<<<<<<<
@@ -5807,25 +5809,25 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
       goto __pyx_L5;
     }
 
-    /* "multidict/_multidict.pyx":270
+    /* "multidict/_multidict.pyx":273
  *                     else:
  *                         self._replace(key, value)
  *             elif hasattr(arg, 'items'):             # <<<<<<<<<<<<<<
  *                 for i in arg.items():
  *                     if isinstance(i, _Pair):
  */
-    __pyx_t_8 = PyObject_HasAttr(__pyx_v_arg, __pyx_n_s_items); if (unlikely(__pyx_t_8 == -1)) __PYX_ERR(0, 270, __pyx_L1_error)
+    __pyx_t_8 = PyObject_HasAttr(__pyx_v_arg, __pyx_n_s_items); if (unlikely(__pyx_t_8 == -1)) __PYX_ERR(0, 273, __pyx_L1_error)
     __pyx_t_2 = (__pyx_t_8 != 0);
     if (__pyx_t_2) {
 
-      /* "multidict/_multidict.pyx":271
+      /* "multidict/_multidict.pyx":274
  *                         self._replace(key, value)
  *             elif hasattr(arg, 'items'):
  *                 for i in arg.items():             # <<<<<<<<<<<<<<
  *                     if isinstance(i, _Pair):
  *                         item = <_Pair>i
  */
-      __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_items); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 271, __pyx_L1_error)
+      __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_items); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 274, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __pyx_t_4 = NULL;
       if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_7))) {
@@ -5838,10 +5840,10 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         }
       }
       if (__pyx_t_4) {
-        __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_7, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 271, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_7, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 274, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
       } else {
-        __pyx_t_3 = __Pyx_PyObject_CallNoArg(__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 271, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_CallNoArg(__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 274, __pyx_L1_error)
       }
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
@@ -5849,9 +5851,9 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __pyx_t_7 = __pyx_t_3; __Pyx_INCREF(__pyx_t_7); __pyx_t_1 = 0;
         __pyx_t_9 = NULL;
       } else {
-        __pyx_t_1 = -1; __pyx_t_7 = PyObject_GetIter(__pyx_t_3); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 271, __pyx_L1_error)
+        __pyx_t_1 = -1; __pyx_t_7 = PyObject_GetIter(__pyx_t_3); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 274, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
-        __pyx_t_9 = Py_TYPE(__pyx_t_7)->tp_iternext; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 271, __pyx_L1_error)
+        __pyx_t_9 = Py_TYPE(__pyx_t_7)->tp_iternext; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 274, __pyx_L1_error)
       }
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       for (;;) {
@@ -5859,17 +5861,17 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
           if (likely(PyList_CheckExact(__pyx_t_7))) {
             if (__pyx_t_1 >= PyList_GET_SIZE(__pyx_t_7)) break;
             #if CYTHON_COMPILING_IN_CPYTHON
-            __pyx_t_3 = PyList_GET_ITEM(__pyx_t_7, __pyx_t_1); __Pyx_INCREF(__pyx_t_3); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 271, __pyx_L1_error)
+            __pyx_t_3 = PyList_GET_ITEM(__pyx_t_7, __pyx_t_1); __Pyx_INCREF(__pyx_t_3); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 274, __pyx_L1_error)
             #else
-            __pyx_t_3 = PySequence_ITEM(__pyx_t_7, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 271, __pyx_L1_error)
+            __pyx_t_3 = PySequence_ITEM(__pyx_t_7, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 274, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_3);
             #endif
           } else {
             if (__pyx_t_1 >= PyTuple_GET_SIZE(__pyx_t_7)) break;
             #if CYTHON_COMPILING_IN_CPYTHON
-            __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_7, __pyx_t_1); __Pyx_INCREF(__pyx_t_3); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 271, __pyx_L1_error)
+            __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_7, __pyx_t_1); __Pyx_INCREF(__pyx_t_3); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 274, __pyx_L1_error)
             #else
-            __pyx_t_3 = PySequence_ITEM(__pyx_t_7, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 271, __pyx_L1_error)
+            __pyx_t_3 = PySequence_ITEM(__pyx_t_7, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 274, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_3);
             #endif
           }
@@ -5879,7 +5881,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
             PyObject* exc_type = PyErr_Occurred();
             if (exc_type) {
               if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-              else __PYX_ERR(0, 271, __pyx_L1_error)
+              else __PYX_ERR(0, 274, __pyx_L1_error)
             }
             break;
           }
@@ -5888,7 +5890,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
         __pyx_t_3 = 0;
 
-        /* "multidict/_multidict.pyx":272
+        /* "multidict/_multidict.pyx":275
  *             elif hasattr(arg, 'items'):
  *                 for i in arg.items():
  *                     if isinstance(i, _Pair):             # <<<<<<<<<<<<<<
@@ -5899,7 +5901,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __pyx_t_8 = (__pyx_t_2 != 0);
         if (__pyx_t_8) {
 
-          /* "multidict/_multidict.pyx":273
+          /* "multidict/_multidict.pyx":276
  *                 for i in arg.items():
  *                     if isinstance(i, _Pair):
  *                         item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -5911,32 +5913,32 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
           __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
           __pyx_t_3 = 0;
 
-          /* "multidict/_multidict.pyx":274
+          /* "multidict/_multidict.pyx":277
  *                     if isinstance(i, _Pair):
  *                         item = <_Pair>i
  *                         key = item._key             # <<<<<<<<<<<<<<
  *                         value = item._value
  *                     else:
  */
-          if (!(likely(PyString_CheckExact(__pyx_v_item->_key))||((__pyx_v_item->_key) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_v_item->_key)->tp_name), 0))) __PYX_ERR(0, 274, __pyx_L1_error)
+          if (!(likely(PyString_CheckExact(__pyx_v_item->_key))||((__pyx_v_item->_key) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_v_item->_key)->tp_name), 0))) __PYX_ERR(0, 277, __pyx_L1_error)
           __pyx_t_3 = __pyx_v_item->_key;
           __Pyx_INCREF(__pyx_t_3);
           __Pyx_XDECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_3));
           __pyx_t_3 = 0;
 
-          /* "multidict/_multidict.pyx":275
+          /* "multidict/_multidict.pyx":278
  *                         item = <_Pair>i
  *                         key = item._key
  *                         value = item._value             # <<<<<<<<<<<<<<
  *                     else:
- *                         key = self._upper(i[0])
+ *                         key = self._title(i[0])
  */
           __pyx_t_3 = __pyx_v_item->_value;
           __Pyx_INCREF(__pyx_t_3);
           __Pyx_XDECREF_SET(__pyx_v_value, __pyx_t_3);
           __pyx_t_3 = 0;
 
-          /* "multidict/_multidict.pyx":272
+          /* "multidict/_multidict.pyx":275
  *             elif hasattr(arg, 'items'):
  *                 for i in arg.items():
  *                     if isinstance(i, _Pair):             # <<<<<<<<<<<<<<
@@ -5946,38 +5948,38 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
           goto __pyx_L11;
         }
 
-        /* "multidict/_multidict.pyx":277
+        /* "multidict/_multidict.pyx":280
  *                         value = item._value
  *                     else:
- *                         key = self._upper(i[0])             # <<<<<<<<<<<<<<
+ *                         key = self._title(i[0])             # <<<<<<<<<<<<<<
  *                         value = i[1]
  *                     if do_add:
  */
         /*else*/ {
-          __pyx_t_3 = __Pyx_GetItemInt(__pyx_v_i, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 277, __pyx_L1_error)
+          __pyx_t_3 = __Pyx_GetItemInt(__pyx_v_i, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 280, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
-          __pyx_t_4 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._upper(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 277, __pyx_L1_error)
+          __pyx_t_4 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._title(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 280, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_4);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
           __Pyx_XDECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_4));
           __pyx_t_4 = 0;
 
-          /* "multidict/_multidict.pyx":278
+          /* "multidict/_multidict.pyx":281
  *                     else:
- *                         key = self._upper(i[0])
+ *                         key = self._title(i[0])
  *                         value = i[1]             # <<<<<<<<<<<<<<
  *                     if do_add:
  *                         self._add(key, value)
  */
-          __pyx_t_4 = __Pyx_GetItemInt(__pyx_v_i, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 278, __pyx_L1_error)
+          __pyx_t_4 = __Pyx_GetItemInt(__pyx_v_i, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 281, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_4);
           __Pyx_XDECREF_SET(__pyx_v_value, __pyx_t_4);
           __pyx_t_4 = 0;
         }
         __pyx_L11:;
 
-        /* "multidict/_multidict.pyx":279
- *                         key = self._upper(i[0])
+        /* "multidict/_multidict.pyx":282
+ *                         key = self._title(i[0])
  *                         value = i[1]
  *                     if do_add:             # <<<<<<<<<<<<<<
  *                         self._add(key, value)
@@ -5986,19 +5988,19 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __pyx_t_8 = (__pyx_v_do_add != 0);
         if (__pyx_t_8) {
 
-          /* "multidict/_multidict.pyx":280
+          /* "multidict/_multidict.pyx":283
  *                         value = i[1]
  *                     if do_add:
  *                         self._add(key, value)             # <<<<<<<<<<<<<<
  *                     else:
  *                         self._replace(key, value)
  */
-          __pyx_t_4 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 280, __pyx_L1_error)
+          __pyx_t_4 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 283, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_4);
           __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-          /* "multidict/_multidict.pyx":279
- *                         key = self._upper(i[0])
+          /* "multidict/_multidict.pyx":282
+ *                         key = self._title(i[0])
  *                         value = i[1]
  *                     if do_add:             # <<<<<<<<<<<<<<
  *                         self._add(key, value)
@@ -6007,7 +6009,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
           goto __pyx_L12;
         }
 
-        /* "multidict/_multidict.pyx":282
+        /* "multidict/_multidict.pyx":285
  *                         self._add(key, value)
  *                     else:
  *                         self._replace(key, value)             # <<<<<<<<<<<<<<
@@ -6015,13 +6017,13 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  *                 for i in arg:
  */
         /*else*/ {
-          __pyx_t_4 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 282, __pyx_L1_error)
+          __pyx_t_4 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 285, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_4);
           __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
         }
         __pyx_L12:;
 
-        /* "multidict/_multidict.pyx":271
+        /* "multidict/_multidict.pyx":274
  *                         self._replace(key, value)
  *             elif hasattr(arg, 'items'):
  *                 for i in arg.items():             # <<<<<<<<<<<<<<
@@ -6031,7 +6033,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
       }
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-      /* "multidict/_multidict.pyx":270
+      /* "multidict/_multidict.pyx":273
  *                     else:
  *                         self._replace(key, value)
  *             elif hasattr(arg, 'items'):             # <<<<<<<<<<<<<<
@@ -6041,7 +6043,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
       goto __pyx_L5;
     }
 
-    /* "multidict/_multidict.pyx":284
+    /* "multidict/_multidict.pyx":287
  *                         self._replace(key, value)
  *             else:
  *                 for i in arg:             # <<<<<<<<<<<<<<
@@ -6053,26 +6055,26 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __pyx_t_7 = __pyx_v_arg; __Pyx_INCREF(__pyx_t_7); __pyx_t_1 = 0;
         __pyx_t_9 = NULL;
       } else {
-        __pyx_t_1 = -1; __pyx_t_7 = PyObject_GetIter(__pyx_v_arg); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 284, __pyx_L1_error)
+        __pyx_t_1 = -1; __pyx_t_7 = PyObject_GetIter(__pyx_v_arg); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 287, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
-        __pyx_t_9 = Py_TYPE(__pyx_t_7)->tp_iternext; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 284, __pyx_L1_error)
+        __pyx_t_9 = Py_TYPE(__pyx_t_7)->tp_iternext; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 287, __pyx_L1_error)
       }
       for (;;) {
         if (likely(!__pyx_t_9)) {
           if (likely(PyList_CheckExact(__pyx_t_7))) {
             if (__pyx_t_1 >= PyList_GET_SIZE(__pyx_t_7)) break;
             #if CYTHON_COMPILING_IN_CPYTHON
-            __pyx_t_4 = PyList_GET_ITEM(__pyx_t_7, __pyx_t_1); __Pyx_INCREF(__pyx_t_4); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 284, __pyx_L1_error)
+            __pyx_t_4 = PyList_GET_ITEM(__pyx_t_7, __pyx_t_1); __Pyx_INCREF(__pyx_t_4); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 287, __pyx_L1_error)
             #else
-            __pyx_t_4 = PySequence_ITEM(__pyx_t_7, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 284, __pyx_L1_error)
+            __pyx_t_4 = PySequence_ITEM(__pyx_t_7, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 287, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_4);
             #endif
           } else {
             if (__pyx_t_1 >= PyTuple_GET_SIZE(__pyx_t_7)) break;
             #if CYTHON_COMPILING_IN_CPYTHON
-            __pyx_t_4 = PyTuple_GET_ITEM(__pyx_t_7, __pyx_t_1); __Pyx_INCREF(__pyx_t_4); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 284, __pyx_L1_error)
+            __pyx_t_4 = PyTuple_GET_ITEM(__pyx_t_7, __pyx_t_1); __Pyx_INCREF(__pyx_t_4); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 287, __pyx_L1_error)
             #else
-            __pyx_t_4 = PySequence_ITEM(__pyx_t_7, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 284, __pyx_L1_error)
+            __pyx_t_4 = PySequence_ITEM(__pyx_t_7, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 287, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_4);
             #endif
           }
@@ -6082,7 +6084,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
             PyObject* exc_type = PyErr_Occurred();
             if (exc_type) {
               if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-              else __PYX_ERR(0, 284, __pyx_L1_error)
+              else __PYX_ERR(0, 287, __pyx_L1_error)
             }
             break;
           }
@@ -6091,7 +6093,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_4);
         __pyx_t_4 = 0;
 
-        /* "multidict/_multidict.pyx":285
+        /* "multidict/_multidict.pyx":288
  *             else:
  *                 for i in arg:
  *                     if isinstance(i, _Pair):             # <<<<<<<<<<<<<<
@@ -6102,7 +6104,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __pyx_t_2 = (__pyx_t_8 != 0);
         if (__pyx_t_2) {
 
-          /* "multidict/_multidict.pyx":286
+          /* "multidict/_multidict.pyx":289
  *                 for i in arg:
  *                     if isinstance(i, _Pair):
  *                         item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -6114,20 +6116,20 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
           __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_4));
           __pyx_t_4 = 0;
 
-          /* "multidict/_multidict.pyx":287
+          /* "multidict/_multidict.pyx":290
  *                     if isinstance(i, _Pair):
  *                         item = <_Pair>i
  *                         key = item._key             # <<<<<<<<<<<<<<
  *                         value = item._value
  *                     else:
  */
-          if (!(likely(PyString_CheckExact(__pyx_v_item->_key))||((__pyx_v_item->_key) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_v_item->_key)->tp_name), 0))) __PYX_ERR(0, 287, __pyx_L1_error)
+          if (!(likely(PyString_CheckExact(__pyx_v_item->_key))||((__pyx_v_item->_key) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_v_item->_key)->tp_name), 0))) __PYX_ERR(0, 290, __pyx_L1_error)
           __pyx_t_4 = __pyx_v_item->_key;
           __Pyx_INCREF(__pyx_t_4);
           __Pyx_XDECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_4));
           __pyx_t_4 = 0;
 
-          /* "multidict/_multidict.pyx":288
+          /* "multidict/_multidict.pyx":291
  *                         item = <_Pair>i
  *                         key = item._key
  *                         value = item._value             # <<<<<<<<<<<<<<
@@ -6139,7 +6141,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
           __Pyx_XDECREF_SET(__pyx_v_value, __pyx_t_4);
           __pyx_t_4 = 0;
 
-          /* "multidict/_multidict.pyx":285
+          /* "multidict/_multidict.pyx":288
  *             else:
  *                 for i in arg:
  *                     if isinstance(i, _Pair):             # <<<<<<<<<<<<<<
@@ -6149,7 +6151,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
           goto __pyx_L15;
         }
 
-        /* "multidict/_multidict.pyx":290
+        /* "multidict/_multidict.pyx":293
  *                         value = item._value
  *                     else:
  *                         if not len(i) == 2:             # <<<<<<<<<<<<<<
@@ -6157,18 +6159,18 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  *                                 "{} takes either dict or list of (key, value) "
  */
         /*else*/ {
-          __pyx_t_10 = PyObject_Length(__pyx_v_i); if (unlikely(__pyx_t_10 == -1)) __PYX_ERR(0, 290, __pyx_L1_error)
+          __pyx_t_10 = PyObject_Length(__pyx_v_i); if (unlikely(__pyx_t_10 == -1)) __PYX_ERR(0, 293, __pyx_L1_error)
           __pyx_t_2 = ((!((__pyx_t_10 == 2) != 0)) != 0);
           if (__pyx_t_2) {
 
-            /* "multidict/_multidict.pyx":293
+            /* "multidict/_multidict.pyx":296
  *                             raise TypeError(
  *                                 "{} takes either dict or list of (key, value) "
  *                                 "tuples".format(name))             # <<<<<<<<<<<<<<
- *                         key = self._upper(i[0])
+ *                         key = self._title(i[0])
  *                         value = i[1]
  */
-            __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_takes_either_dict_or_list_of_ke, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 293, __pyx_L1_error)
+            __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_takes_either_dict_or_list_of_ke, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 296, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_3);
             __pyx_t_5 = NULL;
             if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_3))) {
@@ -6181,41 +6183,41 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
               }
             }
             if (!__pyx_t_5) {
-              __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_name); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 293, __pyx_L1_error)
+              __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_name); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 296, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_4);
             } else {
-              __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 293, __pyx_L1_error)
+              __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 296, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_6);
               __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5); __pyx_t_5 = NULL;
               __Pyx_INCREF(__pyx_v_name);
               __Pyx_GIVEREF(__pyx_v_name);
               PyTuple_SET_ITEM(__pyx_t_6, 0+1, __pyx_v_name);
-              __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_6, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 293, __pyx_L1_error)
+              __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_6, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 296, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_4);
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             }
             __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-            /* "multidict/_multidict.pyx":291
+            /* "multidict/_multidict.pyx":294
  *                     else:
  *                         if not len(i) == 2:
  *                             raise TypeError(             # <<<<<<<<<<<<<<
  *                                 "{} takes either dict or list of (key, value) "
  *                                 "tuples".format(name))
  */
-            __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 291, __pyx_L1_error)
+            __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 294, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_3);
             __Pyx_GIVEREF(__pyx_t_4);
             PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_4);
             __pyx_t_4 = 0;
-            __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 291, __pyx_L1_error)
+            __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 294, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_4);
             __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
             __Pyx_Raise(__pyx_t_4, 0, 0, 0);
             __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-            __PYX_ERR(0, 291, __pyx_L1_error)
+            __PYX_ERR(0, 294, __pyx_L1_error)
 
-            /* "multidict/_multidict.pyx":290
+            /* "multidict/_multidict.pyx":293
  *                         value = item._value
  *                     else:
  *                         if not len(i) == 2:             # <<<<<<<<<<<<<<
@@ -6224,37 +6226,37 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  */
           }
 
-          /* "multidict/_multidict.pyx":294
+          /* "multidict/_multidict.pyx":297
  *                                 "{} takes either dict or list of (key, value) "
  *                                 "tuples".format(name))
- *                         key = self._upper(i[0])             # <<<<<<<<<<<<<<
+ *                         key = self._title(i[0])             # <<<<<<<<<<<<<<
  *                         value = i[1]
  *                     if do_add:
  */
-          __pyx_t_4 = __Pyx_GetItemInt(__pyx_v_i, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 294, __pyx_L1_error)
+          __pyx_t_4 = __Pyx_GetItemInt(__pyx_v_i, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 297, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_4);
-          __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._upper(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 294, __pyx_L1_error)
+          __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._title(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 297, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
           __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
           __Pyx_XDECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_3));
           __pyx_t_3 = 0;
 
-          /* "multidict/_multidict.pyx":295
+          /* "multidict/_multidict.pyx":298
  *                                 "tuples".format(name))
- *                         key = self._upper(i[0])
+ *                         key = self._title(i[0])
  *                         value = i[1]             # <<<<<<<<<<<<<<
  *                     if do_add:
  *                         self._add(key, value)
  */
-          __pyx_t_3 = __Pyx_GetItemInt(__pyx_v_i, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 295, __pyx_L1_error)
+          __pyx_t_3 = __Pyx_GetItemInt(__pyx_v_i, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 298, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
           __Pyx_XDECREF_SET(__pyx_v_value, __pyx_t_3);
           __pyx_t_3 = 0;
         }
         __pyx_L15:;
 
-        /* "multidict/_multidict.pyx":296
- *                         key = self._upper(i[0])
+        /* "multidict/_multidict.pyx":299
+ *                         key = self._title(i[0])
  *                         value = i[1]
  *                     if do_add:             # <<<<<<<<<<<<<<
  *                         self._add(key, value)
@@ -6263,19 +6265,19 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         __pyx_t_2 = (__pyx_v_do_add != 0);
         if (__pyx_t_2) {
 
-          /* "multidict/_multidict.pyx":297
+          /* "multidict/_multidict.pyx":300
  *                         value = i[1]
  *                     if do_add:
  *                         self._add(key, value)             # <<<<<<<<<<<<<<
  *                     else:
  *                         self._replace(key, value)
  */
-          __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 297, __pyx_L1_error)
+          __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 300, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-          /* "multidict/_multidict.pyx":296
- *                         key = self._upper(i[0])
+          /* "multidict/_multidict.pyx":299
+ *                         key = self._title(i[0])
  *                         value = i[1]
  *                     if do_add:             # <<<<<<<<<<<<<<
  *                         self._add(key, value)
@@ -6284,7 +6286,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
           goto __pyx_L17;
         }
 
-        /* "multidict/_multidict.pyx":299
+        /* "multidict/_multidict.pyx":302
  *                         self._add(key, value)
  *                     else:
  *                         self._replace(key, value)             # <<<<<<<<<<<<<<
@@ -6292,13 +6294,13 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  * 
  */
         /*else*/ {
-          __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 299, __pyx_L1_error)
+          __pyx_t_3 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 302, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         }
         __pyx_L17:;
 
-        /* "multidict/_multidict.pyx":284
+        /* "multidict/_multidict.pyx":287
  *                         self._replace(key, value)
  *             else:
  *                 for i in arg:             # <<<<<<<<<<<<<<
@@ -6310,7 +6312,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
     }
     __pyx_L5:;
 
-    /* "multidict/_multidict.pyx":259
+    /* "multidict/_multidict.pyx":262
  *                             " ({} given)".format(name, len(args)))
  * 
  *         if args:             # <<<<<<<<<<<<<<
@@ -6319,26 +6321,26 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  */
   }
 
-  /* "multidict/_multidict.pyx":302
+  /* "multidict/_multidict.pyx":305
  * 
  * 
  *         for key, value in kwargs.items():             # <<<<<<<<<<<<<<
- *             key = self._upper(key)
+ *             key = self._title(key)
  *             if do_add:
  */
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%s'", "items");
-    __PYX_ERR(0, 302, __pyx_L1_error)
+    __PYX_ERR(0, 305, __pyx_L1_error)
   }
-  __pyx_t_7 = __Pyx_PyDict_Items(__pyx_v_kwargs); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 302, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyDict_Items(__pyx_v_kwargs); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 305, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   if (likely(PyList_CheckExact(__pyx_t_7)) || PyTuple_CheckExact(__pyx_t_7)) {
     __pyx_t_3 = __pyx_t_7; __Pyx_INCREF(__pyx_t_3); __pyx_t_1 = 0;
     __pyx_t_9 = NULL;
   } else {
-    __pyx_t_1 = -1; __pyx_t_3 = PyObject_GetIter(__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 302, __pyx_L1_error)
+    __pyx_t_1 = -1; __pyx_t_3 = PyObject_GetIter(__pyx_t_7); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 305, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_9 = Py_TYPE(__pyx_t_3)->tp_iternext; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 302, __pyx_L1_error)
+    __pyx_t_9 = Py_TYPE(__pyx_t_3)->tp_iternext; if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 305, __pyx_L1_error)
   }
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   for (;;) {
@@ -6346,17 +6348,17 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
       if (likely(PyList_CheckExact(__pyx_t_3))) {
         if (__pyx_t_1 >= PyList_GET_SIZE(__pyx_t_3)) break;
         #if CYTHON_COMPILING_IN_CPYTHON
-        __pyx_t_7 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_1); __Pyx_INCREF(__pyx_t_7); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 302, __pyx_L1_error)
+        __pyx_t_7 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_1); __Pyx_INCREF(__pyx_t_7); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 305, __pyx_L1_error)
         #else
-        __pyx_t_7 = PySequence_ITEM(__pyx_t_3, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 302, __pyx_L1_error)
+        __pyx_t_7 = PySequence_ITEM(__pyx_t_3, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 305, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
         #endif
       } else {
         if (__pyx_t_1 >= PyTuple_GET_SIZE(__pyx_t_3)) break;
         #if CYTHON_COMPILING_IN_CPYTHON
-        __pyx_t_7 = PyTuple_GET_ITEM(__pyx_t_3, __pyx_t_1); __Pyx_INCREF(__pyx_t_7); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 302, __pyx_L1_error)
+        __pyx_t_7 = PyTuple_GET_ITEM(__pyx_t_3, __pyx_t_1); __Pyx_INCREF(__pyx_t_7); __pyx_t_1++; if (unlikely(0 < 0)) __PYX_ERR(0, 305, __pyx_L1_error)
         #else
-        __pyx_t_7 = PySequence_ITEM(__pyx_t_3, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 302, __pyx_L1_error)
+        __pyx_t_7 = PySequence_ITEM(__pyx_t_3, __pyx_t_1); __pyx_t_1++; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 305, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
         #endif
       }
@@ -6366,7 +6368,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
         PyObject* exc_type = PyErr_Occurred();
         if (exc_type) {
           if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-          else __PYX_ERR(0, 302, __pyx_L1_error)
+          else __PYX_ERR(0, 305, __pyx_L1_error)
         }
         break;
       }
@@ -6382,7 +6384,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
       if (unlikely(size != 2)) {
         if (size > 2) __Pyx_RaiseTooManyValuesError(2);
         else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-        __PYX_ERR(0, 302, __pyx_L1_error)
+        __PYX_ERR(0, 305, __pyx_L1_error)
       }
       #if CYTHON_COMPILING_IN_CPYTHON
       if (likely(PyTuple_CheckExact(sequence))) {
@@ -6395,15 +6397,15 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
       __Pyx_INCREF(__pyx_t_4);
       __Pyx_INCREF(__pyx_t_6);
       #else
-      __pyx_t_4 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 302, __pyx_L1_error)
+      __pyx_t_4 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 305, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
-      __pyx_t_6 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 302, __pyx_L1_error)
+      __pyx_t_6 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 305, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       #endif
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     } else {
       Py_ssize_t index = -1;
-      __pyx_t_5 = PyObject_GetIter(__pyx_t_7); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 302, __pyx_L1_error)
+      __pyx_t_5 = PyObject_GetIter(__pyx_t_7); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 305, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
       __pyx_t_11 = Py_TYPE(__pyx_t_5)->tp_iternext;
@@ -6411,7 +6413,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
       __Pyx_GOTREF(__pyx_t_4);
       index = 1; __pyx_t_6 = __pyx_t_11(__pyx_t_5); if (unlikely(!__pyx_t_6)) goto __pyx_L20_unpacking_failed;
       __Pyx_GOTREF(__pyx_t_6);
-      if (__Pyx_IternextUnpackEndCheck(__pyx_t_11(__pyx_t_5), 2) < 0) __PYX_ERR(0, 302, __pyx_L1_error)
+      if (__Pyx_IternextUnpackEndCheck(__pyx_t_11(__pyx_t_5), 2) < 0) __PYX_ERR(0, 305, __pyx_L1_error)
       __pyx_t_11 = NULL;
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       goto __pyx_L21_unpacking_done;
@@ -6419,30 +6421,30 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __pyx_t_11 = NULL;
       if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-      __PYX_ERR(0, 302, __pyx_L1_error)
+      __PYX_ERR(0, 305, __pyx_L1_error)
       __pyx_L21_unpacking_done:;
     }
-    if (!(likely(PyString_CheckExact(__pyx_t_4))||((__pyx_t_4) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_t_4)->tp_name), 0))) __PYX_ERR(0, 302, __pyx_L1_error)
+    if (!(likely(PyString_CheckExact(__pyx_t_4))||((__pyx_t_4) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_t_4)->tp_name), 0))) __PYX_ERR(0, 305, __pyx_L1_error)
     __Pyx_XDECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_4));
     __pyx_t_4 = 0;
     __Pyx_XDECREF_SET(__pyx_v_value, __pyx_t_6);
     __pyx_t_6 = 0;
 
-    /* "multidict/_multidict.pyx":303
+    /* "multidict/_multidict.pyx":306
  * 
  *         for key, value in kwargs.items():
- *             key = self._upper(key)             # <<<<<<<<<<<<<<
+ *             key = self._title(key)             # <<<<<<<<<<<<<<
  *             if do_add:
  *                 self._add(key, value)
  */
-    __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._upper(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 303, __pyx_L1_error)
+    __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._title(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 306, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     __Pyx_DECREF_SET(__pyx_v_key, ((PyObject*)__pyx_t_7));
     __pyx_t_7 = 0;
 
-    /* "multidict/_multidict.pyx":304
+    /* "multidict/_multidict.pyx":307
  *         for key, value in kwargs.items():
- *             key = self._upper(key)
+ *             key = self._title(key)
  *             if do_add:             # <<<<<<<<<<<<<<
  *                 self._add(key, value)
  *             else:
@@ -6450,20 +6452,20 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
     __pyx_t_2 = (__pyx_v_do_add != 0);
     if (__pyx_t_2) {
 
-      /* "multidict/_multidict.pyx":305
- *             key = self._upper(key)
+      /* "multidict/_multidict.pyx":308
+ *             key = self._title(key)
  *             if do_add:
  *                 self._add(key, value)             # <<<<<<<<<<<<<<
  *             else:
  *                 self._replace(key, value)
  */
-      __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 305, __pyx_L1_error)
+      __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 308, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-      /* "multidict/_multidict.pyx":304
+      /* "multidict/_multidict.pyx":307
  *         for key, value in kwargs.items():
- *             key = self._upper(key)
+ *             key = self._title(key)
  *             if do_add:             # <<<<<<<<<<<<<<
  *                 self._add(key, value)
  *             else:
@@ -6471,7 +6473,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
       goto __pyx_L22;
     }
 
-    /* "multidict/_multidict.pyx":307
+    /* "multidict/_multidict.pyx":310
  *                 self._add(key, value)
  *             else:
  *                 self._replace(key, value)             # <<<<<<<<<<<<<<
@@ -6479,23 +6481,23 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
  *     cdef _add(self, str key, value):
  */
     /*else*/ {
-      __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 307, __pyx_L1_error)
+      __pyx_t_7 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, __pyx_v_key, __pyx_v_value); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 310, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
     __pyx_L22:;
 
-    /* "multidict/_multidict.pyx":302
+    /* "multidict/_multidict.pyx":305
  * 
  * 
  *         for key, value in kwargs.items():             # <<<<<<<<<<<<<<
- *             key = self._upper(key)
+ *             key = self._title(key)
  *             if do_add:
  */
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-  /* "multidict/_multidict.pyx":251
+  /* "multidict/_multidict.pyx":254
  *         self._extend(args, kwargs, self.__class__.__name__, 1)
  * 
  *     cdef _extend(self, tuple args, dict kwargs, name, int do_add):             # <<<<<<<<<<<<<<
@@ -6525,7 +6527,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__extend(struct __pyx
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":309
+/* "multidict/_multidict.pyx":312
  *                 self._replace(key, value)
  * 
  *     cdef _add(self, str key, value):             # <<<<<<<<<<<<<<
@@ -6541,7 +6543,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__add(struct __pyx_ob
   int __pyx_t_3;
   __Pyx_RefNannySetupContext("_add", 0);
 
-  /* "multidict/_multidict.pyx":310
+  /* "multidict/_multidict.pyx":313
  * 
  *     cdef _add(self, str key, value):
  *         self._items.append(_Pair.__new__(_Pair, key, value))             # <<<<<<<<<<<<<<
@@ -6550,9 +6552,9 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__add(struct __pyx_ob
  */
   if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
     PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%s'", "append");
-    __PYX_ERR(0, 310, __pyx_L1_error)
+    __PYX_ERR(0, 313, __pyx_L1_error)
   }
-  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 310, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 313, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_key);
   __Pyx_GIVEREF(__pyx_v_key);
@@ -6560,13 +6562,13 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__add(struct __pyx_ob
   __Pyx_INCREF(__pyx_v_value);
   __Pyx_GIVEREF(__pyx_v_value);
   PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_v_value);
-  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__Pair(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__Pair), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 310, __pyx_L1_error)
+  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__Pair(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__Pair), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 313, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_3 = __Pyx_PyList_Append(__pyx_v_self->__pyx_base._items, __pyx_t_2); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 310, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyList_Append(__pyx_v_self->__pyx_base._items, __pyx_t_2); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 313, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":309
+  /* "multidict/_multidict.pyx":312
  *                 self._replace(key, value)
  * 
  *     cdef _add(self, str key, value):             # <<<<<<<<<<<<<<
@@ -6588,7 +6590,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__add(struct __pyx_ob
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":312
+/* "multidict/_multidict.pyx":315
  *         self._items.append(_Pair.__new__(_Pair, key, value))
  * 
  *     cdef _replace(self, str key, value):             # <<<<<<<<<<<<<<
@@ -6604,18 +6606,18 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__replace(struct __py
   int __pyx_t_3;
   __Pyx_RefNannySetupContext("_replace", 0);
 
-  /* "multidict/_multidict.pyx":313
+  /* "multidict/_multidict.pyx":316
  * 
  *     cdef _replace(self, str key, value):
  *         self._remove(key, 0)             # <<<<<<<<<<<<<<
  *         self._items.append(_Pair.__new__(_Pair, key, value))
  * 
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_remove(__pyx_v_self, __pyx_v_key, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 313, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_remove(__pyx_v_self, __pyx_v_key, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 316, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":314
+  /* "multidict/_multidict.pyx":317
  *     cdef _replace(self, str key, value):
  *         self._remove(key, 0)
  *         self._items.append(_Pair.__new__(_Pair, key, value))             # <<<<<<<<<<<<<<
@@ -6624,9 +6626,9 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__replace(struct __py
  */
   if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
     PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%s'", "append");
-    __PYX_ERR(0, 314, __pyx_L1_error)
+    __PYX_ERR(0, 317, __pyx_L1_error)
   }
-  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 314, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 317, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_key);
   __Pyx_GIVEREF(__pyx_v_key);
@@ -6634,13 +6636,13 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__replace(struct __py
   __Pyx_INCREF(__pyx_v_value);
   __Pyx_GIVEREF(__pyx_v_value);
   PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_v_value);
-  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__Pair(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__Pair), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 314, __pyx_L1_error)
+  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__Pair(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__Pair), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 317, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_3 = __Pyx_PyList_Append(__pyx_v_self->__pyx_base._items, __pyx_t_2); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 314, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyList_Append(__pyx_v_self->__pyx_base._items, __pyx_t_2); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 317, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":312
+  /* "multidict/_multidict.pyx":315
  *         self._items.append(_Pair.__new__(_Pair, key, value))
  * 
  *     cdef _replace(self, str key, value):             # <<<<<<<<<<<<<<
@@ -6662,12 +6664,12 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__replace(struct __py
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":316
+/* "multidict/_multidict.pyx":319
  *         self._items.append(_Pair.__new__(_Pair, key, value))
  * 
  *     def add(self, key, value):             # <<<<<<<<<<<<<<
  *         """Add the key and value, not overwriting any previous value."""
- *         self._add(self._upper(key), value)
+ *         self._add(self._title(key), value)
  */
 
 /* Python wrapper */
@@ -6699,11 +6701,11 @@ static PyObject *__pyx_pw_9multidict_10_multidict_9MultiDict_3add(PyObject *__py
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_value)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("add", 1, 2, 2, 1); __PYX_ERR(0, 316, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("add", 1, 2, 2, 1); __PYX_ERR(0, 319, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "add") < 0)) __PYX_ERR(0, 316, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "add") < 0)) __PYX_ERR(0, 319, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 2) {
       goto __pyx_L5_argtuple_error;
@@ -6716,7 +6718,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_9MultiDict_3add(PyObject *__py
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("add", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 316, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("add", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 319, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict.MultiDict.add", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -6736,26 +6738,26 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_2add(struct __pyx_o
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("add", 0);
 
-  /* "multidict/_multidict.pyx":318
+  /* "multidict/_multidict.pyx":321
  *     def add(self, key, value):
  *         """Add the key and value, not overwriting any previous value."""
- *         self._add(self._upper(key), value)             # <<<<<<<<<<<<<<
+ *         self._add(self._title(key), value)             # <<<<<<<<<<<<<<
  * 
  *     def copy(self):
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._upper(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 318, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._title(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 321, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_value); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 318, __pyx_L1_error)
+  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_value); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 321, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":316
+  /* "multidict/_multidict.pyx":319
  *         self._items.append(_Pair.__new__(_Pair, key, value))
  * 
  *     def add(self, key, value):             # <<<<<<<<<<<<<<
  *         """Add the key and value, not overwriting any previous value."""
- *         self._add(self._upper(key), value)
+ *         self._add(self._title(key), value)
  */
 
   /* function exit code */
@@ -6772,8 +6774,8 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_2add(struct __pyx_o
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":320
- *         self._add(self._upper(key), value)
+/* "multidict/_multidict.pyx":323
+ *         self._add(self._title(key), value)
  * 
  *     def copy(self):             # <<<<<<<<<<<<<<
  *         """Return a copy of itself."""
@@ -6804,19 +6806,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_4copy(struct __pyx_
   PyObject *__pyx_t_4 = NULL;
   __Pyx_RefNannySetupContext("copy", 0);
 
-  /* "multidict/_multidict.pyx":322
+  /* "multidict/_multidict.pyx":325
  *     def copy(self):
  *         """Return a copy of itself."""
  *         cls = self.__class__             # <<<<<<<<<<<<<<
  *         return cls(self._items)
  * 
  */
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 322, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 325, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_cls = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":323
+  /* "multidict/_multidict.pyx":326
  *         """Return a copy of itself."""
  *         cls = self.__class__
  *         return cls(self._items)             # <<<<<<<<<<<<<<
@@ -6836,16 +6838,16 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_4copy(struct __pyx_
     }
   }
   if (!__pyx_t_3) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_v_self->__pyx_base._items); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 323, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_v_self->__pyx_base._items); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 326, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 323, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 326, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3); __pyx_t_3 = NULL;
     __Pyx_INCREF(__pyx_v_self->__pyx_base._items);
     __Pyx_GIVEREF(__pyx_v_self->__pyx_base._items);
     PyTuple_SET_ITEM(__pyx_t_4, 0+1, __pyx_v_self->__pyx_base._items);
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 323, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 326, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
@@ -6854,8 +6856,8 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_4copy(struct __pyx_
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":320
- *         self._add(self._upper(key), value)
+  /* "multidict/_multidict.pyx":323
+ *         self._add(self._title(key), value)
  * 
  *     def copy(self):             # <<<<<<<<<<<<<<
  *         """Return a copy of itself."""
@@ -6877,7 +6879,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_4copy(struct __pyx_
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":325
+/* "multidict/_multidict.pyx":328
  *         return cls(self._items)
  * 
  *     def extend(self, *args, **kwargs):             # <<<<<<<<<<<<<<
@@ -6914,18 +6916,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_6extend(struct __py
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("extend", 0);
 
-  /* "multidict/_multidict.pyx":330
+  /* "multidict/_multidict.pyx":333
  *         This method must be used instead of update.
  *         """
  *         self._extend(args, kwargs, "extend", 1)             # <<<<<<<<<<<<<<
  * 
  *     def clear(self):
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_extend(__pyx_v_self, __pyx_v_args, __pyx_v_kwargs, __pyx_n_s_extend, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 330, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_extend(__pyx_v_self, __pyx_v_args, __pyx_v_kwargs, __pyx_n_s_extend, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 333, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":325
+  /* "multidict/_multidict.pyx":328
  *         return cls(self._items)
  * 
  *     def extend(self, *args, **kwargs):             # <<<<<<<<<<<<<<
@@ -6946,7 +6948,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_6extend(struct __py
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":332
+/* "multidict/_multidict.pyx":335
  *         self._extend(args, kwargs, "extend", 1)
  * 
  *     def clear(self):             # <<<<<<<<<<<<<<
@@ -6976,14 +6978,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_8clear(struct __pyx
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("clear", 0);
 
-  /* "multidict/_multidict.pyx":334
+  /* "multidict/_multidict.pyx":337
  *     def clear(self):
  *         """Remove all items from MultiDict"""
  *         self._items.clear()             # <<<<<<<<<<<<<<
  * 
  *     # MutableMapping interface #
  */
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->__pyx_base._items, __pyx_n_s_clear); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 334, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->__pyx_base._items, __pyx_n_s_clear); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 337, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_3 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_2))) {
@@ -6996,16 +6998,16 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_8clear(struct __pyx
     }
   }
   if (__pyx_t_3) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 334, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 337, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   } else {
-    __pyx_t_1 = __Pyx_PyObject_CallNoArg(__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 334, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_CallNoArg(__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 337, __pyx_L1_error)
   }
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":332
+  /* "multidict/_multidict.pyx":335
  *         self._extend(args, kwargs, "extend", 1)
  * 
  *     def clear(self):             # <<<<<<<<<<<<<<
@@ -7028,11 +7030,11 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_8clear(struct __pyx
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":338
+/* "multidict/_multidict.pyx":341
  *     # MutableMapping interface #
  * 
  *     def __setitem__(self, key, value):             # <<<<<<<<<<<<<<
- *         self._replace(self._upper(key), value)
+ *         self._replace(self._title(key), value)
  * 
  */
 
@@ -7056,25 +7058,25 @@ static int __pyx_pf_9multidict_10_multidict_9MultiDict_10__setitem__(struct __py
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__setitem__", 0);
 
-  /* "multidict/_multidict.pyx":339
+  /* "multidict/_multidict.pyx":342
  * 
  *     def __setitem__(self, key, value):
- *         self._replace(self._upper(key), value)             # <<<<<<<<<<<<<<
+ *         self._replace(self._title(key), value)             # <<<<<<<<<<<<<<
  * 
  *     def __delitem__(self, key):
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._upper(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 339, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._title(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 342, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_value); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 339, __pyx_L1_error)
+  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_replace(__pyx_v_self, ((PyObject*)__pyx_t_1), __pyx_v_value); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 342, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":338
+  /* "multidict/_multidict.pyx":341
  *     # MutableMapping interface #
  * 
  *     def __setitem__(self, key, value):             # <<<<<<<<<<<<<<
- *         self._replace(self._upper(key), value)
+ *         self._replace(self._title(key), value)
  * 
  */
 
@@ -7091,11 +7093,11 @@ static int __pyx_pf_9multidict_10_multidict_9MultiDict_10__setitem__(struct __py
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":341
- *         self._replace(self._upper(key), value)
+/* "multidict/_multidict.pyx":344
+ *         self._replace(self._title(key), value)
  * 
  *     def __delitem__(self, key):             # <<<<<<<<<<<<<<
- *         self._remove(self._upper(key), True)
+ *         self._remove(self._title(key), True)
  * 
  */
 
@@ -7119,25 +7121,25 @@ static int __pyx_pf_9multidict_10_multidict_9MultiDict_12__delitem__(struct __py
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__delitem__", 0);
 
-  /* "multidict/_multidict.pyx":342
+  /* "multidict/_multidict.pyx":345
  * 
  *     def __delitem__(self, key):
- *         self._remove(self._upper(key), True)             # <<<<<<<<<<<<<<
+ *         self._remove(self._title(key), True)             # <<<<<<<<<<<<<<
  * 
  *     cdef _remove(self, str key, int raise_key_error):
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._upper(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 342, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._title(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 345, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_remove(__pyx_v_self, ((PyObject*)__pyx_t_1), 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 342, __pyx_L1_error)
+  __pyx_t_2 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_remove(__pyx_v_self, ((PyObject*)__pyx_t_1), 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 345, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":341
- *         self._replace(self._upper(key), value)
+  /* "multidict/_multidict.pyx":344
+ *         self._replace(self._title(key), value)
  * 
  *     def __delitem__(self, key):             # <<<<<<<<<<<<<<
- *         self._remove(self._upper(key), True)
+ *         self._remove(self._title(key), True)
  * 
  */
 
@@ -7154,8 +7156,8 @@ static int __pyx_pf_9multidict_10_multidict_9MultiDict_12__delitem__(struct __py
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":344
- *         self._remove(self._upper(key), True)
+/* "multidict/_multidict.pyx":347
+ *         self._remove(self._title(key), True)
  * 
  *     cdef _remove(self, str key, int raise_key_error):             # <<<<<<<<<<<<<<
  *         cdef _Pair item
@@ -7176,7 +7178,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
   int __pyx_t_6;
   __Pyx_RefNannySetupContext("_remove", 0);
 
-  /* "multidict/_multidict.pyx":347
+  /* "multidict/_multidict.pyx":350
  *         cdef _Pair item
  *         cdef int found
  *         found = False             # <<<<<<<<<<<<<<
@@ -7185,7 +7187,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
  */
   __pyx_v_found = 0;
 
-  /* "multidict/_multidict.pyx":348
+  /* "multidict/_multidict.pyx":351
  *         cdef int found
  *         found = False
  *         for i in range(len(self._items) - 1, -1, -1):             # <<<<<<<<<<<<<<
@@ -7196,14 +7198,14 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
   __Pyx_INCREF(__pyx_t_1);
   if (unlikely(__pyx_t_1 == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 348, __pyx_L1_error)
+    __PYX_ERR(0, 351, __pyx_L1_error)
   }
-  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 348, __pyx_L1_error)
+  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 351, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   for (__pyx_t_3 = (__pyx_t_2 - 1); __pyx_t_3 > -1L; __pyx_t_3-=1) {
     __pyx_v_i = __pyx_t_3;
 
-    /* "multidict/_multidict.pyx":349
+    /* "multidict/_multidict.pyx":352
  *         found = False
  *         for i in range(len(self._items) - 1, -1, -1):
  *             item = <_Pair>self._items[i]             # <<<<<<<<<<<<<<
@@ -7212,9 +7214,9 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
  */
     if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 349, __pyx_L1_error)
+      __PYX_ERR(0, 352, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_self->__pyx_base._items, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 349, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_self->__pyx_base._items, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 352, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_t_4 = __pyx_t_1;
     __Pyx_INCREF(__pyx_t_4);
@@ -7222,17 +7224,17 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_4));
     __pyx_t_4 = 0;
 
-    /* "multidict/_multidict.pyx":350
+    /* "multidict/_multidict.pyx":353
  *         for i in range(len(self._items) - 1, -1, -1):
  *             item = <_Pair>self._items[i]
  *             if item._key == key:             # <<<<<<<<<<<<<<
  *                 del self._items[i]
  *                 found = True
  */
-    __pyx_t_5 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_key, Py_EQ)); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 350, __pyx_L1_error)
+    __pyx_t_5 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_key, Py_EQ)); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 353, __pyx_L1_error)
     if (__pyx_t_5) {
 
-      /* "multidict/_multidict.pyx":351
+      /* "multidict/_multidict.pyx":354
  *             item = <_Pair>self._items[i]
  *             if item._key == key:
  *                 del self._items[i]             # <<<<<<<<<<<<<<
@@ -7241,11 +7243,11 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
  */
       if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 351, __pyx_L1_error)
+        __PYX_ERR(0, 354, __pyx_L1_error)
       }
-      if (unlikely(__Pyx_DelItemInt(__pyx_v_self->__pyx_base._items, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 1) < 0)) __PYX_ERR(0, 351, __pyx_L1_error)
+      if (unlikely(__Pyx_DelItemInt(__pyx_v_self->__pyx_base._items, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 1) < 0)) __PYX_ERR(0, 354, __pyx_L1_error)
 
-      /* "multidict/_multidict.pyx":352
+      /* "multidict/_multidict.pyx":355
  *             if item._key == key:
  *                 del self._items[i]
  *                 found = True             # <<<<<<<<<<<<<<
@@ -7254,7 +7256,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
  */
       __pyx_v_found = 1;
 
-      /* "multidict/_multidict.pyx":350
+      /* "multidict/_multidict.pyx":353
  *         for i in range(len(self._items) - 1, -1, -1):
  *             item = <_Pair>self._items[i]
  *             if item._key == key:             # <<<<<<<<<<<<<<
@@ -7264,7 +7266,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
     }
   }
 
-  /* "multidict/_multidict.pyx":353
+  /* "multidict/_multidict.pyx":356
  *                 del self._items[i]
  *                 found = True
  *         if not found and raise_key_error:             # <<<<<<<<<<<<<<
@@ -7282,26 +7284,26 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
   __pyx_L7_bool_binop_done:;
   if (__pyx_t_5) {
 
-    /* "multidict/_multidict.pyx":354
+    /* "multidict/_multidict.pyx":357
  *                 found = True
  *         if not found and raise_key_error:
  *             raise KeyError(key)             # <<<<<<<<<<<<<<
  * 
  *     def setdefault(self, key, default=None):
  */
-    __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 354, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 357, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_INCREF(__pyx_v_key);
     __Pyx_GIVEREF(__pyx_v_key);
     PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_v_key);
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 354, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 357, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_Raise(__pyx_t_1, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __PYX_ERR(0, 354, __pyx_L1_error)
+    __PYX_ERR(0, 357, __pyx_L1_error)
 
-    /* "multidict/_multidict.pyx":353
+    /* "multidict/_multidict.pyx":356
  *                 del self._items[i]
  *                 found = True
  *         if not found and raise_key_error:             # <<<<<<<<<<<<<<
@@ -7310,8 +7312,8 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
  */
   }
 
-  /* "multidict/_multidict.pyx":344
- *         self._remove(self._upper(key), True)
+  /* "multidict/_multidict.pyx":347
+ *         self._remove(self._title(key), True)
  * 
  *     cdef _remove(self, str key, int raise_key_error):             # <<<<<<<<<<<<<<
  *         cdef _Pair item
@@ -7333,7 +7335,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_9MultiDict__remove(struct __pyx
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":356
+/* "multidict/_multidict.pyx":359
  *             raise KeyError(key)
  * 
  *     def setdefault(self, key, default=None):             # <<<<<<<<<<<<<<
@@ -7375,7 +7377,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_9MultiDict_15setdefault(PyObje
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "setdefault") < 0)) __PYX_ERR(0, 356, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "setdefault") < 0)) __PYX_ERR(0, 359, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -7390,7 +7392,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_9MultiDict_15setdefault(PyObje
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("setdefault", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 356, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("setdefault", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 359, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict.MultiDict.setdefault", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -7415,43 +7417,43 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_14setdefault(struct
   int __pyx_t_4;
   __Pyx_RefNannySetupContext("setdefault", 0);
 
-  /* "multidict/_multidict.pyx":360
+  /* "multidict/_multidict.pyx":363
  *         cdef str skey
  *         cdef _Pair item
- *         skey = self._upper(key)             # <<<<<<<<<<<<<<
+ *         skey = self._title(key)             # <<<<<<<<<<<<<<
  *         for i in self._items:
  *             item = <_Pair>i
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._upper(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 360, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._title(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 363, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_skey = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":361
+  /* "multidict/_multidict.pyx":364
  *         cdef _Pair item
- *         skey = self._upper(key)
+ *         skey = self._title(key)
  *         for i in self._items:             # <<<<<<<<<<<<<<
  *             item = <_Pair>i
  *             if item._key == skey:
  */
   if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 361, __pyx_L1_error)
+    __PYX_ERR(0, 364, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->__pyx_base._items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 361, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 364, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 361, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 364, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":362
- *         skey = self._upper(key)
+    /* "multidict/_multidict.pyx":365
+ *         skey = self._title(key)
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
  *             if item._key == skey:
@@ -7462,17 +7464,17 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_14setdefault(struct
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":363
+    /* "multidict/_multidict.pyx":366
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == skey:             # <<<<<<<<<<<<<<
  *                 return item._value
  *         self._add(skey, default)
  */
-    __pyx_t_4 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_skey, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 363, __pyx_L1_error)
+    __pyx_t_4 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_skey, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 366, __pyx_L1_error)
     if (__pyx_t_4) {
 
-      /* "multidict/_multidict.pyx":364
+      /* "multidict/_multidict.pyx":367
  *             item = <_Pair>i
  *             if item._key == skey:
  *                 return item._value             # <<<<<<<<<<<<<<
@@ -7485,7 +7487,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_14setdefault(struct
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":363
+      /* "multidict/_multidict.pyx":366
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == skey:             # <<<<<<<<<<<<<<
@@ -7494,9 +7496,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_14setdefault(struct
  */
     }
 
-    /* "multidict/_multidict.pyx":361
+    /* "multidict/_multidict.pyx":364
  *         cdef _Pair item
- *         skey = self._upper(key)
+ *         skey = self._title(key)
  *         for i in self._items:             # <<<<<<<<<<<<<<
  *             item = <_Pair>i
  *             if item._key == skey:
@@ -7504,18 +7506,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_14setdefault(struct
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":365
+  /* "multidict/_multidict.pyx":368
  *             if item._key == skey:
  *                 return item._value
  *         self._add(skey, default)             # <<<<<<<<<<<<<<
  *         return default
  * 
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_skey, __pyx_v_default); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 365, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_add(__pyx_v_self, __pyx_v_skey, __pyx_v_default); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 368, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":366
+  /* "multidict/_multidict.pyx":369
  *                 return item._value
  *         self._add(skey, default)
  *         return default             # <<<<<<<<<<<<<<
@@ -7527,7 +7529,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_14setdefault(struct
   __pyx_r = __pyx_v_default;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":356
+  /* "multidict/_multidict.pyx":359
  *             raise KeyError(key)
  * 
  *     def setdefault(self, key, default=None):             # <<<<<<<<<<<<<<
@@ -7550,7 +7552,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_14setdefault(struct
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":368
+/* "multidict/_multidict.pyx":371
  *         return default
  * 
  *     def pop(self, key, default=_marker):             # <<<<<<<<<<<<<<
@@ -7592,7 +7594,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_9MultiDict_17pop(PyObject *__p
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "pop") < 0)) __PYX_ERR(0, 368, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "pop") < 0)) __PYX_ERR(0, 371, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -7607,7 +7609,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_9MultiDict_17pop(PyObject *__p
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("pop", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 368, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("pop", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 371, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict.MultiDict.pop", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -7636,21 +7638,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
   int __pyx_t_6;
   __Pyx_RefNannySetupContext("pop", 0);
 
-  /* "multidict/_multidict.pyx":379
+  /* "multidict/_multidict.pyx":382
  *         cdef object value
  *         cdef _Pair item
- *         skey = self._upper(key)             # <<<<<<<<<<<<<<
+ *         skey = self._title(key)             # <<<<<<<<<<<<<<
  *         value = None
  *         found = False
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._upper(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 379, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->__pyx_base._title(((struct __pyx_obj_9multidict_10_multidict__Base *)__pyx_v_self), __pyx_v_key); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 382, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_skey = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":380
+  /* "multidict/_multidict.pyx":383
  *         cdef _Pair item
- *         skey = self._upper(key)
+ *         skey = self._title(key)
  *         value = None             # <<<<<<<<<<<<<<
  *         found = False
  *         for i in range(len(self._items) - 1, -1, -1):
@@ -7658,8 +7660,8 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
   __Pyx_INCREF(Py_None);
   __pyx_v_value = Py_None;
 
-  /* "multidict/_multidict.pyx":381
- *         skey = self._upper(key)
+  /* "multidict/_multidict.pyx":384
+ *         skey = self._title(key)
  *         value = None
  *         found = False             # <<<<<<<<<<<<<<
  *         for i in range(len(self._items) - 1, -1, -1):
@@ -7667,7 +7669,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
  */
   __pyx_v_found = 0;
 
-  /* "multidict/_multidict.pyx":382
+  /* "multidict/_multidict.pyx":385
  *         value = None
  *         found = False
  *         for i in range(len(self._items) - 1, -1, -1):             # <<<<<<<<<<<<<<
@@ -7678,14 +7680,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
   __Pyx_INCREF(__pyx_t_1);
   if (unlikely(__pyx_t_1 == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 382, __pyx_L1_error)
+    __PYX_ERR(0, 385, __pyx_L1_error)
   }
-  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 382, __pyx_L1_error)
+  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 385, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   for (__pyx_t_3 = (__pyx_t_2 - 1); __pyx_t_3 > -1L; __pyx_t_3-=1) {
     __pyx_v_i = __pyx_t_3;
 
-    /* "multidict/_multidict.pyx":383
+    /* "multidict/_multidict.pyx":386
  *         found = False
  *         for i in range(len(self._items) - 1, -1, -1):
  *             item = <_Pair>self._items[i]             # <<<<<<<<<<<<<<
@@ -7694,9 +7696,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
  */
     if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 383, __pyx_L1_error)
+      __PYX_ERR(0, 386, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_self->__pyx_base._items, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 383, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_self->__pyx_base._items, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 386, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_t_4 = __pyx_t_1;
     __Pyx_INCREF(__pyx_t_4);
@@ -7704,17 +7706,17 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_4));
     __pyx_t_4 = 0;
 
-    /* "multidict/_multidict.pyx":384
+    /* "multidict/_multidict.pyx":387
  *         for i in range(len(self._items) - 1, -1, -1):
  *             item = <_Pair>self._items[i]
  *             if item._key == skey:             # <<<<<<<<<<<<<<
  *                 value = item._value
  *                 del self._items[i]
  */
-    __pyx_t_5 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_skey, Py_EQ)); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 384, __pyx_L1_error)
+    __pyx_t_5 = (__Pyx_PyString_Equals(__pyx_v_item->_key, __pyx_v_skey, Py_EQ)); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 387, __pyx_L1_error)
     if (__pyx_t_5) {
 
-      /* "multidict/_multidict.pyx":385
+      /* "multidict/_multidict.pyx":388
  *             item = <_Pair>self._items[i]
  *             if item._key == skey:
  *                 value = item._value             # <<<<<<<<<<<<<<
@@ -7726,7 +7728,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
       __Pyx_DECREF_SET(__pyx_v_value, __pyx_t_4);
       __pyx_t_4 = 0;
 
-      /* "multidict/_multidict.pyx":386
+      /* "multidict/_multidict.pyx":389
  *             if item._key == skey:
  *                 value = item._value
  *                 del self._items[i]             # <<<<<<<<<<<<<<
@@ -7735,11 +7737,11 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
  */
       if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 386, __pyx_L1_error)
+        __PYX_ERR(0, 389, __pyx_L1_error)
       }
-      if (unlikely(__Pyx_DelItemInt(__pyx_v_self->__pyx_base._items, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 1) < 0)) __PYX_ERR(0, 386, __pyx_L1_error)
+      if (unlikely(__Pyx_DelItemInt(__pyx_v_self->__pyx_base._items, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 1) < 0)) __PYX_ERR(0, 389, __pyx_L1_error)
 
-      /* "multidict/_multidict.pyx":387
+      /* "multidict/_multidict.pyx":390
  *                 value = item._value
  *                 del self._items[i]
  *                 found = True             # <<<<<<<<<<<<<<
@@ -7748,7 +7750,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
  */
       __pyx_v_found = 1;
 
-      /* "multidict/_multidict.pyx":384
+      /* "multidict/_multidict.pyx":387
  *         for i in range(len(self._items) - 1, -1, -1):
  *             item = <_Pair>self._items[i]
  *             if item._key == skey:             # <<<<<<<<<<<<<<
@@ -7758,7 +7760,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
     }
   }
 
-  /* "multidict/_multidict.pyx":388
+  /* "multidict/_multidict.pyx":391
  *                 del self._items[i]
  *                 found = True
  *         if not found:             # <<<<<<<<<<<<<<
@@ -7768,7 +7770,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
   __pyx_t_5 = ((!(__pyx_v_found != 0)) != 0);
   if (__pyx_t_5) {
 
-    /* "multidict/_multidict.pyx":389
+    /* "multidict/_multidict.pyx":392
  *                 found = True
  *         if not found:
  *             if default is self.marker:             # <<<<<<<<<<<<<<
@@ -7779,26 +7781,26 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
     __pyx_t_6 = (__pyx_t_5 != 0);
     if (__pyx_t_6) {
 
-      /* "multidict/_multidict.pyx":390
+      /* "multidict/_multidict.pyx":393
  *         if not found:
  *             if default is self.marker:
  *                 raise KeyError(key)             # <<<<<<<<<<<<<<
  *             else:
  *                 return default
  */
-      __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 390, __pyx_L1_error)
+      __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 393, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_INCREF(__pyx_v_key);
       __Pyx_GIVEREF(__pyx_v_key);
       PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_v_key);
-      __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 390, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 393, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
       __Pyx_Raise(__pyx_t_1, 0, 0, 0);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-      __PYX_ERR(0, 390, __pyx_L1_error)
+      __PYX_ERR(0, 393, __pyx_L1_error)
 
-      /* "multidict/_multidict.pyx":389
+      /* "multidict/_multidict.pyx":392
  *                 found = True
  *         if not found:
  *             if default is self.marker:             # <<<<<<<<<<<<<<
@@ -7807,7 +7809,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
  */
     }
 
-    /* "multidict/_multidict.pyx":392
+    /* "multidict/_multidict.pyx":395
  *                 raise KeyError(key)
  *             else:
  *                 return default             # <<<<<<<<<<<<<<
@@ -7821,7 +7823,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
       goto __pyx_L0;
     }
 
-    /* "multidict/_multidict.pyx":388
+    /* "multidict/_multidict.pyx":391
  *                 del self._items[i]
  *                 found = True
  *         if not found:             # <<<<<<<<<<<<<<
@@ -7830,7 +7832,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
  */
   }
 
-  /* "multidict/_multidict.pyx":394
+  /* "multidict/_multidict.pyx":397
  *                 return default
  *         else:
  *             return value             # <<<<<<<<<<<<<<
@@ -7844,7 +7846,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
     goto __pyx_L0;
   }
 
-  /* "multidict/_multidict.pyx":368
+  /* "multidict/_multidict.pyx":371
  *         return default
  * 
  *     def pop(self, key, default=_marker):             # <<<<<<<<<<<<<<
@@ -7867,7 +7869,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_16pop(struct __pyx_
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":396
+/* "multidict/_multidict.pyx":399
  *             return value
  * 
  *     def popitem(self):             # <<<<<<<<<<<<<<
@@ -7898,7 +7900,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_18popitem(struct __
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("popitem", 0);
 
-  /* "multidict/_multidict.pyx":399
+  /* "multidict/_multidict.pyx":402
  *         """Remove and return an arbitrary (key, value) pair."""
  *         cdef _Pair item
  *         if self._items:             # <<<<<<<<<<<<<<
@@ -7908,7 +7910,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_18popitem(struct __
   __pyx_t_1 = (__pyx_v_self->__pyx_base._items != Py_None) && (PyList_GET_SIZE(__pyx_v_self->__pyx_base._items) != 0);
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":400
+    /* "multidict/_multidict.pyx":403
  *         cdef _Pair item
  *         if self._items:
  *             item = <_Pair>self._items.pop(0)             # <<<<<<<<<<<<<<
@@ -7917,9 +7919,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_18popitem(struct __
  */
     if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
       PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%s'", "pop");
-      __PYX_ERR(0, 400, __pyx_L1_error)
+      __PYX_ERR(0, 403, __pyx_L1_error)
     }
-    __pyx_t_2 = __Pyx_PyList_PopIndex(__pyx_v_self->__pyx_base._items, __pyx_int_0, 0, 1, Py_ssize_t, PyInt_FromSsize_t); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 400, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyList_PopIndex(__pyx_v_self->__pyx_base._items, __pyx_int_0, 0, 1, Py_ssize_t, PyInt_FromSsize_t); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 403, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __pyx_t_3 = __pyx_t_2;
     __Pyx_INCREF(__pyx_t_3);
@@ -7927,7 +7929,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_18popitem(struct __
     __pyx_v_item = ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":401
+    /* "multidict/_multidict.pyx":404
  *         if self._items:
  *             item = <_Pair>self._items.pop(0)
  *             return (item._key, item._value)             # <<<<<<<<<<<<<<
@@ -7935,7 +7937,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_18popitem(struct __
  *             raise KeyError("empty multidict")
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 401, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 404, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_INCREF(__pyx_v_item->_key);
     __Pyx_GIVEREF(__pyx_v_item->_key);
@@ -7947,7 +7949,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_18popitem(struct __
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":399
+    /* "multidict/_multidict.pyx":402
  *         """Remove and return an arbitrary (key, value) pair."""
  *         cdef _Pair item
  *         if self._items:             # <<<<<<<<<<<<<<
@@ -7956,7 +7958,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_18popitem(struct __
  */
   }
 
-  /* "multidict/_multidict.pyx":403
+  /* "multidict/_multidict.pyx":406
  *             return (item._key, item._value)
  *         else:
  *             raise KeyError("empty multidict")             # <<<<<<<<<<<<<<
@@ -7964,14 +7966,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_18popitem(struct __
  *     def update(self, *args, **kwargs):
  */
   /*else*/ {
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_tuple__7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 403, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_KeyError, __pyx_tuple__7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 406, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_Raise(__pyx_t_3, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __PYX_ERR(0, 403, __pyx_L1_error)
+    __PYX_ERR(0, 406, __pyx_L1_error)
   }
 
-  /* "multidict/_multidict.pyx":396
+  /* "multidict/_multidict.pyx":399
  *             return value
  * 
  *     def popitem(self):             # <<<<<<<<<<<<<<
@@ -7992,7 +7994,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_18popitem(struct __
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":405
+/* "multidict/_multidict.pyx":408
  *             raise KeyError("empty multidict")
  * 
  *     def update(self, *args, **kwargs):             # <<<<<<<<<<<<<<
@@ -8029,18 +8031,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_20update(struct __p
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("update", 0);
 
-  /* "multidict/_multidict.pyx":407
+  /* "multidict/_multidict.pyx":410
  *     def update(self, *args, **kwargs):
  *         """Update the dictionary from *other*, overwriting existing keys."""
  *         self._extend(args, kwargs, "update", 0)             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_extend(__pyx_v_self, __pyx_v_args, __pyx_v_kwargs, __pyx_n_s_update, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 407, __pyx_L1_error)
+  __pyx_t_1 = ((struct __pyx_vtabstruct_9multidict_10_multidict_MultiDict *)__pyx_v_self->__pyx_base.__pyx_vtab)->_extend(__pyx_v_self, __pyx_v_args, __pyx_v_kwargs, __pyx_n_s_update, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 410, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":405
+  /* "multidict/_multidict.pyx":408
  *             raise KeyError("empty multidict")
  * 
  *     def update(self, *args, **kwargs):             # <<<<<<<<<<<<<<
@@ -8061,15 +8063,15 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9MultiDict_20update(struct __p
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":416
+/* "multidict/_multidict.pyx":419
  *     """An ordered dictionary that can have multiple values for each key."""
  * 
- *     cdef str _upper(self, s):             # <<<<<<<<<<<<<<
+ *     cdef str _title(self, s):             # <<<<<<<<<<<<<<
  *         if type(s) is self._upstr:
  *             return <str>s
  */
 
-static PyObject *__pyx_f_9multidict_10_multidict_11CIMultiDict__upper(struct __pyx_obj_9multidict_10_multidict_CIMultiDict *__pyx_v_self, PyObject *__pyx_v_s) {
+static PyObject *__pyx_f_9multidict_10_multidict_11CIMultiDict__title(struct __pyx_obj_9multidict_10_multidict_CIMultiDict *__pyx_v_self, PyObject *__pyx_v_s) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
@@ -8077,24 +8079,24 @@ static PyObject *__pyx_f_9multidict_10_multidict_11CIMultiDict__upper(struct __p
   PyObject *__pyx_t_3 = NULL;
   PyObject *__pyx_t_4 = NULL;
   PyObject *__pyx_t_5 = NULL;
-  __Pyx_RefNannySetupContext("_upper", 0);
+  __Pyx_RefNannySetupContext("_title", 0);
 
-  /* "multidict/_multidict.pyx":417
+  /* "multidict/_multidict.pyx":420
  * 
- *     cdef str _upper(self, s):
+ *     cdef str _title(self, s):
  *         if type(s) is self._upstr:             # <<<<<<<<<<<<<<
  *             return <str>s
- *         return s.upper()
+ *         return s.title()
  */
   __pyx_t_1 = (((PyObject *)Py_TYPE(__pyx_v_s)) == __pyx_v_self->__pyx_base.__pyx_base._upstr);
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":418
- *     cdef str _upper(self, s):
+    /* "multidict/_multidict.pyx":421
+ *     cdef str _title(self, s):
  *         if type(s) is self._upstr:
  *             return <str>s             # <<<<<<<<<<<<<<
- *         return s.upper()
+ *         return s.title()
  * 
  */
     __Pyx_XDECREF(__pyx_r);
@@ -8102,24 +8104,24 @@ static PyObject *__pyx_f_9multidict_10_multidict_11CIMultiDict__upper(struct __p
     __pyx_r = ((PyObject*)__pyx_v_s);
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":417
+    /* "multidict/_multidict.pyx":420
  * 
- *     cdef str _upper(self, s):
+ *     cdef str _title(self, s):
  *         if type(s) is self._upstr:             # <<<<<<<<<<<<<<
  *             return <str>s
- *         return s.upper()
+ *         return s.title()
  */
   }
 
-  /* "multidict/_multidict.pyx":419
+  /* "multidict/_multidict.pyx":422
  *         if type(s) is self._upstr:
  *             return <str>s
- *         return s.upper()             # <<<<<<<<<<<<<<
+ *         return s.title()             # <<<<<<<<<<<<<<
  * 
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_s, __pyx_n_s_upper); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 419, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_s, __pyx_n_s_title); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 422, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_5 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_4))) {
@@ -8132,22 +8134,22 @@ static PyObject *__pyx_f_9multidict_10_multidict_11CIMultiDict__upper(struct __p
     }
   }
   if (__pyx_t_5) {
-    __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 419, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 422, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   } else {
-    __pyx_t_3 = __Pyx_PyObject_CallNoArg(__pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 419, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_CallNoArg(__pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 422, __pyx_L1_error)
   }
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  if (!(likely(PyString_CheckExact(__pyx_t_3))||((__pyx_t_3) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_t_3)->tp_name), 0))) __PYX_ERR(0, 419, __pyx_L1_error)
+  if (!(likely(PyString_CheckExact(__pyx_t_3))||((__pyx_t_3) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "str", Py_TYPE(__pyx_t_3)->tp_name), 0))) __PYX_ERR(0, 422, __pyx_L1_error)
   __pyx_r = ((PyObject*)__pyx_t_3);
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":416
+  /* "multidict/_multidict.pyx":419
  *     """An ordered dictionary that can have multiple values for each key."""
  * 
- *     cdef str _upper(self, s):             # <<<<<<<<<<<<<<
+ *     cdef str _title(self, s):             # <<<<<<<<<<<<<<
  *         if type(s) is self._upstr:
  *             return <str>s
  */
@@ -8157,7 +8159,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_11CIMultiDict__upper(struct __p
   __Pyx_XDECREF(__pyx_t_3);
   __Pyx_XDECREF(__pyx_t_4);
   __Pyx_XDECREF(__pyx_t_5);
-  __Pyx_AddTraceback("multidict._multidict.CIMultiDict._upper", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("multidict._multidict.CIMultiDict._title", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = 0;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -8165,7 +8167,7 @@ static PyObject *__pyx_f_9multidict_10_multidict_11CIMultiDict__upper(struct __p
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":430
+/* "multidict/_multidict.pyx":433
  *     cdef list _items
  * 
  *     def __cinit__(self, list items):             # <<<<<<<<<<<<<<
@@ -8198,7 +8200,7 @@ static int __pyx_pw_9multidict_10_multidict_9_ViewBase_1__cinit__(PyObject *__py
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 430, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 433, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
@@ -8209,13 +8211,13 @@ static int __pyx_pw_9multidict_10_multidict_9_ViewBase_1__cinit__(PyObject *__py
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 430, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 433, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict._ViewBase.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return -1;
   __pyx_L4_argument_unpacking_done:;
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_items), (&PyList_Type), 1, "items", 1))) __PYX_ERR(0, 430, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_items), (&PyList_Type), 1, "items", 1))) __PYX_ERR(0, 433, __pyx_L1_error)
   __pyx_r = __pyx_pf_9multidict_10_multidict_9_ViewBase___cinit__(((struct __pyx_obj_9multidict_10_multidict__ViewBase *)__pyx_v_self), __pyx_v_items);
 
   /* function exit code */
@@ -8232,7 +8234,7 @@ static int __pyx_pf_9multidict_10_multidict_9_ViewBase___cinit__(struct __pyx_ob
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "multidict/_multidict.pyx":431
+  /* "multidict/_multidict.pyx":434
  * 
  *     def __cinit__(self, list items):
  *         self._items = items             # <<<<<<<<<<<<<<
@@ -8245,7 +8247,7 @@ static int __pyx_pf_9multidict_10_multidict_9_ViewBase___cinit__(struct __pyx_ob
   __Pyx_DECREF(__pyx_v_self->_items);
   __pyx_v_self->_items = __pyx_v_items;
 
-  /* "multidict/_multidict.pyx":430
+  /* "multidict/_multidict.pyx":433
  *     cdef list _items
  * 
  *     def __cinit__(self, list items):             # <<<<<<<<<<<<<<
@@ -8259,7 +8261,7 @@ static int __pyx_pf_9multidict_10_multidict_9_ViewBase___cinit__(struct __pyx_ob
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":433
+/* "multidict/_multidict.pyx":436
  *         self._items = items
  * 
  *     def __len__(self):             # <<<<<<<<<<<<<<
@@ -8287,7 +8289,7 @@ static Py_ssize_t __pyx_pf_9multidict_10_multidict_9_ViewBase_2__len__(struct __
   Py_ssize_t __pyx_t_2;
   __Pyx_RefNannySetupContext("__len__", 0);
 
-  /* "multidict/_multidict.pyx":434
+  /* "multidict/_multidict.pyx":437
  * 
  *     def __len__(self):
  *         return len(self._items)             # <<<<<<<<<<<<<<
@@ -8298,14 +8300,14 @@ static Py_ssize_t __pyx_pf_9multidict_10_multidict_9_ViewBase_2__len__(struct __
   __Pyx_INCREF(__pyx_t_1);
   if (unlikely(__pyx_t_1 == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 434, __pyx_L1_error)
+    __PYX_ERR(0, 437, __pyx_L1_error)
   }
-  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 434, __pyx_L1_error)
+  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 437, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":433
+  /* "multidict/_multidict.pyx":436
  *         self._items = items
  * 
  *     def __len__(self):             # <<<<<<<<<<<<<<
@@ -8323,7 +8325,7 @@ static Py_ssize_t __pyx_pf_9multidict_10_multidict_9_ViewBase_2__len__(struct __
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":439
+/* "multidict/_multidict.pyx":442
  * cdef class _ViewBaseSet(_ViewBase):
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
@@ -8338,7 +8340,7 @@ static PyObject *__pyx_pw_9multidict_10_multidict_12_ViewBaseSet_1__richcmp__(Py
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__richcmp__ (wrapper)", 0);
-  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(0, 439, __pyx_L3_error)
+  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(0, 442, __pyx_L3_error)
   __Pyx_GOTREF(__pyx_v_op);
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L3_error:;
@@ -8367,34 +8369,34 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
   PyObject *(*__pyx_t_7)(PyObject *);
   __Pyx_RefNannySetupContext("__richcmp__", 0);
 
-  /* "multidict/_multidict.pyx":440
+  /* "multidict/_multidict.pyx":443
  * 
  *     def __richcmp__(self, other, op):
  *         if op == 0:  # <             # <<<<<<<<<<<<<<
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 440, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 443, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 440, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 443, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":441
+    /* "multidict/_multidict.pyx":444
  *     def __richcmp__(self, other, op):
  *         if op == 0:  # <
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
  *                 return NotImplemented
  *             return len(self) < len(other) and self <= other
  */
-    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 441, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 444, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 441, __pyx_L1_error)
+    __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 444, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_3 = ((!(__pyx_t_2 != 0)) != 0);
     if (__pyx_t_3) {
 
-      /* "multidict/_multidict.pyx":442
+      /* "multidict/_multidict.pyx":445
  *         if op == 0:  # <
  *             if not isinstance(other, Set):
  *                 return NotImplemented             # <<<<<<<<<<<<<<
@@ -8406,7 +8408,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __pyx_r = __pyx_builtin_NotImplemented;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":441
+      /* "multidict/_multidict.pyx":444
  *     def __richcmp__(self, other, op):
  *         if op == 0:  # <
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
@@ -8415,7 +8417,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
     }
 
-    /* "multidict/_multidict.pyx":443
+    /* "multidict/_multidict.pyx":446
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  *             return len(self) < len(other) and self <= other             # <<<<<<<<<<<<<<
@@ -8423,18 +8425,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  *             if not isinstance(other, Set):
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 443, __pyx_L1_error)
-    __pyx_t_5 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 443, __pyx_L1_error)
+    __pyx_t_4 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 446, __pyx_L1_error)
+    __pyx_t_5 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 446, __pyx_L1_error)
     __pyx_t_3 = (__pyx_t_4 < __pyx_t_5);
     if (__pyx_t_3) {
     } else {
-      __pyx_t_6 = __Pyx_PyBool_FromLong(__pyx_t_3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 443, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyBool_FromLong(__pyx_t_3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 446, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __pyx_t_1 = __pyx_t_6;
       __pyx_t_6 = 0;
       goto __pyx_L5_bool_binop_done;
     }
-    __pyx_t_6 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_LE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 443, __pyx_L1_error)
+    __pyx_t_6 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_LE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 446, __pyx_L1_error)
     __Pyx_INCREF(__pyx_t_6);
     __pyx_t_1 = __pyx_t_6;
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
@@ -8443,7 +8445,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":440
+    /* "multidict/_multidict.pyx":443
  * 
  *     def __richcmp__(self, other, op):
  *         if op == 0:  # <             # <<<<<<<<<<<<<<
@@ -8452,34 +8454,34 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
   }
 
-  /* "multidict/_multidict.pyx":444
+  /* "multidict/_multidict.pyx":447
  *                 return NotImplemented
  *             return len(self) < len(other) and self <= other
  *         elif op == 1:  # <=             # <<<<<<<<<<<<<<
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 444, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 447, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 444, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 447, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_3) {
 
-    /* "multidict/_multidict.pyx":445
+    /* "multidict/_multidict.pyx":448
  *             return len(self) < len(other) and self <= other
  *         elif op == 1:  # <=
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
  *                 return NotImplemented
  *             if len(self) > len(other):
  */
-    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 445, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 448, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 445, __pyx_L1_error)
+    __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 448, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_2 = ((!(__pyx_t_3 != 0)) != 0);
     if (__pyx_t_2) {
 
-      /* "multidict/_multidict.pyx":446
+      /* "multidict/_multidict.pyx":449
  *         elif op == 1:  # <=
  *             if not isinstance(other, Set):
  *                 return NotImplemented             # <<<<<<<<<<<<<<
@@ -8491,7 +8493,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __pyx_r = __pyx_builtin_NotImplemented;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":445
+      /* "multidict/_multidict.pyx":448
  *             return len(self) < len(other) and self <= other
  *         elif op == 1:  # <=
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
@@ -8500,19 +8502,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
     }
 
-    /* "multidict/_multidict.pyx":447
+    /* "multidict/_multidict.pyx":450
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  *             if len(self) > len(other):             # <<<<<<<<<<<<<<
  *                 return False
  *             for elem in self:
  */
-    __pyx_t_5 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 447, __pyx_L1_error)
-    __pyx_t_4 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 447, __pyx_L1_error)
+    __pyx_t_5 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 450, __pyx_L1_error)
+    __pyx_t_4 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 450, __pyx_L1_error)
     __pyx_t_2 = ((__pyx_t_5 > __pyx_t_4) != 0);
     if (__pyx_t_2) {
 
-      /* "multidict/_multidict.pyx":448
+      /* "multidict/_multidict.pyx":451
  *                 return NotImplemented
  *             if len(self) > len(other):
  *                 return False             # <<<<<<<<<<<<<<
@@ -8524,7 +8526,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __pyx_r = Py_False;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":447
+      /* "multidict/_multidict.pyx":450
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  *             if len(self) > len(other):             # <<<<<<<<<<<<<<
@@ -8533,7 +8535,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
     }
 
-    /* "multidict/_multidict.pyx":449
+    /* "multidict/_multidict.pyx":452
  *             if len(self) > len(other):
  *                 return False
  *             for elem in self:             # <<<<<<<<<<<<<<
@@ -8544,26 +8546,26 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __pyx_t_1 = __pyx_v_self; __Pyx_INCREF(__pyx_t_1); __pyx_t_4 = 0;
       __pyx_t_7 = NULL;
     } else {
-      __pyx_t_4 = -1; __pyx_t_1 = PyObject_GetIter(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 449, __pyx_L1_error)
+      __pyx_t_4 = -1; __pyx_t_1 = PyObject_GetIter(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 452, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_7 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 449, __pyx_L1_error)
+      __pyx_t_7 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 452, __pyx_L1_error)
     }
     for (;;) {
       if (likely(!__pyx_t_7)) {
         if (likely(PyList_CheckExact(__pyx_t_1))) {
           if (__pyx_t_4 >= PyList_GET_SIZE(__pyx_t_1)) break;
           #if CYTHON_COMPILING_IN_CPYTHON
-          __pyx_t_6 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_4); __Pyx_INCREF(__pyx_t_6); __pyx_t_4++; if (unlikely(0 < 0)) __PYX_ERR(0, 449, __pyx_L1_error)
+          __pyx_t_6 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_4); __Pyx_INCREF(__pyx_t_6); __pyx_t_4++; if (unlikely(0 < 0)) __PYX_ERR(0, 452, __pyx_L1_error)
           #else
-          __pyx_t_6 = PySequence_ITEM(__pyx_t_1, __pyx_t_4); __pyx_t_4++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 449, __pyx_L1_error)
+          __pyx_t_6 = PySequence_ITEM(__pyx_t_1, __pyx_t_4); __pyx_t_4++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 452, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           #endif
         } else {
           if (__pyx_t_4 >= PyTuple_GET_SIZE(__pyx_t_1)) break;
           #if CYTHON_COMPILING_IN_CPYTHON
-          __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_4); __Pyx_INCREF(__pyx_t_6); __pyx_t_4++; if (unlikely(0 < 0)) __PYX_ERR(0, 449, __pyx_L1_error)
+          __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_4); __Pyx_INCREF(__pyx_t_6); __pyx_t_4++; if (unlikely(0 < 0)) __PYX_ERR(0, 452, __pyx_L1_error)
           #else
-          __pyx_t_6 = PySequence_ITEM(__pyx_t_1, __pyx_t_4); __pyx_t_4++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 449, __pyx_L1_error)
+          __pyx_t_6 = PySequence_ITEM(__pyx_t_1, __pyx_t_4); __pyx_t_4++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 452, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           #endif
         }
@@ -8573,7 +8575,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
           PyObject* exc_type = PyErr_Occurred();
           if (exc_type) {
             if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-            else __PYX_ERR(0, 449, __pyx_L1_error)
+            else __PYX_ERR(0, 452, __pyx_L1_error)
           }
           break;
         }
@@ -8582,18 +8584,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __Pyx_XDECREF_SET(__pyx_v_elem, __pyx_t_6);
       __pyx_t_6 = 0;
 
-      /* "multidict/_multidict.pyx":450
+      /* "multidict/_multidict.pyx":453
  *                 return False
  *             for elem in self:
  *                 if elem not in other:             # <<<<<<<<<<<<<<
  *                     return False
  *             return True
  */
-      __pyx_t_2 = (__Pyx_PySequence_ContainsTF(__pyx_v_elem, __pyx_v_other, Py_NE)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 450, __pyx_L1_error)
+      __pyx_t_2 = (__Pyx_PySequence_ContainsTF(__pyx_v_elem, __pyx_v_other, Py_NE)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 453, __pyx_L1_error)
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
 
-        /* "multidict/_multidict.pyx":451
+        /* "multidict/_multidict.pyx":454
  *             for elem in self:
  *                 if elem not in other:
  *                     return False             # <<<<<<<<<<<<<<
@@ -8606,7 +8608,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         goto __pyx_L0;
 
-        /* "multidict/_multidict.pyx":450
+        /* "multidict/_multidict.pyx":453
  *                 return False
  *             for elem in self:
  *                 if elem not in other:             # <<<<<<<<<<<<<<
@@ -8615,7 +8617,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
       }
 
-      /* "multidict/_multidict.pyx":449
+      /* "multidict/_multidict.pyx":452
  *             if len(self) > len(other):
  *                 return False
  *             for elem in self:             # <<<<<<<<<<<<<<
@@ -8625,7 +8627,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
     }
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "multidict/_multidict.pyx":452
+    /* "multidict/_multidict.pyx":455
  *                 if elem not in other:
  *                     return False
  *             return True             # <<<<<<<<<<<<<<
@@ -8637,7 +8639,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
     __pyx_r = Py_True;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":444
+    /* "multidict/_multidict.pyx":447
  *                 return NotImplemented
  *             return len(self) < len(other) and self <= other
  *         elif op == 1:  # <=             # <<<<<<<<<<<<<<
@@ -8646,34 +8648,34 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
   }
 
-  /* "multidict/_multidict.pyx":453
+  /* "multidict/_multidict.pyx":456
  *                     return False
  *             return True
  *         elif op == 2:  # ==             # <<<<<<<<<<<<<<
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 453, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 456, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 453, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 456, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_3) {
 
-    /* "multidict/_multidict.pyx":454
+    /* "multidict/_multidict.pyx":457
  *             return True
  *         elif op == 2:  # ==
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
  *                 return NotImplemented
  *             return len(self) == len(other) and self <= other
  */
-    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 454, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 457, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 454, __pyx_L1_error)
+    __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 457, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_2 = ((!(__pyx_t_3 != 0)) != 0);
     if (__pyx_t_2) {
 
-      /* "multidict/_multidict.pyx":455
+      /* "multidict/_multidict.pyx":458
  *         elif op == 2:  # ==
  *             if not isinstance(other, Set):
  *                 return NotImplemented             # <<<<<<<<<<<<<<
@@ -8685,7 +8687,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __pyx_r = __pyx_builtin_NotImplemented;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":454
+      /* "multidict/_multidict.pyx":457
  *             return True
  *         elif op == 2:  # ==
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
@@ -8694,7 +8696,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
     }
 
-    /* "multidict/_multidict.pyx":456
+    /* "multidict/_multidict.pyx":459
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  *             return len(self) == len(other) and self <= other             # <<<<<<<<<<<<<<
@@ -8702,18 +8704,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  *             return not self == other
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 456, __pyx_L1_error)
-    __pyx_t_5 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 456, __pyx_L1_error)
+    __pyx_t_4 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 459, __pyx_L1_error)
+    __pyx_t_5 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 459, __pyx_L1_error)
     __pyx_t_2 = (__pyx_t_4 == __pyx_t_5);
     if (__pyx_t_2) {
     } else {
-      __pyx_t_6 = __Pyx_PyBool_FromLong(__pyx_t_2); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 456, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyBool_FromLong(__pyx_t_2); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 459, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __pyx_t_1 = __pyx_t_6;
       __pyx_t_6 = 0;
       goto __pyx_L13_bool_binop_done;
     }
-    __pyx_t_6 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_LE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 456, __pyx_L1_error)
+    __pyx_t_6 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_LE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 459, __pyx_L1_error)
     __Pyx_INCREF(__pyx_t_6);
     __pyx_t_1 = __pyx_t_6;
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
@@ -8722,7 +8724,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":453
+    /* "multidict/_multidict.pyx":456
  *                     return False
  *             return True
  *         elif op == 2:  # ==             # <<<<<<<<<<<<<<
@@ -8731,20 +8733,20 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
   }
 
-  /* "multidict/_multidict.pyx":457
+  /* "multidict/_multidict.pyx":460
  *                 return NotImplemented
  *             return len(self) == len(other) and self <= other
  *         elif op == 3:  # !=             # <<<<<<<<<<<<<<
  *             return not self == other
  *         elif op == 4:  #  >
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 457, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 460, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 457, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 460, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":458
+    /* "multidict/_multidict.pyx":461
  *             return len(self) == len(other) and self <= other
  *         elif op == 3:  # !=
  *             return not self == other             # <<<<<<<<<<<<<<
@@ -8752,16 +8754,16 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  *             if not isinstance(other, Set):
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_1 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_EQ); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 458, __pyx_L1_error)
-    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 458, __pyx_L1_error)
+    __pyx_t_1 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_EQ); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 461, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 461, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyBool_FromLong((!__pyx_t_2)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 458, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyBool_FromLong((!__pyx_t_2)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 461, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_r = __pyx_t_1;
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":457
+    /* "multidict/_multidict.pyx":460
  *                 return NotImplemented
  *             return len(self) == len(other) and self <= other
  *         elif op == 3:  # !=             # <<<<<<<<<<<<<<
@@ -8770,34 +8772,34 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
   }
 
-  /* "multidict/_multidict.pyx":459
+  /* "multidict/_multidict.pyx":462
  *         elif op == 3:  # !=
  *             return not self == other
  *         elif op == 4:  #  >             # <<<<<<<<<<<<<<
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_4, 4, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 459, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_4, 4, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 462, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 459, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 462, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":460
+    /* "multidict/_multidict.pyx":463
  *             return not self == other
  *         elif op == 4:  #  >
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
  *                 return NotImplemented
  *             return len(self) > len(other) and self >= other
  */
-    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 460, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 463, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 460, __pyx_L1_error)
+    __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 463, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_3 = ((!(__pyx_t_2 != 0)) != 0);
     if (__pyx_t_3) {
 
-      /* "multidict/_multidict.pyx":461
+      /* "multidict/_multidict.pyx":464
  *         elif op == 4:  #  >
  *             if not isinstance(other, Set):
  *                 return NotImplemented             # <<<<<<<<<<<<<<
@@ -8809,7 +8811,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __pyx_r = __pyx_builtin_NotImplemented;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":460
+      /* "multidict/_multidict.pyx":463
  *             return not self == other
  *         elif op == 4:  #  >
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
@@ -8818,7 +8820,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
     }
 
-    /* "multidict/_multidict.pyx":462
+    /* "multidict/_multidict.pyx":465
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  *             return len(self) > len(other) and self >= other             # <<<<<<<<<<<<<<
@@ -8826,18 +8828,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  *             if not isinstance(other, Set):
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_5 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 462, __pyx_L1_error)
-    __pyx_t_4 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 462, __pyx_L1_error)
+    __pyx_t_5 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 465, __pyx_L1_error)
+    __pyx_t_4 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 465, __pyx_L1_error)
     __pyx_t_3 = (__pyx_t_5 > __pyx_t_4);
     if (__pyx_t_3) {
     } else {
-      __pyx_t_6 = __Pyx_PyBool_FromLong(__pyx_t_3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 462, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyBool_FromLong(__pyx_t_3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 465, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __pyx_t_1 = __pyx_t_6;
       __pyx_t_6 = 0;
       goto __pyx_L16_bool_binop_done;
     }
-    __pyx_t_6 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_GE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 462, __pyx_L1_error)
+    __pyx_t_6 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_GE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 465, __pyx_L1_error)
     __Pyx_INCREF(__pyx_t_6);
     __pyx_t_1 = __pyx_t_6;
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
@@ -8846,7 +8848,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":459
+    /* "multidict/_multidict.pyx":462
  *         elif op == 3:  # !=
  *             return not self == other
  *         elif op == 4:  #  >             # <<<<<<<<<<<<<<
@@ -8855,34 +8857,34 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
   }
 
-  /* "multidict/_multidict.pyx":463
+  /* "multidict/_multidict.pyx":466
  *                 return NotImplemented
  *             return len(self) > len(other) and self >= other
  *         elif op == 5:  # >=             # <<<<<<<<<<<<<<
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  */
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_5, 5, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 463, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_5, 5, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 466, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 463, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 466, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_3) {
 
-    /* "multidict/_multidict.pyx":464
+    /* "multidict/_multidict.pyx":467
  *             return len(self) > len(other) and self >= other
  *         elif op == 5:  # >=
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
  *                 return NotImplemented
  *             if len(self) < len(other):
  */
-    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 464, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 467, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 464, __pyx_L1_error)
+    __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 467, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_2 = ((!(__pyx_t_3 != 0)) != 0);
     if (__pyx_t_2) {
 
-      /* "multidict/_multidict.pyx":465
+      /* "multidict/_multidict.pyx":468
  *         elif op == 5:  # >=
  *             if not isinstance(other, Set):
  *                 return NotImplemented             # <<<<<<<<<<<<<<
@@ -8894,7 +8896,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __pyx_r = __pyx_builtin_NotImplemented;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":464
+      /* "multidict/_multidict.pyx":467
  *             return len(self) > len(other) and self >= other
  *         elif op == 5:  # >=
  *             if not isinstance(other, Set):             # <<<<<<<<<<<<<<
@@ -8903,19 +8905,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
     }
 
-    /* "multidict/_multidict.pyx":466
+    /* "multidict/_multidict.pyx":469
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  *             if len(self) < len(other):             # <<<<<<<<<<<<<<
  *                 return False
  *             for elem in other:
  */
-    __pyx_t_4 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 466, __pyx_L1_error)
-    __pyx_t_5 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 466, __pyx_L1_error)
+    __pyx_t_4 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 469, __pyx_L1_error)
+    __pyx_t_5 = PyObject_Length(__pyx_v_other); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 469, __pyx_L1_error)
     __pyx_t_2 = ((__pyx_t_4 < __pyx_t_5) != 0);
     if (__pyx_t_2) {
 
-      /* "multidict/_multidict.pyx":467
+      /* "multidict/_multidict.pyx":470
  *                 return NotImplemented
  *             if len(self) < len(other):
  *                 return False             # <<<<<<<<<<<<<<
@@ -8927,7 +8929,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __pyx_r = Py_False;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":466
+      /* "multidict/_multidict.pyx":469
  *             if not isinstance(other, Set):
  *                 return NotImplemented
  *             if len(self) < len(other):             # <<<<<<<<<<<<<<
@@ -8936,7 +8938,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
     }
 
-    /* "multidict/_multidict.pyx":468
+    /* "multidict/_multidict.pyx":471
  *             if len(self) < len(other):
  *                 return False
  *             for elem in other:             # <<<<<<<<<<<<<<
@@ -8947,26 +8949,26 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __pyx_t_1 = __pyx_v_other; __Pyx_INCREF(__pyx_t_1); __pyx_t_5 = 0;
       __pyx_t_7 = NULL;
     } else {
-      __pyx_t_5 = -1; __pyx_t_1 = PyObject_GetIter(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 468, __pyx_L1_error)
+      __pyx_t_5 = -1; __pyx_t_1 = PyObject_GetIter(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 471, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_7 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 468, __pyx_L1_error)
+      __pyx_t_7 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 471, __pyx_L1_error)
     }
     for (;;) {
       if (likely(!__pyx_t_7)) {
         if (likely(PyList_CheckExact(__pyx_t_1))) {
           if (__pyx_t_5 >= PyList_GET_SIZE(__pyx_t_1)) break;
           #if CYTHON_COMPILING_IN_CPYTHON
-          __pyx_t_6 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 468, __pyx_L1_error)
+          __pyx_t_6 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 471, __pyx_L1_error)
           #else
-          __pyx_t_6 = PySequence_ITEM(__pyx_t_1, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 468, __pyx_L1_error)
+          __pyx_t_6 = PySequence_ITEM(__pyx_t_1, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 471, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           #endif
         } else {
           if (__pyx_t_5 >= PyTuple_GET_SIZE(__pyx_t_1)) break;
           #if CYTHON_COMPILING_IN_CPYTHON
-          __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 468, __pyx_L1_error)
+          __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 471, __pyx_L1_error)
           #else
-          __pyx_t_6 = PySequence_ITEM(__pyx_t_1, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 468, __pyx_L1_error)
+          __pyx_t_6 = PySequence_ITEM(__pyx_t_1, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 471, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           #endif
         }
@@ -8976,7 +8978,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
           PyObject* exc_type = PyErr_Occurred();
           if (exc_type) {
             if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-            else __PYX_ERR(0, 468, __pyx_L1_error)
+            else __PYX_ERR(0, 471, __pyx_L1_error)
           }
           break;
         }
@@ -8985,18 +8987,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
       __Pyx_XDECREF_SET(__pyx_v_elem, __pyx_t_6);
       __pyx_t_6 = 0;
 
-      /* "multidict/_multidict.pyx":469
+      /* "multidict/_multidict.pyx":472
  *                 return False
  *             for elem in other:
  *                 if elem not in self:             # <<<<<<<<<<<<<<
  *                     return False
  *             return True
  */
-      __pyx_t_2 = (__Pyx_PySequence_ContainsTF(__pyx_v_elem, __pyx_v_self, Py_NE)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 469, __pyx_L1_error)
+      __pyx_t_2 = (__Pyx_PySequence_ContainsTF(__pyx_v_elem, __pyx_v_self, Py_NE)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 472, __pyx_L1_error)
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
 
-        /* "multidict/_multidict.pyx":470
+        /* "multidict/_multidict.pyx":473
  *             for elem in other:
  *                 if elem not in self:
  *                     return False             # <<<<<<<<<<<<<<
@@ -9009,7 +9011,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         goto __pyx_L0;
 
-        /* "multidict/_multidict.pyx":469
+        /* "multidict/_multidict.pyx":472
  *                 return False
  *             for elem in other:
  *                 if elem not in self:             # <<<<<<<<<<<<<<
@@ -9018,7 +9020,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
       }
 
-      /* "multidict/_multidict.pyx":468
+      /* "multidict/_multidict.pyx":471
  *             if len(self) < len(other):
  *                 return False
  *             for elem in other:             # <<<<<<<<<<<<<<
@@ -9028,7 +9030,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
     }
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "multidict/_multidict.pyx":471
+    /* "multidict/_multidict.pyx":474
  *                 if elem not in self:
  *                     return False
  *             return True             # <<<<<<<<<<<<<<
@@ -9040,7 +9042,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
     __pyx_r = Py_True;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":463
+    /* "multidict/_multidict.pyx":466
  *                 return NotImplemented
  *             return len(self) > len(other) and self >= other
  *         elif op == 5:  # >=             # <<<<<<<<<<<<<<
@@ -9049,7 +9051,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
  */
   }
 
-  /* "multidict/_multidict.pyx":439
+  /* "multidict/_multidict.pyx":442
  * cdef class _ViewBaseSet(_ViewBase):
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
@@ -9072,7 +9074,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet___richcmp__(PyO
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":473
+/* "multidict/_multidict.pyx":476
  *             return True
  * 
  *     def __and__(self, other):             # <<<<<<<<<<<<<<
@@ -9103,21 +9105,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_2__and__(PyObje
   __Pyx_RefNannySetupContext("__and__", 0);
   __Pyx_INCREF(__pyx_v_other);
 
-  /* "multidict/_multidict.pyx":474
+  /* "multidict/_multidict.pyx":477
  * 
  *     def __and__(self, other):
  *         if not isinstance(other, Iterable):             # <<<<<<<<<<<<<<
  *             return NotImplemented
  *         if not isinstance(other, Set):
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Iterable); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 474, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Iterable); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 477, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 474, __pyx_L1_error)
+  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 477, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_3 = ((!(__pyx_t_2 != 0)) != 0);
   if (__pyx_t_3) {
 
-    /* "multidict/_multidict.pyx":475
+    /* "multidict/_multidict.pyx":478
  *     def __and__(self, other):
  *         if not isinstance(other, Iterable):
  *             return NotImplemented             # <<<<<<<<<<<<<<
@@ -9129,7 +9131,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_2__and__(PyObje
     __pyx_r = __pyx_builtin_NotImplemented;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":474
+    /* "multidict/_multidict.pyx":477
  * 
  *     def __and__(self, other):
  *         if not isinstance(other, Iterable):             # <<<<<<<<<<<<<<
@@ -9138,33 +9140,33 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_2__and__(PyObje
  */
   }
 
-  /* "multidict/_multidict.pyx":476
+  /* "multidict/_multidict.pyx":479
  *         if not isinstance(other, Iterable):
  *             return NotImplemented
  *         if not isinstance(other, Set):             # <<<<<<<<<<<<<<
  *             other = set(other)
  *         return set(self) & other
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 476, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 479, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 476, __pyx_L1_error)
+  __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 479, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_2 = ((!(__pyx_t_3 != 0)) != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":477
+    /* "multidict/_multidict.pyx":480
  *             return NotImplemented
  *         if not isinstance(other, Set):
  *             other = set(other)             # <<<<<<<<<<<<<<
  *         return set(self) & other
  * 
  */
-    __pyx_t_1 = PySet_New(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 477, __pyx_L1_error)
+    __pyx_t_1 = PySet_New(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 480, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF_SET(__pyx_v_other, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "multidict/_multidict.pyx":476
+    /* "multidict/_multidict.pyx":479
  *         if not isinstance(other, Iterable):
  *             return NotImplemented
  *         if not isinstance(other, Set):             # <<<<<<<<<<<<<<
@@ -9173,7 +9175,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_2__and__(PyObje
  */
   }
 
-  /* "multidict/_multidict.pyx":478
+  /* "multidict/_multidict.pyx":481
  *         if not isinstance(other, Set):
  *             other = set(other)
  *         return set(self) & other             # <<<<<<<<<<<<<<
@@ -9181,16 +9183,16 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_2__and__(PyObje
  *     def __or__(self, other):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PySet_New(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 478, __pyx_L1_error)
+  __pyx_t_1 = PySet_New(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 481, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_4 = PyNumber_And(__pyx_t_1, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 478, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_And(__pyx_t_1, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 481, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_4;
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":473
+  /* "multidict/_multidict.pyx":476
  *             return True
  * 
  *     def __and__(self, other):             # <<<<<<<<<<<<<<
@@ -9211,7 +9213,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_2__and__(PyObje
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":480
+/* "multidict/_multidict.pyx":483
  *         return set(self) & other
  * 
  *     def __or__(self, other):             # <<<<<<<<<<<<<<
@@ -9242,21 +9244,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_4__or__(PyObjec
   __Pyx_RefNannySetupContext("__or__", 0);
   __Pyx_INCREF(__pyx_v_other);
 
-  /* "multidict/_multidict.pyx":481
+  /* "multidict/_multidict.pyx":484
  * 
  *     def __or__(self, other):
  *         if not isinstance(other, Iterable):             # <<<<<<<<<<<<<<
  *             return NotImplemented
  *         if not isinstance(other, Set):
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Iterable); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 481, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Iterable); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 484, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 481, __pyx_L1_error)
+  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 484, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_3 = ((!(__pyx_t_2 != 0)) != 0);
   if (__pyx_t_3) {
 
-    /* "multidict/_multidict.pyx":482
+    /* "multidict/_multidict.pyx":485
  *     def __or__(self, other):
  *         if not isinstance(other, Iterable):
  *             return NotImplemented             # <<<<<<<<<<<<<<
@@ -9268,7 +9270,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_4__or__(PyObjec
     __pyx_r = __pyx_builtin_NotImplemented;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":481
+    /* "multidict/_multidict.pyx":484
  * 
  *     def __or__(self, other):
  *         if not isinstance(other, Iterable):             # <<<<<<<<<<<<<<
@@ -9277,33 +9279,33 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_4__or__(PyObjec
  */
   }
 
-  /* "multidict/_multidict.pyx":483
+  /* "multidict/_multidict.pyx":486
  *         if not isinstance(other, Iterable):
  *             return NotImplemented
  *         if not isinstance(other, Set):             # <<<<<<<<<<<<<<
  *             other = set(other)
  *         return set(self) | other
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 483, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 486, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 483, __pyx_L1_error)
+  __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 486, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_2 = ((!(__pyx_t_3 != 0)) != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":484
+    /* "multidict/_multidict.pyx":487
  *             return NotImplemented
  *         if not isinstance(other, Set):
  *             other = set(other)             # <<<<<<<<<<<<<<
  *         return set(self) | other
  * 
  */
-    __pyx_t_1 = PySet_New(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 484, __pyx_L1_error)
+    __pyx_t_1 = PySet_New(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 487, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF_SET(__pyx_v_other, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "multidict/_multidict.pyx":483
+    /* "multidict/_multidict.pyx":486
  *         if not isinstance(other, Iterable):
  *             return NotImplemented
  *         if not isinstance(other, Set):             # <<<<<<<<<<<<<<
@@ -9312,7 +9314,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_4__or__(PyObjec
  */
   }
 
-  /* "multidict/_multidict.pyx":485
+  /* "multidict/_multidict.pyx":488
  *         if not isinstance(other, Set):
  *             other = set(other)
  *         return set(self) | other             # <<<<<<<<<<<<<<
@@ -9320,16 +9322,16 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_4__or__(PyObjec
  *     def __sub__(self, other):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PySet_New(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 485, __pyx_L1_error)
+  __pyx_t_1 = PySet_New(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 488, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_4 = PyNumber_Or(__pyx_t_1, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 485, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Or(__pyx_t_1, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 488, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_4;
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":480
+  /* "multidict/_multidict.pyx":483
  *         return set(self) & other
  * 
  *     def __or__(self, other):             # <<<<<<<<<<<<<<
@@ -9350,7 +9352,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_4__or__(PyObjec
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":487
+/* "multidict/_multidict.pyx":490
  *         return set(self) | other
  * 
  *     def __sub__(self, other):             # <<<<<<<<<<<<<<
@@ -9381,21 +9383,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_6__sub__(PyObje
   __Pyx_RefNannySetupContext("__sub__", 0);
   __Pyx_INCREF(__pyx_v_other);
 
-  /* "multidict/_multidict.pyx":488
+  /* "multidict/_multidict.pyx":491
  * 
  *     def __sub__(self, other):
  *         if not isinstance(other, Iterable):             # <<<<<<<<<<<<<<
  *             return NotImplemented
  *         if not isinstance(other, Set):
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Iterable); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 488, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Iterable); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 491, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 488, __pyx_L1_error)
+  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 491, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_3 = ((!(__pyx_t_2 != 0)) != 0);
   if (__pyx_t_3) {
 
-    /* "multidict/_multidict.pyx":489
+    /* "multidict/_multidict.pyx":492
  *     def __sub__(self, other):
  *         if not isinstance(other, Iterable):
  *             return NotImplemented             # <<<<<<<<<<<<<<
@@ -9407,7 +9409,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_6__sub__(PyObje
     __pyx_r = __pyx_builtin_NotImplemented;
     goto __pyx_L0;
 
-    /* "multidict/_multidict.pyx":488
+    /* "multidict/_multidict.pyx":491
  * 
  *     def __sub__(self, other):
  *         if not isinstance(other, Iterable):             # <<<<<<<<<<<<<<
@@ -9416,33 +9418,33 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_6__sub__(PyObje
  */
   }
 
-  /* "multidict/_multidict.pyx":490
+  /* "multidict/_multidict.pyx":493
  *         if not isinstance(other, Iterable):
  *             return NotImplemented
  *         if not isinstance(other, Set):             # <<<<<<<<<<<<<<
  *             other = set(other)
  *         return set(self) - other
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 490, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 493, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 490, __pyx_L1_error)
+  __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 493, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_2 = ((!(__pyx_t_3 != 0)) != 0);
   if (__pyx_t_2) {
 
-    /* "multidict/_multidict.pyx":491
+    /* "multidict/_multidict.pyx":494
  *             return NotImplemented
  *         if not isinstance(other, Set):
  *             other = set(other)             # <<<<<<<<<<<<<<
  *         return set(self) - other
  * 
  */
-    __pyx_t_1 = PySet_New(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 491, __pyx_L1_error)
+    __pyx_t_1 = PySet_New(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 494, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF_SET(__pyx_v_other, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "multidict/_multidict.pyx":490
+    /* "multidict/_multidict.pyx":493
  *         if not isinstance(other, Iterable):
  *             return NotImplemented
  *         if not isinstance(other, Set):             # <<<<<<<<<<<<<<
@@ -9451,7 +9453,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_6__sub__(PyObje
  */
   }
 
-  /* "multidict/_multidict.pyx":492
+  /* "multidict/_multidict.pyx":495
  *         if not isinstance(other, Set):
  *             other = set(other)
  *         return set(self) - other             # <<<<<<<<<<<<<<
@@ -9459,16 +9461,16 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_6__sub__(PyObje
  *     def __xor__(self, other):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PySet_New(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 492, __pyx_L1_error)
+  __pyx_t_1 = PySet_New(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 495, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_4 = PyNumber_Subtract(__pyx_t_1, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 492, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Subtract(__pyx_t_1, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 495, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_4;
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":487
+  /* "multidict/_multidict.pyx":490
  *         return set(self) | other
  * 
  *     def __sub__(self, other):             # <<<<<<<<<<<<<<
@@ -9489,7 +9491,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_6__sub__(PyObje
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":494
+/* "multidict/_multidict.pyx":497
  *         return set(self) - other
  * 
  *     def __xor__(self, other):             # <<<<<<<<<<<<<<
@@ -9520,35 +9522,35 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_8__xor__(PyObje
   __Pyx_RefNannySetupContext("__xor__", 0);
   __Pyx_INCREF(__pyx_v_other);
 
-  /* "multidict/_multidict.pyx":495
+  /* "multidict/_multidict.pyx":498
  * 
  *     def __xor__(self, other):
  *         if not isinstance(other, Set):             # <<<<<<<<<<<<<<
  *             if not isinstance(other, Iterable):
  *                 return NotImplemented
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 495, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Set); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 498, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 495, __pyx_L1_error)
+  __pyx_t_2 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 498, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_3 = ((!(__pyx_t_2 != 0)) != 0);
   if (__pyx_t_3) {
 
-    /* "multidict/_multidict.pyx":496
+    /* "multidict/_multidict.pyx":499
  *     def __xor__(self, other):
  *         if not isinstance(other, Set):
  *             if not isinstance(other, Iterable):             # <<<<<<<<<<<<<<
  *                 return NotImplemented
  *             other = set(other)
  */
-    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Iterable); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 496, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_Iterable); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 499, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 496, __pyx_L1_error)
+    __pyx_t_3 = PyObject_IsInstance(__pyx_v_other, __pyx_t_1); if (unlikely(__pyx_t_3 == -1)) __PYX_ERR(0, 499, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_2 = ((!(__pyx_t_3 != 0)) != 0);
     if (__pyx_t_2) {
 
-      /* "multidict/_multidict.pyx":497
+      /* "multidict/_multidict.pyx":500
  *         if not isinstance(other, Set):
  *             if not isinstance(other, Iterable):
  *                 return NotImplemented             # <<<<<<<<<<<<<<
@@ -9560,7 +9562,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_8__xor__(PyObje
       __pyx_r = __pyx_builtin_NotImplemented;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":496
+      /* "multidict/_multidict.pyx":499
  *     def __xor__(self, other):
  *         if not isinstance(other, Set):
  *             if not isinstance(other, Iterable):             # <<<<<<<<<<<<<<
@@ -9569,19 +9571,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_8__xor__(PyObje
  */
     }
 
-    /* "multidict/_multidict.pyx":498
+    /* "multidict/_multidict.pyx":501
  *             if not isinstance(other, Iterable):
  *                 return NotImplemented
  *             other = set(other)             # <<<<<<<<<<<<<<
  *         return set(self) ^ other
  * 
  */
-    __pyx_t_1 = PySet_New(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 498, __pyx_L1_error)
+    __pyx_t_1 = PySet_New(__pyx_v_other); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 501, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF_SET(__pyx_v_other, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "multidict/_multidict.pyx":495
+    /* "multidict/_multidict.pyx":498
  * 
  *     def __xor__(self, other):
  *         if not isinstance(other, Set):             # <<<<<<<<<<<<<<
@@ -9590,7 +9592,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_8__xor__(PyObje
  */
   }
 
-  /* "multidict/_multidict.pyx":499
+  /* "multidict/_multidict.pyx":502
  *                 return NotImplemented
  *             other = set(other)
  *         return set(self) ^ other             # <<<<<<<<<<<<<<
@@ -9598,16 +9600,16 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_8__xor__(PyObje
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PySet_New(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 499, __pyx_L1_error)
+  __pyx_t_1 = PySet_New(__pyx_v_self); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 502, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_4 = PyNumber_Xor(__pyx_t_1, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 499, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Xor(__pyx_t_1, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 502, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_4;
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":494
+  /* "multidict/_multidict.pyx":497
  *         return set(self) - other
  * 
  *     def __xor__(self, other):             # <<<<<<<<<<<<<<
@@ -9628,7 +9630,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_12_ViewBaseSet_8__xor__(PyObje
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":507
+/* "multidict/_multidict.pyx":510
  *     cdef int _len
  * 
  *     def __cinit__(self, items):             # <<<<<<<<<<<<<<
@@ -9661,7 +9663,7 @@ static int __pyx_pw_9multidict_10_multidict_10_ItemsIter_1__cinit__(PyObject *__
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 507, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 510, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
@@ -9672,7 +9674,7 @@ static int __pyx_pw_9multidict_10_multidict_10_ItemsIter_1__cinit__(PyObject *__
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 507, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 510, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict._ItemsIter.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -9692,14 +9694,14 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsIter___cinit__(struct __pyx_
   Py_ssize_t __pyx_t_2;
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "multidict/_multidict.pyx":508
+  /* "multidict/_multidict.pyx":511
  * 
  *     def __cinit__(self, items):
  *         self._items = items             # <<<<<<<<<<<<<<
  *         self._current = 0
  *         self._len = len(self._items)
  */
-  if (!(likely(PyList_CheckExact(__pyx_v_items))||((__pyx_v_items) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "list", Py_TYPE(__pyx_v_items)->tp_name), 0))) __PYX_ERR(0, 508, __pyx_L1_error)
+  if (!(likely(PyList_CheckExact(__pyx_v_items))||((__pyx_v_items) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "list", Py_TYPE(__pyx_v_items)->tp_name), 0))) __PYX_ERR(0, 511, __pyx_L1_error)
   __pyx_t_1 = __pyx_v_items;
   __Pyx_INCREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
@@ -9708,7 +9710,7 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsIter___cinit__(struct __pyx_
   __pyx_v_self->_items = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":509
+  /* "multidict/_multidict.pyx":512
  *     def __cinit__(self, items):
  *         self._items = items
  *         self._current = 0             # <<<<<<<<<<<<<<
@@ -9717,7 +9719,7 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsIter___cinit__(struct __pyx_
  */
   __pyx_v_self->_current = 0;
 
-  /* "multidict/_multidict.pyx":510
+  /* "multidict/_multidict.pyx":513
  *         self._items = items
  *         self._current = 0
  *         self._len = len(self._items)             # <<<<<<<<<<<<<<
@@ -9728,13 +9730,13 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsIter___cinit__(struct __pyx_
   __Pyx_INCREF(__pyx_t_1);
   if (unlikely(__pyx_t_1 == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 510, __pyx_L1_error)
+    __PYX_ERR(0, 513, __pyx_L1_error)
   }
-  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 510, __pyx_L1_error)
+  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 513, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_self->_len = __pyx_t_2;
 
-  /* "multidict/_multidict.pyx":507
+  /* "multidict/_multidict.pyx":510
  *     cdef int _len
  * 
  *     def __cinit__(self, items):             # <<<<<<<<<<<<<<
@@ -9754,7 +9756,7 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsIter___cinit__(struct __pyx_
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":512
+/* "multidict/_multidict.pyx":515
  *         self._len = len(self._items)
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -9780,7 +9782,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_2__iter__(struct 
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__iter__", 0);
 
-  /* "multidict/_multidict.pyx":513
+  /* "multidict/_multidict.pyx":516
  * 
  *     def __iter__(self):
  *         return self             # <<<<<<<<<<<<<<
@@ -9792,7 +9794,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_2__iter__(struct 
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":512
+  /* "multidict/_multidict.pyx":515
  *         self._len = len(self._items)
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -9807,7 +9809,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_2__iter__(struct 
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":515
+/* "multidict/_multidict.pyx":518
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -9837,7 +9839,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__next__", 0);
 
-  /* "multidict/_multidict.pyx":516
+  /* "multidict/_multidict.pyx":519
  * 
  *     def __next__(self):
  *         if self._current == self._len:             # <<<<<<<<<<<<<<
@@ -9847,7 +9849,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
   __pyx_t_1 = ((__pyx_v_self->_current == __pyx_v_self->_len) != 0);
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":517
+    /* "multidict/_multidict.pyx":520
  *     def __next__(self):
  *         if self._current == self._len:
  *             raise StopIteration             # <<<<<<<<<<<<<<
@@ -9855,9 +9857,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
  *         self._current += 1
  */
     __Pyx_Raise(__pyx_builtin_StopIteration, 0, 0, 0);
-    __PYX_ERR(0, 517, __pyx_L1_error)
+    __PYX_ERR(0, 520, __pyx_L1_error)
 
-    /* "multidict/_multidict.pyx":516
+    /* "multidict/_multidict.pyx":519
  * 
  *     def __next__(self):
  *         if self._current == self._len:             # <<<<<<<<<<<<<<
@@ -9866,7 +9868,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
  */
   }
 
-  /* "multidict/_multidict.pyx":518
+  /* "multidict/_multidict.pyx":521
  *         if self._current == self._len:
  *             raise StopIteration
  *         item = <_Pair>self._items[self._current]             # <<<<<<<<<<<<<<
@@ -9875,9 +9877,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
  */
   if (unlikely(__pyx_v_self->_items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 518, __pyx_L1_error)
+    __PYX_ERR(0, 521, __pyx_L1_error)
   }
-  __pyx_t_2 = __Pyx_GetItemInt_List(__pyx_v_self->_items, __pyx_v_self->_current, int, 1, __Pyx_PyInt_From_int, 1, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 518, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt_List(__pyx_v_self->_items, __pyx_v_self->_current, int, 1, __Pyx_PyInt_From_int, 1, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 521, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_3 = __pyx_t_2;
   __Pyx_INCREF(__pyx_t_3);
@@ -9885,7 +9887,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
   __pyx_v_item = ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "multidict/_multidict.pyx":519
+  /* "multidict/_multidict.pyx":522
  *             raise StopIteration
  *         item = <_Pair>self._items[self._current]
  *         self._current += 1             # <<<<<<<<<<<<<<
@@ -9894,7 +9896,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
  */
   __pyx_v_self->_current = (__pyx_v_self->_current + 1);
 
-  /* "multidict/_multidict.pyx":520
+  /* "multidict/_multidict.pyx":523
  *         item = <_Pair>self._items[self._current]
  *         self._current += 1
  *         return (item._key, item._value)             # <<<<<<<<<<<<<<
@@ -9902,7 +9904,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 520, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 523, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_INCREF(__pyx_v_item->_key);
   __Pyx_GIVEREF(__pyx_v_item->_key);
@@ -9914,7 +9916,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":515
+  /* "multidict/_multidict.pyx":518
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -9935,7 +9937,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsIter_4__next__(struct 
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":525
+/* "multidict/_multidict.pyx":528
  * cdef class _ItemsView(_ViewBaseSet):
  * 
  *     def isdisjoint(self, other):             # <<<<<<<<<<<<<<
@@ -9970,7 +9972,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_isdisjoint(struct
   int __pyx_t_5;
   __Pyx_RefNannySetupContext("isdisjoint", 0);
 
-  /* "multidict/_multidict.pyx":528
+  /* "multidict/_multidict.pyx":531
  *         'Return True if two sets have a null intersection.'
  *         cdef _Pair item
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -9979,21 +9981,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_isdisjoint(struct
  */
   if (unlikely(__pyx_v_self->__pyx_base.__pyx_base._items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 528, __pyx_L1_error)
+    __PYX_ERR(0, 531, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->__pyx_base.__pyx_base._items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 528, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 531, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 528, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 531, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":529
+    /* "multidict/_multidict.pyx":532
  *         cdef _Pair item
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -10005,14 +10007,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_isdisjoint(struct
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":530
+    /* "multidict/_multidict.pyx":533
  *         for i in self._items:
  *             item = <_Pair>i
  *             t = (item._key, item._value)             # <<<<<<<<<<<<<<
  *             if t in other:
  *                 return False
  */
-    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 530, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 533, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_INCREF(__pyx_v_item->_key);
     __Pyx_GIVEREF(__pyx_v_item->_key);
@@ -10023,18 +10025,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_isdisjoint(struct
     __Pyx_XDECREF_SET(__pyx_v_t, ((PyObject*)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":531
+    /* "multidict/_multidict.pyx":534
  *             item = <_Pair>i
  *             t = (item._key, item._value)
  *             if t in other:             # <<<<<<<<<<<<<<
  *                 return False
  *         return True
  */
-    __pyx_t_4 = (__Pyx_PySequence_ContainsTF(__pyx_v_t, __pyx_v_other, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 531, __pyx_L1_error)
+    __pyx_t_4 = (__Pyx_PySequence_ContainsTF(__pyx_v_t, __pyx_v_other, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 534, __pyx_L1_error)
     __pyx_t_5 = (__pyx_t_4 != 0);
     if (__pyx_t_5) {
 
-      /* "multidict/_multidict.pyx":532
+      /* "multidict/_multidict.pyx":535
  *             t = (item._key, item._value)
  *             if t in other:
  *                 return False             # <<<<<<<<<<<<<<
@@ -10047,7 +10049,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_isdisjoint(struct
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":531
+      /* "multidict/_multidict.pyx":534
  *             item = <_Pair>i
  *             t = (item._key, item._value)
  *             if t in other:             # <<<<<<<<<<<<<<
@@ -10056,7 +10058,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_isdisjoint(struct
  */
     }
 
-    /* "multidict/_multidict.pyx":528
+    /* "multidict/_multidict.pyx":531
  *         'Return True if two sets have a null intersection.'
  *         cdef _Pair item
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -10066,7 +10068,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_isdisjoint(struct
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":533
+  /* "multidict/_multidict.pyx":536
  *             if t in other:
  *                 return False
  *         return True             # <<<<<<<<<<<<<<
@@ -10078,7 +10080,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_isdisjoint(struct
   __pyx_r = Py_True;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":525
+  /* "multidict/_multidict.pyx":528
  * cdef class _ItemsView(_ViewBaseSet):
  * 
  *     def isdisjoint(self, other):             # <<<<<<<<<<<<<<
@@ -10101,7 +10103,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_isdisjoint(struct
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":535
+/* "multidict/_multidict.pyx":538
  *         return True
  * 
  *     def __contains__(self, i):             # <<<<<<<<<<<<<<
@@ -10135,7 +10137,7 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsView_2__contains__(struct __
   PyObject *__pyx_t_7 = NULL;
   __Pyx_RefNannySetupContext("__contains__", 0);
 
-  /* "multidict/_multidict.pyx":537
+  /* "multidict/_multidict.pyx":540
  *     def __contains__(self, i):
  *         cdef _Pair item
  *         assert isinstance(i, tuple) or isinstance(i, list)             # <<<<<<<<<<<<<<
@@ -10157,12 +10159,12 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsView_2__contains__(struct __
     __pyx_L3_bool_binop_done:;
     if (unlikely(!__pyx_t_1)) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 537, __pyx_L1_error)
+      __PYX_ERR(0, 540, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "multidict/_multidict.pyx":538
+  /* "multidict/_multidict.pyx":541
  *         cdef _Pair item
  *         assert isinstance(i, tuple) or isinstance(i, list)
  *         assert len(i) == 2             # <<<<<<<<<<<<<<
@@ -10171,26 +10173,26 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsView_2__contains__(struct __
  */
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
-    __pyx_t_4 = PyObject_Length(__pyx_v_i); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 538, __pyx_L1_error)
+    __pyx_t_4 = PyObject_Length(__pyx_v_i); if (unlikely(__pyx_t_4 == -1)) __PYX_ERR(0, 541, __pyx_L1_error)
     if (unlikely(!((__pyx_t_4 == 2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 538, __pyx_L1_error)
+      __PYX_ERR(0, 541, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "multidict/_multidict.pyx":539
+  /* "multidict/_multidict.pyx":542
  *         assert isinstance(i, tuple) or isinstance(i, list)
  *         assert len(i) == 2
  *         item = _Pair.__new__(_Pair, i[0], i[1])             # <<<<<<<<<<<<<<
  *         return item in self._items
  * 
  */
-  __pyx_t_5 = __Pyx_GetItemInt(__pyx_v_i, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 539, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetItemInt(__pyx_v_i, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 542, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_6 = __Pyx_GetItemInt(__pyx_v_i, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 539, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_GetItemInt(__pyx_v_i, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 542, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_7 = PyTuple_New(2); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 539, __pyx_L1_error)
+  __pyx_t_7 = PyTuple_New(2); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 542, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_GIVEREF(__pyx_t_5);
   PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_5);
@@ -10198,25 +10200,25 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsView_2__contains__(struct __
   PyTuple_SET_ITEM(__pyx_t_7, 1, __pyx_t_6);
   __pyx_t_5 = 0;
   __pyx_t_6 = 0;
-  __pyx_t_6 = __pyx_tp_new_9multidict_10_multidict__Pair(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__Pair), __pyx_t_7, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 539, __pyx_L1_error)
+  __pyx_t_6 = __pyx_tp_new_9multidict_10_multidict__Pair(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__Pair), __pyx_t_7, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 542, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  if (!(likely(__Pyx_TypeTest(__pyx_t_6, __pyx_ptype_9multidict_10_multidict__Pair)))) __PYX_ERR(0, 539, __pyx_L1_error)
+  if (!(likely(__Pyx_TypeTest(__pyx_t_6, __pyx_ptype_9multidict_10_multidict__Pair)))) __PYX_ERR(0, 542, __pyx_L1_error)
   __pyx_v_item = ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_6);
   __pyx_t_6 = 0;
 
-  /* "multidict/_multidict.pyx":540
+  /* "multidict/_multidict.pyx":543
  *         assert len(i) == 2
  *         item = _Pair.__new__(_Pair, i[0], i[1])
  *         return item in self._items             # <<<<<<<<<<<<<<
  * 
  *     def __iter__(self):
  */
-  __pyx_t_1 = (__Pyx_PySequence_ContainsTF(((PyObject *)__pyx_v_item), __pyx_v_self->__pyx_base.__pyx_base._items, Py_EQ)); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 540, __pyx_L1_error)
+  __pyx_t_1 = (__Pyx_PySequence_ContainsTF(((PyObject *)__pyx_v_item), __pyx_v_self->__pyx_base.__pyx_base._items, Py_EQ)); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 543, __pyx_L1_error)
   __pyx_r = __pyx_t_1;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":535
+  /* "multidict/_multidict.pyx":538
  *         return True
  * 
  *     def __contains__(self, i):             # <<<<<<<<<<<<<<
@@ -10237,7 +10239,7 @@ static int __pyx_pf_9multidict_10_multidict_10_ItemsView_2__contains__(struct __
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":542
+/* "multidict/_multidict.pyx":545
  *         return item in self._items
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -10265,7 +10267,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_4__iter__(struct 
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__iter__", 0);
 
-  /* "multidict/_multidict.pyx":543
+  /* "multidict/_multidict.pyx":546
  * 
  *     def __iter__(self):
  *         return _ItemsIter.__new__(_ItemsIter, self._items)             # <<<<<<<<<<<<<<
@@ -10273,19 +10275,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_4__iter__(struct 
  *     def __repr__(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 543, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 546, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_self->__pyx_base.__pyx_base._items);
   __Pyx_GIVEREF(__pyx_v_self->__pyx_base.__pyx_base._items);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_self->__pyx_base.__pyx_base._items);
-  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__ItemsIter(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__ItemsIter), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 543, __pyx_L1_error)
+  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__ItemsIter(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__ItemsIter), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 546, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":542
+  /* "multidict/_multidict.pyx":545
  *         return item in self._items
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -10305,7 +10307,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_4__iter__(struct 
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":545
+/* "multidict/_multidict.pyx":548
  *         return _ItemsIter.__new__(_ItemsIter, self._items)
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -10343,19 +10345,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
   int __pyx_t_8;
   __Pyx_RefNannySetupContext("__repr__", 0);
 
-  /* "multidict/_multidict.pyx":547
+  /* "multidict/_multidict.pyx":550
  *     def __repr__(self):
  *         cdef _Pair item
  *         lst = []             # <<<<<<<<<<<<<<
  *         for i in self._items:
  *             item = <_Pair>i
  */
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 547, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 550, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_lst = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":548
+  /* "multidict/_multidict.pyx":551
  *         cdef _Pair item
  *         lst = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -10364,21 +10366,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
  */
   if (unlikely(__pyx_v_self->__pyx_base.__pyx_base._items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 548, __pyx_L1_error)
+    __PYX_ERR(0, 551, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->__pyx_base.__pyx_base._items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 548, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 551, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 548, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 551, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":549
+    /* "multidict/_multidict.pyx":552
  *         lst = []
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -10390,14 +10392,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":550
+    /* "multidict/_multidict.pyx":553
  *         for i in self._items:
  *             item = <_Pair>i
  *             lst.append("{!r}: {!r}".format(item._key, item._value))             # <<<<<<<<<<<<<<
  *         body = ', '.join(lst)
  *         return '{}({})'.format(self.__class__.__name__, body)
  */
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_r_r, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 550, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_r_r, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 553, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __pyx_t_5 = NULL;
     __pyx_t_6 = 0;
@@ -10411,7 +10413,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
         __pyx_t_6 = 1;
       }
     }
-    __pyx_t_7 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 550, __pyx_L1_error)
+    __pyx_t_7 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 553, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     if (__pyx_t_5) {
       __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_5); __pyx_t_5 = NULL;
@@ -10422,14 +10424,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
     __Pyx_INCREF(__pyx_v_item->_value);
     __Pyx_GIVEREF(__pyx_v_item->_value);
     PyTuple_SET_ITEM(__pyx_t_7, 1+__pyx_t_6, __pyx_v_item->_value);
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 550, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 553, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __pyx_t_8 = __Pyx_PyList_Append(__pyx_v_lst, __pyx_t_3); if (unlikely(__pyx_t_8 == -1)) __PYX_ERR(0, 550, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_PyList_Append(__pyx_v_lst, __pyx_t_3); if (unlikely(__pyx_t_8 == -1)) __PYX_ERR(0, 553, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":548
+    /* "multidict/_multidict.pyx":551
  *         cdef _Pair item
  *         lst = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -10439,19 +10441,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":551
+  /* "multidict/_multidict.pyx":554
  *             item = <_Pair>i
  *             lst.append("{!r}: {!r}".format(item._key, item._value))
  *         body = ', '.join(lst)             # <<<<<<<<<<<<<<
  *         return '{}({})'.format(self.__class__.__name__, body)
  * 
  */
-  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__4, __pyx_v_lst); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 551, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__4, __pyx_v_lst); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 554, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_body = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":552
+  /* "multidict/_multidict.pyx":555
  *             lst.append("{!r}: {!r}".format(item._key, item._value))
  *         body = ', '.join(lst)
  *         return '{}({})'.format(self.__class__.__name__, body)             # <<<<<<<<<<<<<<
@@ -10459,11 +10461,11 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s__8, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 552, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s__8, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 555, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 552, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 555, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_name); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 552, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_name); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 555, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_4 = NULL;
@@ -10478,7 +10480,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
       __pyx_t_2 = 1;
     }
   }
-  __pyx_t_5 = PyTuple_New(2+__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 552, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_New(2+__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 555, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   if (__pyx_t_4) {
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
@@ -10489,7 +10491,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
   __Pyx_GIVEREF(__pyx_v_body);
   PyTuple_SET_ITEM(__pyx_t_5, 1+__pyx_t_2, __pyx_v_body);
   __pyx_t_7 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 552, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 555, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -10497,7 +10499,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":545
+  /* "multidict/_multidict.pyx":548
  *         return _ItemsIter.__new__(_ItemsIter, self._items)
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -10524,7 +10526,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_10_ItemsView_6__repr__(struct 
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":563
+/* "multidict/_multidict.pyx":566
  *     cdef int _len
  * 
  *     def __cinit__(self, items):             # <<<<<<<<<<<<<<
@@ -10557,7 +10559,7 @@ static int __pyx_pw_9multidict_10_multidict_11_ValuesIter_1__cinit__(PyObject *_
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 563, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 566, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
@@ -10568,7 +10570,7 @@ static int __pyx_pw_9multidict_10_multidict_11_ValuesIter_1__cinit__(PyObject *_
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 563, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 566, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict._ValuesIter.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -10588,14 +10590,14 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesIter___cinit__(struct __pyx
   Py_ssize_t __pyx_t_2;
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "multidict/_multidict.pyx":564
+  /* "multidict/_multidict.pyx":567
  * 
  *     def __cinit__(self, items):
  *         self._items = items             # <<<<<<<<<<<<<<
  *         self._current = 0
  *         self._len = len(self._items)
  */
-  if (!(likely(PyList_CheckExact(__pyx_v_items))||((__pyx_v_items) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "list", Py_TYPE(__pyx_v_items)->tp_name), 0))) __PYX_ERR(0, 564, __pyx_L1_error)
+  if (!(likely(PyList_CheckExact(__pyx_v_items))||((__pyx_v_items) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "list", Py_TYPE(__pyx_v_items)->tp_name), 0))) __PYX_ERR(0, 567, __pyx_L1_error)
   __pyx_t_1 = __pyx_v_items;
   __Pyx_INCREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
@@ -10604,7 +10606,7 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesIter___cinit__(struct __pyx
   __pyx_v_self->_items = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":565
+  /* "multidict/_multidict.pyx":568
  *     def __cinit__(self, items):
  *         self._items = items
  *         self._current = 0             # <<<<<<<<<<<<<<
@@ -10613,7 +10615,7 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesIter___cinit__(struct __pyx
  */
   __pyx_v_self->_current = 0;
 
-  /* "multidict/_multidict.pyx":566
+  /* "multidict/_multidict.pyx":569
  *         self._items = items
  *         self._current = 0
  *         self._len = len(self._items)             # <<<<<<<<<<<<<<
@@ -10624,13 +10626,13 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesIter___cinit__(struct __pyx
   __Pyx_INCREF(__pyx_t_1);
   if (unlikely(__pyx_t_1 == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 566, __pyx_L1_error)
+    __PYX_ERR(0, 569, __pyx_L1_error)
   }
-  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 566, __pyx_L1_error)
+  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 569, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_self->_len = __pyx_t_2;
 
-  /* "multidict/_multidict.pyx":563
+  /* "multidict/_multidict.pyx":566
  *     cdef int _len
  * 
  *     def __cinit__(self, items):             # <<<<<<<<<<<<<<
@@ -10650,7 +10652,7 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesIter___cinit__(struct __pyx
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":568
+/* "multidict/_multidict.pyx":571
  *         self._len = len(self._items)
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -10676,7 +10678,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_2__iter__(struct
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__iter__", 0);
 
-  /* "multidict/_multidict.pyx":569
+  /* "multidict/_multidict.pyx":572
  * 
  *     def __iter__(self):
  *         return self             # <<<<<<<<<<<<<<
@@ -10688,7 +10690,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_2__iter__(struct
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":568
+  /* "multidict/_multidict.pyx":571
  *         self._len = len(self._items)
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -10703,7 +10705,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_2__iter__(struct
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":571
+/* "multidict/_multidict.pyx":574
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -10733,7 +10735,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_4__next__(struct
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__next__", 0);
 
-  /* "multidict/_multidict.pyx":572
+  /* "multidict/_multidict.pyx":575
  * 
  *     def __next__(self):
  *         if self._current == self._len:             # <<<<<<<<<<<<<<
@@ -10743,7 +10745,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_4__next__(struct
   __pyx_t_1 = ((__pyx_v_self->_current == __pyx_v_self->_len) != 0);
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":573
+    /* "multidict/_multidict.pyx":576
  *     def __next__(self):
  *         if self._current == self._len:
  *             raise StopIteration             # <<<<<<<<<<<<<<
@@ -10751,9 +10753,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_4__next__(struct
  *         self._current += 1
  */
     __Pyx_Raise(__pyx_builtin_StopIteration, 0, 0, 0);
-    __PYX_ERR(0, 573, __pyx_L1_error)
+    __PYX_ERR(0, 576, __pyx_L1_error)
 
-    /* "multidict/_multidict.pyx":572
+    /* "multidict/_multidict.pyx":575
  * 
  *     def __next__(self):
  *         if self._current == self._len:             # <<<<<<<<<<<<<<
@@ -10762,7 +10764,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_4__next__(struct
  */
   }
 
-  /* "multidict/_multidict.pyx":574
+  /* "multidict/_multidict.pyx":577
  *         if self._current == self._len:
  *             raise StopIteration
  *         item = <_Pair>self._items[self._current]             # <<<<<<<<<<<<<<
@@ -10771,9 +10773,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_4__next__(struct
  */
   if (unlikely(__pyx_v_self->_items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 574, __pyx_L1_error)
+    __PYX_ERR(0, 577, __pyx_L1_error)
   }
-  __pyx_t_2 = __Pyx_GetItemInt_List(__pyx_v_self->_items, __pyx_v_self->_current, int, 1, __Pyx_PyInt_From_int, 1, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 574, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt_List(__pyx_v_self->_items, __pyx_v_self->_current, int, 1, __Pyx_PyInt_From_int, 1, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 577, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_3 = __pyx_t_2;
   __Pyx_INCREF(__pyx_t_3);
@@ -10781,7 +10783,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_4__next__(struct
   __pyx_v_item = ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "multidict/_multidict.pyx":575
+  /* "multidict/_multidict.pyx":578
  *             raise StopIteration
  *         item = <_Pair>self._items[self._current]
  *         self._current += 1             # <<<<<<<<<<<<<<
@@ -10790,7 +10792,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_4__next__(struct
  */
   __pyx_v_self->_current = (__pyx_v_self->_current + 1);
 
-  /* "multidict/_multidict.pyx":576
+  /* "multidict/_multidict.pyx":579
  *         item = <_Pair>self._items[self._current]
  *         self._current += 1
  *         return item._value             # <<<<<<<<<<<<<<
@@ -10802,7 +10804,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_4__next__(struct
   __pyx_r = __pyx_v_item->_value;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":571
+  /* "multidict/_multidict.pyx":574
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -10823,7 +10825,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesIter_4__next__(struct
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":581
+/* "multidict/_multidict.pyx":584
  * cdef class _ValuesView(_ViewBase):
  * 
  *     def __contains__(self, value):             # <<<<<<<<<<<<<<
@@ -10855,7 +10857,7 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesView___contains__(struct __
   int __pyx_t_4;
   __Pyx_RefNannySetupContext("__contains__", 0);
 
-  /* "multidict/_multidict.pyx":583
+  /* "multidict/_multidict.pyx":586
  *     def __contains__(self, value):
  *         cdef _Pair item
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -10864,21 +10866,21 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesView___contains__(struct __
  */
   if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 583, __pyx_L1_error)
+    __PYX_ERR(0, 586, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->__pyx_base._items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 583, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 586, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 583, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 586, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":584
+    /* "multidict/_multidict.pyx":587
  *         cdef _Pair item
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -10890,19 +10892,19 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesView___contains__(struct __
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":585
+    /* "multidict/_multidict.pyx":588
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._value == value:             # <<<<<<<<<<<<<<
  *                 return True
  *         return False
  */
-    __pyx_t_3 = PyObject_RichCompare(__pyx_v_item->_value, __pyx_v_value, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 585, __pyx_L1_error)
-    __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 585, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_v_item->_value, __pyx_v_value, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 588, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 588, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     if (__pyx_t_4) {
 
-      /* "multidict/_multidict.pyx":586
+      /* "multidict/_multidict.pyx":589
  *             item = <_Pair>i
  *             if item._value == value:
  *                 return True             # <<<<<<<<<<<<<<
@@ -10913,7 +10915,7 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesView___contains__(struct __
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":585
+      /* "multidict/_multidict.pyx":588
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._value == value:             # <<<<<<<<<<<<<<
@@ -10922,7 +10924,7 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesView___contains__(struct __
  */
     }
 
-    /* "multidict/_multidict.pyx":583
+    /* "multidict/_multidict.pyx":586
  *     def __contains__(self, value):
  *         cdef _Pair item
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -10932,7 +10934,7 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesView___contains__(struct __
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":587
+  /* "multidict/_multidict.pyx":590
  *             if item._value == value:
  *                 return True
  *         return False             # <<<<<<<<<<<<<<
@@ -10942,7 +10944,7 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesView___contains__(struct __
   __pyx_r = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":581
+  /* "multidict/_multidict.pyx":584
  * cdef class _ValuesView(_ViewBase):
  * 
  *     def __contains__(self, value):             # <<<<<<<<<<<<<<
@@ -10963,7 +10965,7 @@ static int __pyx_pf_9multidict_10_multidict_11_ValuesView___contains__(struct __
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":589
+/* "multidict/_multidict.pyx":592
  *         return False
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -10991,7 +10993,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_2__iter__(struct
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__iter__", 0);
 
-  /* "multidict/_multidict.pyx":590
+  /* "multidict/_multidict.pyx":593
  * 
  *     def __iter__(self):
  *         return _ValuesIter.__new__(_ValuesIter, self._items)             # <<<<<<<<<<<<<<
@@ -10999,19 +11001,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_2__iter__(struct
  *     def __repr__(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 590, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 593, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_self->__pyx_base._items);
   __Pyx_GIVEREF(__pyx_v_self->__pyx_base._items);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_self->__pyx_base._items);
-  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__ValuesIter(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__ValuesIter), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 590, __pyx_L1_error)
+  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__ValuesIter(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__ValuesIter), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 593, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":589
+  /* "multidict/_multidict.pyx":592
  *         return False
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -11031,7 +11033,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_2__iter__(struct
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":592
+/* "multidict/_multidict.pyx":595
  *         return _ValuesIter.__new__(_ValuesIter, self._items)
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -11068,19 +11070,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
   int __pyx_t_7;
   __Pyx_RefNannySetupContext("__repr__", 0);
 
-  /* "multidict/_multidict.pyx":594
+  /* "multidict/_multidict.pyx":597
  *     def __repr__(self):
  *         cdef _Pair item
  *         lst = []             # <<<<<<<<<<<<<<
  *         for i in self._items:
  *             item = <_Pair>i
  */
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 594, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 597, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_lst = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":595
+  /* "multidict/_multidict.pyx":598
  *         cdef _Pair item
  *         lst = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -11089,21 +11091,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
  */
   if (unlikely(__pyx_v_self->__pyx_base._items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 595, __pyx_L1_error)
+    __PYX_ERR(0, 598, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->__pyx_base._items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 595, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 598, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 595, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 598, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":596
+    /* "multidict/_multidict.pyx":599
  *         lst = []
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -11115,14 +11117,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":597
+    /* "multidict/_multidict.pyx":600
  *         for i in self._items:
  *             item = <_Pair>i
  *             lst.append("{!r}".format(item._value))             # <<<<<<<<<<<<<<
  *         body = ', '.join(lst)
  *         return '{}({})'.format(self.__class__.__name__, body)
  */
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_r_2, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 597, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_r_2, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 600, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __pyx_t_5 = NULL;
     if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_4))) {
@@ -11135,24 +11137,24 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
       }
     }
     if (!__pyx_t_5) {
-      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_v_item->_value); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 597, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_v_item->_value); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 600, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
     } else {
-      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 597, __pyx_L1_error)
+      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 600, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5); __pyx_t_5 = NULL;
       __Pyx_INCREF(__pyx_v_item->_value);
       __Pyx_GIVEREF(__pyx_v_item->_value);
       PyTuple_SET_ITEM(__pyx_t_6, 0+1, __pyx_v_item->_value);
-      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 597, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 600, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     }
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __pyx_t_7 = __Pyx_PyList_Append(__pyx_v_lst, __pyx_t_3); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 597, __pyx_L1_error)
+    __pyx_t_7 = __Pyx_PyList_Append(__pyx_v_lst, __pyx_t_3); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 600, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":595
+    /* "multidict/_multidict.pyx":598
  *         cdef _Pair item
  *         lst = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -11162,19 +11164,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":598
+  /* "multidict/_multidict.pyx":601
  *             item = <_Pair>i
  *             lst.append("{!r}".format(item._value))
  *         body = ', '.join(lst)             # <<<<<<<<<<<<<<
  *         return '{}({})'.format(self.__class__.__name__, body)
  * 
  */
-  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__4, __pyx_v_lst); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 598, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__4, __pyx_v_lst); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 601, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_body = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":599
+  /* "multidict/_multidict.pyx":602
  *             lst.append("{!r}".format(item._value))
  *         body = ', '.join(lst)
  *         return '{}({})'.format(self.__class__.__name__, body)             # <<<<<<<<<<<<<<
@@ -11182,11 +11184,11 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s__8, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 599, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s__8, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 602, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 599, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 602, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_name); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 599, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_name); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 602, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_4 = NULL;
@@ -11201,7 +11203,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
       __pyx_t_2 = 1;
     }
   }
-  __pyx_t_5 = PyTuple_New(2+__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 599, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_New(2+__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 602, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   if (__pyx_t_4) {
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
@@ -11212,7 +11214,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
   __Pyx_GIVEREF(__pyx_v_body);
   PyTuple_SET_ITEM(__pyx_t_5, 1+__pyx_t_2, __pyx_v_body);
   __pyx_t_6 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 599, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 602, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -11220,7 +11222,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":592
+  /* "multidict/_multidict.pyx":595
  *         return _ValuesIter.__new__(_ValuesIter, self._items)
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -11247,7 +11249,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_11_ValuesView_4__repr__(struct
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":610
+/* "multidict/_multidict.pyx":613
  *     cdef int _len
  * 
  *     def __cinit__(self, items):             # <<<<<<<<<<<<<<
@@ -11280,7 +11282,7 @@ static int __pyx_pw_9multidict_10_multidict_9_KeysIter_1__cinit__(PyObject *__py
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 610, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 613, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
@@ -11291,7 +11293,7 @@ static int __pyx_pw_9multidict_10_multidict_9_KeysIter_1__cinit__(PyObject *__py
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 610, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 613, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("multidict._multidict._KeysIter.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -11311,14 +11313,14 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysIter___cinit__(struct __pyx_ob
   Py_ssize_t __pyx_t_2;
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "multidict/_multidict.pyx":611
+  /* "multidict/_multidict.pyx":614
  * 
  *     def __cinit__(self, items):
  *         self._items = items             # <<<<<<<<<<<<<<
  *         self._current = 0
  *         self._len = len(self._items)
  */
-  if (!(likely(PyList_CheckExact(__pyx_v_items))||((__pyx_v_items) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "list", Py_TYPE(__pyx_v_items)->tp_name), 0))) __PYX_ERR(0, 611, __pyx_L1_error)
+  if (!(likely(PyList_CheckExact(__pyx_v_items))||((__pyx_v_items) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "list", Py_TYPE(__pyx_v_items)->tp_name), 0))) __PYX_ERR(0, 614, __pyx_L1_error)
   __pyx_t_1 = __pyx_v_items;
   __Pyx_INCREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
@@ -11327,7 +11329,7 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysIter___cinit__(struct __pyx_ob
   __pyx_v_self->_items = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":612
+  /* "multidict/_multidict.pyx":615
  *     def __cinit__(self, items):
  *         self._items = items
  *         self._current = 0             # <<<<<<<<<<<<<<
@@ -11336,7 +11338,7 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysIter___cinit__(struct __pyx_ob
  */
   __pyx_v_self->_current = 0;
 
-  /* "multidict/_multidict.pyx":613
+  /* "multidict/_multidict.pyx":616
  *         self._items = items
  *         self._current = 0
  *         self._len = len(self._items)             # <<<<<<<<<<<<<<
@@ -11347,13 +11349,13 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysIter___cinit__(struct __pyx_ob
   __Pyx_INCREF(__pyx_t_1);
   if (unlikely(__pyx_t_1 == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 613, __pyx_L1_error)
+    __PYX_ERR(0, 616, __pyx_L1_error)
   }
-  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 613, __pyx_L1_error)
+  __pyx_t_2 = PyList_GET_SIZE(__pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 616, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_self->_len = __pyx_t_2;
 
-  /* "multidict/_multidict.pyx":610
+  /* "multidict/_multidict.pyx":613
  *     cdef int _len
  * 
  *     def __cinit__(self, items):             # <<<<<<<<<<<<<<
@@ -11373,7 +11375,7 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysIter___cinit__(struct __pyx_ob
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":615
+/* "multidict/_multidict.pyx":618
  *         self._len = len(self._items)
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -11399,7 +11401,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_2__iter__(struct __
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__iter__", 0);
 
-  /* "multidict/_multidict.pyx":616
+  /* "multidict/_multidict.pyx":619
  * 
  *     def __iter__(self):
  *         return self             # <<<<<<<<<<<<<<
@@ -11411,7 +11413,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_2__iter__(struct __
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":615
+  /* "multidict/_multidict.pyx":618
  *         self._len = len(self._items)
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -11426,7 +11428,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_2__iter__(struct __
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":618
+/* "multidict/_multidict.pyx":621
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -11456,7 +11458,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_4__next__(struct __
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__next__", 0);
 
-  /* "multidict/_multidict.pyx":619
+  /* "multidict/_multidict.pyx":622
  * 
  *     def __next__(self):
  *         if self._current == self._len:             # <<<<<<<<<<<<<<
@@ -11466,7 +11468,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_4__next__(struct __
   __pyx_t_1 = ((__pyx_v_self->_current == __pyx_v_self->_len) != 0);
   if (__pyx_t_1) {
 
-    /* "multidict/_multidict.pyx":620
+    /* "multidict/_multidict.pyx":623
  *     def __next__(self):
  *         if self._current == self._len:
  *             raise StopIteration             # <<<<<<<<<<<<<<
@@ -11474,9 +11476,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_4__next__(struct __
  *         self._current += 1
  */
     __Pyx_Raise(__pyx_builtin_StopIteration, 0, 0, 0);
-    __PYX_ERR(0, 620, __pyx_L1_error)
+    __PYX_ERR(0, 623, __pyx_L1_error)
 
-    /* "multidict/_multidict.pyx":619
+    /* "multidict/_multidict.pyx":622
  * 
  *     def __next__(self):
  *         if self._current == self._len:             # <<<<<<<<<<<<<<
@@ -11485,7 +11487,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_4__next__(struct __
  */
   }
 
-  /* "multidict/_multidict.pyx":621
+  /* "multidict/_multidict.pyx":624
  *         if self._current == self._len:
  *             raise StopIteration
  *         item = <_Pair>self._items[self._current]             # <<<<<<<<<<<<<<
@@ -11494,9 +11496,9 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_4__next__(struct __
  */
   if (unlikely(__pyx_v_self->_items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 621, __pyx_L1_error)
+    __PYX_ERR(0, 624, __pyx_L1_error)
   }
-  __pyx_t_2 = __Pyx_GetItemInt_List(__pyx_v_self->_items, __pyx_v_self->_current, int, 1, __Pyx_PyInt_From_int, 1, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 621, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt_List(__pyx_v_self->_items, __pyx_v_self->_current, int, 1, __Pyx_PyInt_From_int, 1, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 624, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_3 = __pyx_t_2;
   __Pyx_INCREF(__pyx_t_3);
@@ -11504,7 +11506,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_4__next__(struct __
   __pyx_v_item = ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "multidict/_multidict.pyx":622
+  /* "multidict/_multidict.pyx":625
  *             raise StopIteration
  *         item = <_Pair>self._items[self._current]
  *         self._current += 1             # <<<<<<<<<<<<<<
@@ -11513,7 +11515,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_4__next__(struct __
  */
   __pyx_v_self->_current = (__pyx_v_self->_current + 1);
 
-  /* "multidict/_multidict.pyx":623
+  /* "multidict/_multidict.pyx":626
  *         item = <_Pair>self._items[self._current]
  *         self._current += 1
  *         return item._key             # <<<<<<<<<<<<<<
@@ -11525,7 +11527,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_4__next__(struct __
   __pyx_r = __pyx_v_item->_key;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":618
+  /* "multidict/_multidict.pyx":621
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -11546,7 +11548,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysIter_4__next__(struct __
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":628
+/* "multidict/_multidict.pyx":631
  * cdef class _KeysView(_ViewBaseSet):
  * 
  *     def isdisjoint(self, other):             # <<<<<<<<<<<<<<
@@ -11580,7 +11582,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_isdisjoint(struct _
   int __pyx_t_5;
   __Pyx_RefNannySetupContext("isdisjoint", 0);
 
-  /* "multidict/_multidict.pyx":631
+  /* "multidict/_multidict.pyx":634
  *         'Return True if two sets have a null intersection.'
  *         cdef _Pair item
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -11589,21 +11591,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_isdisjoint(struct _
  */
   if (unlikely(__pyx_v_self->__pyx_base.__pyx_base._items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 631, __pyx_L1_error)
+    __PYX_ERR(0, 634, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->__pyx_base.__pyx_base._items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 631, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 634, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 631, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 634, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":632
+    /* "multidict/_multidict.pyx":635
  *         cdef _Pair item
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -11615,18 +11617,18 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_isdisjoint(struct _
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":633
+    /* "multidict/_multidict.pyx":636
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key in other:             # <<<<<<<<<<<<<<
  *                 return False
  *         return True
  */
-    __pyx_t_4 = (__Pyx_PySequence_ContainsTF(__pyx_v_item->_key, __pyx_v_other, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 633, __pyx_L1_error)
+    __pyx_t_4 = (__Pyx_PySequence_ContainsTF(__pyx_v_item->_key, __pyx_v_other, Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 636, __pyx_L1_error)
     __pyx_t_5 = (__pyx_t_4 != 0);
     if (__pyx_t_5) {
 
-      /* "multidict/_multidict.pyx":634
+      /* "multidict/_multidict.pyx":637
  *             item = <_Pair>i
  *             if item._key in other:
  *                 return False             # <<<<<<<<<<<<<<
@@ -11639,7 +11641,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_isdisjoint(struct _
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":633
+      /* "multidict/_multidict.pyx":636
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key in other:             # <<<<<<<<<<<<<<
@@ -11648,7 +11650,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_isdisjoint(struct _
  */
     }
 
-    /* "multidict/_multidict.pyx":631
+    /* "multidict/_multidict.pyx":634
  *         'Return True if two sets have a null intersection.'
  *         cdef _Pair item
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -11658,7 +11660,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_isdisjoint(struct _
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":635
+  /* "multidict/_multidict.pyx":638
  *             if item._key in other:
  *                 return False
  *         return True             # <<<<<<<<<<<<<<
@@ -11670,7 +11672,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_isdisjoint(struct _
   __pyx_r = Py_True;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":628
+  /* "multidict/_multidict.pyx":631
  * cdef class _KeysView(_ViewBaseSet):
  * 
  *     def isdisjoint(self, other):             # <<<<<<<<<<<<<<
@@ -11692,7 +11694,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_isdisjoint(struct _
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":637
+/* "multidict/_multidict.pyx":640
  *         return True
  * 
  *     def __contains__(self, value):             # <<<<<<<<<<<<<<
@@ -11724,7 +11726,7 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysView_2__contains__(struct __py
   int __pyx_t_4;
   __Pyx_RefNannySetupContext("__contains__", 0);
 
-  /* "multidict/_multidict.pyx":639
+  /* "multidict/_multidict.pyx":642
  *     def __contains__(self, value):
  *         cdef _Pair item
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -11733,21 +11735,21 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysView_2__contains__(struct __py
  */
   if (unlikely(__pyx_v_self->__pyx_base.__pyx_base._items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 639, __pyx_L1_error)
+    __PYX_ERR(0, 642, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->__pyx_base.__pyx_base._items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 639, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 642, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 639, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 642, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":640
+    /* "multidict/_multidict.pyx":643
  *         cdef _Pair item
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -11759,19 +11761,19 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysView_2__contains__(struct __py
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":641
+    /* "multidict/_multidict.pyx":644
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == value:             # <<<<<<<<<<<<<<
  *                 return True
  *         return False
  */
-    __pyx_t_3 = PyObject_RichCompare(__pyx_v_item->_key, __pyx_v_value, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 641, __pyx_L1_error)
-    __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 641, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_v_item->_key, __pyx_v_value, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 644, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 644, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     if (__pyx_t_4) {
 
-      /* "multidict/_multidict.pyx":642
+      /* "multidict/_multidict.pyx":645
  *             item = <_Pair>i
  *             if item._key == value:
  *                 return True             # <<<<<<<<<<<<<<
@@ -11782,7 +11784,7 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysView_2__contains__(struct __py
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       goto __pyx_L0;
 
-      /* "multidict/_multidict.pyx":641
+      /* "multidict/_multidict.pyx":644
  *         for i in self._items:
  *             item = <_Pair>i
  *             if item._key == value:             # <<<<<<<<<<<<<<
@@ -11791,7 +11793,7 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysView_2__contains__(struct __py
  */
     }
 
-    /* "multidict/_multidict.pyx":639
+    /* "multidict/_multidict.pyx":642
  *     def __contains__(self, value):
  *         cdef _Pair item
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -11801,7 +11803,7 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysView_2__contains__(struct __py
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":643
+  /* "multidict/_multidict.pyx":646
  *             if item._key == value:
  *                 return True
  *         return False             # <<<<<<<<<<<<<<
@@ -11811,7 +11813,7 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysView_2__contains__(struct __py
   __pyx_r = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":637
+  /* "multidict/_multidict.pyx":640
  *         return True
  * 
  *     def __contains__(self, value):             # <<<<<<<<<<<<<<
@@ -11832,7 +11834,7 @@ static int __pyx_pf_9multidict_10_multidict_9_KeysView_2__contains__(struct __py
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":645
+/* "multidict/_multidict.pyx":648
  *         return False
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -11860,7 +11862,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_4__iter__(struct __
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__iter__", 0);
 
-  /* "multidict/_multidict.pyx":646
+  /* "multidict/_multidict.pyx":649
  * 
  *     def __iter__(self):
  *         return _KeysIter.__new__(_KeysIter, self._items)             # <<<<<<<<<<<<<<
@@ -11868,19 +11870,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_4__iter__(struct __
  *     def __repr__(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 646, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 649, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_self->__pyx_base.__pyx_base._items);
   __Pyx_GIVEREF(__pyx_v_self->__pyx_base.__pyx_base._items);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_self->__pyx_base.__pyx_base._items);
-  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__KeysIter(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__KeysIter), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 646, __pyx_L1_error)
+  __pyx_t_2 = __pyx_tp_new_9multidict_10_multidict__KeysIter(((PyTypeObject *)__pyx_ptype_9multidict_10_multidict__KeysIter), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 649, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":645
+  /* "multidict/_multidict.pyx":648
  *         return False
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -11900,7 +11902,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_4__iter__(struct __
   return __pyx_r;
 }
 
-/* "multidict/_multidict.pyx":648
+/* "multidict/_multidict.pyx":651
  *         return _KeysIter.__new__(_KeysIter, self._items)
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -11937,19 +11939,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_6__repr__(struct __
   int __pyx_t_7;
   __Pyx_RefNannySetupContext("__repr__", 0);
 
-  /* "multidict/_multidict.pyx":650
+  /* "multidict/_multidict.pyx":653
  *     def __repr__(self):
  *         cdef _Pair item
  *         lst = []             # <<<<<<<<<<<<<<
  *         for i in self._items:
  *             item = <_Pair>i
  */
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 650, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 653, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_lst = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":651
+  /* "multidict/_multidict.pyx":654
  *         cdef _Pair item
  *         lst = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -11958,21 +11960,21 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_6__repr__(struct __
  */
   if (unlikely(__pyx_v_self->__pyx_base.__pyx_base._items == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 651, __pyx_L1_error)
+    __PYX_ERR(0, 654, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->__pyx_base.__pyx_base._items; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
   for (;;) {
     if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_COMPILING_IN_CPYTHON
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 651, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 654, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 651, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 654, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_i, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":652
+    /* "multidict/_multidict.pyx":655
  *         lst = []
  *         for i in self._items:
  *             item = <_Pair>i             # <<<<<<<<<<<<<<
@@ -11984,14 +11986,14 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_6__repr__(struct __
     __Pyx_XDECREF_SET(__pyx_v_item, ((struct __pyx_obj_9multidict_10_multidict__Pair *)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":653
+    /* "multidict/_multidict.pyx":656
  *         for i in self._items:
  *             item = <_Pair>i
  *             lst.append("{!r}".format(item._key))             # <<<<<<<<<<<<<<
  *         body = ', '.join(lst)
  *         return '{}({})'.format(self.__class__.__name__, body)
  */
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_r_2, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 653, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_r_2, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 656, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __pyx_t_5 = NULL;
     if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_4))) {
@@ -12004,24 +12006,24 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_6__repr__(struct __
       }
     }
     if (!__pyx_t_5) {
-      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_v_item->_key); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 653, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_v_item->_key); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 656, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
     } else {
-      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 653, __pyx_L1_error)
+      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 656, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5); __pyx_t_5 = NULL;
       __Pyx_INCREF(__pyx_v_item->_key);
       __Pyx_GIVEREF(__pyx_v_item->_key);
       PyTuple_SET_ITEM(__pyx_t_6, 0+1, __pyx_v_item->_key);
-      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 653, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 656, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     }
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __pyx_t_7 = __Pyx_PyList_Append(__pyx_v_lst, __pyx_t_3); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 653, __pyx_L1_error)
+    __pyx_t_7 = __Pyx_PyList_Append(__pyx_v_lst, __pyx_t_3); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 656, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "multidict/_multidict.pyx":651
+    /* "multidict/_multidict.pyx":654
  *         cdef _Pair item
  *         lst = []
  *         for i in self._items:             # <<<<<<<<<<<<<<
@@ -12031,19 +12033,19 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_6__repr__(struct __
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":654
+  /* "multidict/_multidict.pyx":657
  *             item = <_Pair>i
  *             lst.append("{!r}".format(item._key))
  *         body = ', '.join(lst)             # <<<<<<<<<<<<<<
  *         return '{}({})'.format(self.__class__.__name__, body)
  * 
  */
-  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__4, __pyx_v_lst); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 654, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__4, __pyx_v_lst); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 657, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_body = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "multidict/_multidict.pyx":655
+  /* "multidict/_multidict.pyx":658
  *             lst.append("{!r}".format(item._key))
  *         body = ', '.join(lst)
  *         return '{}({})'.format(self.__class__.__name__, body)             # <<<<<<<<<<<<<<
@@ -12051,11 +12053,11 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_6__repr__(struct __
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s__8, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 655, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s__8, __pyx_n_s_format); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 658, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 655, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_class); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 658, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_name); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 655, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_name); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 658, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_4 = NULL;
@@ -12070,7 +12072,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_6__repr__(struct __
       __pyx_t_2 = 1;
     }
   }
-  __pyx_t_5 = PyTuple_New(2+__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 655, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_New(2+__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 658, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   if (__pyx_t_4) {
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
@@ -12081,7 +12083,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_6__repr__(struct __
   __Pyx_GIVEREF(__pyx_v_body);
   PyTuple_SET_ITEM(__pyx_t_5, 1+__pyx_t_2, __pyx_v_body);
   __pyx_t_6 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 655, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 658, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -12089,7 +12091,7 @@ static PyObject *__pyx_pf_9multidict_10_multidict_9_KeysView_6__repr__(struct __
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "multidict/_multidict.pyx":648
+  /* "multidict/_multidict.pyx":651
  *         return _KeysIter.__new__(_KeysIter, self._items)
  * 
  *     def __repr__(self):             # <<<<<<<<<<<<<<
@@ -13650,7 +13652,10 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_getdefaultencoding, __pyx_k_getdefaultencoding, sizeof(__pyx_k_getdefaultencoding), 0, 0, 1, 1},
   {&__pyx_kp_s_home_andrew_projects_multidict, __pyx_k_home_andrew_projects_multidict, sizeof(__pyx_k_home_andrew_projects_multidict), 0, 0, 1, 0},
   {&__pyx_n_s_import, __pyx_k_import, sizeof(__pyx_k_import), 0, 0, 1, 1},
-  {&__pyx_n_s_is_upstr, __pyx_k_is_upstr, sizeof(__pyx_k_is_upstr), 0, 0, 1, 1},
+  {&__pyx_n_s_is_istr, __pyx_k_is_istr, sizeof(__pyx_k_is_istr), 0, 0, 1, 1},
+  {&__pyx_n_s_istr, __pyx_k_istr, sizeof(__pyx_k_istr), 0, 0, 1, 1},
+  {&__pyx_n_s_istr___new, __pyx_k_istr___new, sizeof(__pyx_k_istr___new), 0, 0, 1, 1},
+  {&__pyx_n_s_istr_title, __pyx_k_istr_title, sizeof(__pyx_k_istr_title), 0, 0, 1, 1},
   {&__pyx_n_s_itemgetter, __pyx_k_itemgetter, sizeof(__pyx_k_itemgetter), 0, 0, 1, 1},
   {&__pyx_n_s_items, __pyx_k_items, sizeof(__pyx_k_items), 0, 0, 1, 1},
   {&__pyx_n_s_join, __pyx_k_join, sizeof(__pyx_k_join), 0, 0, 1, 1},
@@ -13682,11 +13687,9 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_kp_s_takes_at_most_1_positional_argu, __pyx_k_takes_at_most_1_positional_argu, sizeof(__pyx_k_takes_at_most_1_positional_argu), 0, 0, 1, 0},
   {&__pyx_kp_s_takes_either_dict_or_list_of_ke, __pyx_k_takes_either_dict_or_list_of_ke, sizeof(__pyx_k_takes_either_dict_or_list_of_ke), 0, 0, 1, 0},
   {&__pyx_n_s_test, __pyx_k_test, sizeof(__pyx_k_test), 0, 0, 1, 1},
+  {&__pyx_n_s_title, __pyx_k_title, sizeof(__pyx_k_title), 0, 0, 1, 1},
   {&__pyx_n_s_update, __pyx_k_update, sizeof(__pyx_k_update), 0, 0, 1, 1},
-  {&__pyx_n_s_upper, __pyx_k_upper, sizeof(__pyx_k_upper), 0, 0, 1, 1},
   {&__pyx_n_s_upstr, __pyx_k_upstr, sizeof(__pyx_k_upstr), 0, 0, 1, 1},
-  {&__pyx_n_s_upstr___new, __pyx_k_upstr___new, sizeof(__pyx_k_upstr___new), 0, 0, 1, 1},
-  {&__pyx_n_s_upstr_upper, __pyx_k_upstr_upper, sizeof(__pyx_k_upstr_upper), 0, 0, 1, 1},
   {&__pyx_n_s_val, __pyx_k_val, sizeof(__pyx_k_val), 0, 0, 1, 1},
   {&__pyx_n_s_value, __pyx_k_value, sizeof(__pyx_k_value), 0, 0, 1, 1},
   {0, 0, 0, 0, 0, 0, 0}
@@ -13694,11 +13697,11 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
 static int __Pyx_InitCachedBuiltins(void) {
   __pyx_builtin_object = __Pyx_GetBuiltinName(__pyx_n_s_object); if (!__pyx_builtin_object) __PYX_ERR(0, 7, __pyx_L1_error)
   __pyx_builtin_memoryview = __Pyx_GetBuiltinName(__pyx_n_s_memoryview); if (!__pyx_builtin_memoryview) __PYX_ERR(0, 21, __pyx_L1_error)
-  __pyx_builtin_NotImplemented = __Pyx_GetBuiltinName(__pyx_n_s_NotImplemented); if (!__pyx_builtin_NotImplemented) __PYX_ERR(0, 49, __pyx_L1_error)
-  __pyx_builtin_KeyError = __Pyx_GetBuiltinName(__pyx_n_s_KeyError); if (!__pyx_builtin_KeyError) __PYX_ERR(0, 103, __pyx_L1_error)
-  __pyx_builtin_TypeError = __Pyx_GetBuiltinName(__pyx_n_s_TypeError); if (!__pyx_builtin_TypeError) __PYX_ERR(0, 204, __pyx_L1_error)
-  __pyx_builtin_range = __Pyx_GetBuiltinName(__pyx_n_s_range); if (!__pyx_builtin_range) __PYX_ERR(0, 348, __pyx_L1_error)
-  __pyx_builtin_StopIteration = __Pyx_GetBuiltinName(__pyx_n_s_StopIteration); if (!__pyx_builtin_StopIteration) __PYX_ERR(0, 517, __pyx_L1_error)
+  __pyx_builtin_NotImplemented = __Pyx_GetBuiltinName(__pyx_n_s_NotImplemented); if (!__pyx_builtin_NotImplemented) __PYX_ERR(0, 52, __pyx_L1_error)
+  __pyx_builtin_KeyError = __Pyx_GetBuiltinName(__pyx_n_s_KeyError); if (!__pyx_builtin_KeyError) __PYX_ERR(0, 106, __pyx_L1_error)
+  __pyx_builtin_TypeError = __Pyx_GetBuiltinName(__pyx_n_s_TypeError); if (!__pyx_builtin_TypeError) __PYX_ERR(0, 207, __pyx_L1_error)
+  __pyx_builtin_range = __Pyx_GetBuiltinName(__pyx_n_s_range); if (!__pyx_builtin_range) __PYX_ERR(0, 351, __pyx_L1_error)
+  __pyx_builtin_StopIteration = __Pyx_GetBuiltinName(__pyx_n_s_StopIteration); if (!__pyx_builtin_StopIteration) __PYX_ERR(0, 520, __pyx_L1_error)
   return 0;
   __pyx_L1_error:;
   return -1;
@@ -13708,23 +13711,23 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__Pyx_InitCachedConstants", 0);
 
-  /* "multidict/_multidict.pyx":403
+  /* "multidict/_multidict.pyx":406
  *             return (item._key, item._value)
  *         else:
  *             raise KeyError("empty multidict")             # <<<<<<<<<<<<<<
  * 
  *     def update(self, *args, **kwargs):
  */
-  __pyx_tuple__7 = PyTuple_Pack(1, __pyx_kp_s_empty_multidict); if (unlikely(!__pyx_tuple__7)) __PYX_ERR(0, 403, __pyx_L1_error)
+  __pyx_tuple__7 = PyTuple_Pack(1, __pyx_kp_s_empty_multidict); if (unlikely(!__pyx_tuple__7)) __PYX_ERR(0, 406, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__7);
   __Pyx_GIVEREF(__pyx_tuple__7);
 
   /* "multidict/_multidict.pyx":16
- *     __is_upstr__ = True
+ *     __is_istr__ = True
  * 
  *     def __new__(cls, val='',             # <<<<<<<<<<<<<<
  *                 encoding=sys.getdefaultencoding(), errors='strict'):
- *         if getattr(val, '__is_upstr__', False):
+ *         if getattr(val, '__is_istr__', False):
  */
   __pyx_tuple__9 = PyTuple_Pack(5, __pyx_n_s_cls, __pyx_n_s_val, __pyx_n_s_encoding, __pyx_n_s_errors, __pyx_n_s_ret); if (unlikely(!__pyx_tuple__9)) __PYX_ERR(0, 16, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__9);
@@ -13734,14 +13737,14 @@ static int __Pyx_InitCachedConstants(void) {
   /* "multidict/_multidict.pyx":30
  *         return ret
  * 
- *     def upper(self):             # <<<<<<<<<<<<<<
+ *     def title(self):             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
   __pyx_tuple__11 = PyTuple_Pack(1, __pyx_n_s_self); if (unlikely(!__pyx_tuple__11)) __PYX_ERR(0, 30, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__11);
   __Pyx_GIVEREF(__pyx_tuple__11);
-  __pyx_codeobj__12 = (PyObject*)__Pyx_PyCode_New(1, 0, 1, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__11, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_andrew_projects_multidict, __pyx_n_s_upper, 30, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__12)) __PYX_ERR(0, 30, __pyx_L1_error)
+  __pyx_codeobj__12 = (PyObject*)__Pyx_PyCode_New(1, 0, 1, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__11, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_andrew_projects_multidict, __pyx_n_s_title, 30, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__12)) __PYX_ERR(0, 30, __pyx_L1_error)
   __Pyx_RefNannyFinishContext();
   return 0;
   __pyx_L1_error:;
@@ -13853,38 +13856,38 @@ PyMODINIT_FUNC PyInit__multidict(void)
   /*--- Variable export code ---*/
   /*--- Function export code ---*/
   /*--- Type init code ---*/
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__Pair) < 0) __PYX_ERR(0, 52, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__Pair) < 0) __PYX_ERR(0, 55, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__Pair.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "_Pair", (PyObject *)&__pyx_type_9multidict_10_multidict__Pair) < 0) __PYX_ERR(0, 52, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_Pair", (PyObject *)&__pyx_type_9multidict_10_multidict__Pair) < 0) __PYX_ERR(0, 55, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__Pair = &__pyx_type_9multidict_10_multidict__Pair;
   __pyx_vtabptr_9multidict_10_multidict__Base = &__pyx_vtable_9multidict_10_multidict__Base;
-  __pyx_vtable_9multidict_10_multidict__Base._upper = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *))__pyx_f_9multidict_10_multidict_5_Base__upper;
+  __pyx_vtable_9multidict_10_multidict__Base._title = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *))__pyx_f_9multidict_10_multidict_5_Base__title;
   __pyx_vtable_9multidict_10_multidict__Base._getall = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *, PyObject *))__pyx_f_9multidict_10_multidict_5_Base__getall;
   __pyx_vtable_9multidict_10_multidict__Base._getone = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *, PyObject *))__pyx_f_9multidict_10_multidict_5_Base__getone;
   __pyx_vtable_9multidict_10_multidict__Base._contains = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *))__pyx_f_9multidict_10_multidict_5_Base__contains;
   __pyx_vtable_9multidict_10_multidict__Base.keys = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, int __pyx_skip_dispatch))__pyx_f_9multidict_10_multidict_5_Base_keys;
   __pyx_vtable_9multidict_10_multidict__Base._eq_to_mapping = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *))__pyx_f_9multidict_10_multidict_5_Base__eq_to_mapping;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__Base) < 0) __PYX_ERR(0, 71, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__Base) < 0) __PYX_ERR(0, 74, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__Base.tp_print = 0;
-  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict__Base.tp_dict, __pyx_vtabptr_9multidict_10_multidict__Base) < 0) __PYX_ERR(0, 71, __pyx_L1_error)
-  if (PyObject_SetAttrString(__pyx_m, "_Base", (PyObject *)&__pyx_type_9multidict_10_multidict__Base) < 0) __PYX_ERR(0, 71, __pyx_L1_error)
+  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict__Base.tp_dict, __pyx_vtabptr_9multidict_10_multidict__Base) < 0) __PYX_ERR(0, 74, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_Base", (PyObject *)&__pyx_type_9multidict_10_multidict__Base) < 0) __PYX_ERR(0, 74, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__Base = &__pyx_type_9multidict_10_multidict__Base;
   __pyx_vtabptr_9multidict_10_multidict_MultiDictProxy = &__pyx_vtable_9multidict_10_multidict_MultiDictProxy;
   __pyx_vtable_9multidict_10_multidict_MultiDictProxy.__pyx_base = *__pyx_vtabptr_9multidict_10_multidict__Base;
   __pyx_type_9multidict_10_multidict_MultiDictProxy.tp_base = __pyx_ptype_9multidict_10_multidict__Base;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict_MultiDictProxy) < 0) __PYX_ERR(0, 199, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict_MultiDictProxy) < 0) __PYX_ERR(0, 202, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict_MultiDictProxy.tp_print = 0;
-  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict_MultiDictProxy.tp_dict, __pyx_vtabptr_9multidict_10_multidict_MultiDictProxy) < 0) __PYX_ERR(0, 199, __pyx_L1_error)
-  if (PyObject_SetAttrString(__pyx_m, "MultiDictProxy", (PyObject *)&__pyx_type_9multidict_10_multidict_MultiDictProxy) < 0) __PYX_ERR(0, 199, __pyx_L1_error)
+  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict_MultiDictProxy.tp_dict, __pyx_vtabptr_9multidict_10_multidict_MultiDictProxy) < 0) __PYX_ERR(0, 202, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "MultiDictProxy", (PyObject *)&__pyx_type_9multidict_10_multidict_MultiDictProxy) < 0) __PYX_ERR(0, 202, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict_MultiDictProxy = &__pyx_type_9multidict_10_multidict_MultiDictProxy;
   __pyx_vtabptr_9multidict_10_multidict_CIMultiDictProxy = &__pyx_vtable_9multidict_10_multidict_CIMultiDictProxy;
   __pyx_vtable_9multidict_10_multidict_CIMultiDictProxy.__pyx_base = *__pyx_vtabptr_9multidict_10_multidict_MultiDictProxy;
-  __pyx_vtable_9multidict_10_multidict_CIMultiDictProxy.__pyx_base.__pyx_base._upper = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *))__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__upper;
+  __pyx_vtable_9multidict_10_multidict_CIMultiDictProxy.__pyx_base.__pyx_base._title = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *))__pyx_f_9multidict_10_multidict_16CIMultiDictProxy__title;
   __pyx_type_9multidict_10_multidict_CIMultiDictProxy.tp_base = __pyx_ptype_9multidict_10_multidict_MultiDictProxy;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict_CIMultiDictProxy) < 0) __PYX_ERR(0, 218, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict_CIMultiDictProxy) < 0) __PYX_ERR(0, 221, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict_CIMultiDictProxy.tp_print = 0;
-  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict_CIMultiDictProxy.tp_dict, __pyx_vtabptr_9multidict_10_multidict_CIMultiDictProxy) < 0) __PYX_ERR(0, 218, __pyx_L1_error)
-  if (PyObject_SetAttrString(__pyx_m, "CIMultiDictProxy", (PyObject *)&__pyx_type_9multidict_10_multidict_CIMultiDictProxy) < 0) __PYX_ERR(0, 218, __pyx_L1_error)
+  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict_CIMultiDictProxy.tp_dict, __pyx_vtabptr_9multidict_10_multidict_CIMultiDictProxy) < 0) __PYX_ERR(0, 221, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "CIMultiDictProxy", (PyObject *)&__pyx_type_9multidict_10_multidict_CIMultiDictProxy) < 0) __PYX_ERR(0, 221, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict_CIMultiDictProxy = &__pyx_type_9multidict_10_multidict_CIMultiDictProxy;
   __pyx_vtabptr_9multidict_10_multidict_MultiDict = &__pyx_vtable_9multidict_10_multidict_MultiDict;
   __pyx_vtable_9multidict_10_multidict_MultiDict.__pyx_base = *__pyx_vtabptr_9multidict_10_multidict__Base;
@@ -13893,55 +13896,55 @@ PyMODINIT_FUNC PyInit__multidict(void)
   __pyx_vtable_9multidict_10_multidict_MultiDict._replace = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict_MultiDict *, PyObject *, PyObject *))__pyx_f_9multidict_10_multidict_9MultiDict__replace;
   __pyx_vtable_9multidict_10_multidict_MultiDict._remove = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict_MultiDict *, PyObject *, int))__pyx_f_9multidict_10_multidict_9MultiDict__remove;
   __pyx_type_9multidict_10_multidict_MultiDict.tp_base = __pyx_ptype_9multidict_10_multidict__Base;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict_MultiDict) < 0) __PYX_ERR(0, 243, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict_MultiDict) < 0) __PYX_ERR(0, 246, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict_MultiDict.tp_print = 0;
-  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict_MultiDict.tp_dict, __pyx_vtabptr_9multidict_10_multidict_MultiDict) < 0) __PYX_ERR(0, 243, __pyx_L1_error)
-  if (PyObject_SetAttrString(__pyx_m, "MultiDict", (PyObject *)&__pyx_type_9multidict_10_multidict_MultiDict) < 0) __PYX_ERR(0, 243, __pyx_L1_error)
+  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict_MultiDict.tp_dict, __pyx_vtabptr_9multidict_10_multidict_MultiDict) < 0) __PYX_ERR(0, 246, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "MultiDict", (PyObject *)&__pyx_type_9multidict_10_multidict_MultiDict) < 0) __PYX_ERR(0, 246, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict_MultiDict = &__pyx_type_9multidict_10_multidict_MultiDict;
   __pyx_vtabptr_9multidict_10_multidict_CIMultiDict = &__pyx_vtable_9multidict_10_multidict_CIMultiDict;
   __pyx_vtable_9multidict_10_multidict_CIMultiDict.__pyx_base = *__pyx_vtabptr_9multidict_10_multidict_MultiDict;
-  __pyx_vtable_9multidict_10_multidict_CIMultiDict.__pyx_base.__pyx_base._upper = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *))__pyx_f_9multidict_10_multidict_11CIMultiDict__upper;
+  __pyx_vtable_9multidict_10_multidict_CIMultiDict.__pyx_base.__pyx_base._title = (PyObject *(*)(struct __pyx_obj_9multidict_10_multidict__Base *, PyObject *))__pyx_f_9multidict_10_multidict_11CIMultiDict__title;
   __pyx_type_9multidict_10_multidict_CIMultiDict.tp_base = __pyx_ptype_9multidict_10_multidict_MultiDict;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict_CIMultiDict) < 0) __PYX_ERR(0, 413, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict_CIMultiDict) < 0) __PYX_ERR(0, 416, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict_CIMultiDict.tp_print = 0;
-  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict_CIMultiDict.tp_dict, __pyx_vtabptr_9multidict_10_multidict_CIMultiDict) < 0) __PYX_ERR(0, 413, __pyx_L1_error)
-  if (PyObject_SetAttrString(__pyx_m, "CIMultiDict", (PyObject *)&__pyx_type_9multidict_10_multidict_CIMultiDict) < 0) __PYX_ERR(0, 413, __pyx_L1_error)
+  if (__Pyx_SetVtable(__pyx_type_9multidict_10_multidict_CIMultiDict.tp_dict, __pyx_vtabptr_9multidict_10_multidict_CIMultiDict) < 0) __PYX_ERR(0, 416, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "CIMultiDict", (PyObject *)&__pyx_type_9multidict_10_multidict_CIMultiDict) < 0) __PYX_ERR(0, 416, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict_CIMultiDict = &__pyx_type_9multidict_10_multidict_CIMultiDict;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ViewBase) < 0) __PYX_ERR(0, 426, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ViewBase) < 0) __PYX_ERR(0, 429, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__ViewBase.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "_ViewBase", (PyObject *)&__pyx_type_9multidict_10_multidict__ViewBase) < 0) __PYX_ERR(0, 426, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_ViewBase", (PyObject *)&__pyx_type_9multidict_10_multidict__ViewBase) < 0) __PYX_ERR(0, 429, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__ViewBase = &__pyx_type_9multidict_10_multidict__ViewBase;
   __pyx_type_9multidict_10_multidict__ViewBaseSet.tp_base = __pyx_ptype_9multidict_10_multidict__ViewBase;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ViewBaseSet) < 0) __PYX_ERR(0, 437, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ViewBaseSet) < 0) __PYX_ERR(0, 440, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__ViewBaseSet.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "_ViewBaseSet", (PyObject *)&__pyx_type_9multidict_10_multidict__ViewBaseSet) < 0) __PYX_ERR(0, 437, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_ViewBaseSet", (PyObject *)&__pyx_type_9multidict_10_multidict__ViewBaseSet) < 0) __PYX_ERR(0, 440, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__ViewBaseSet = &__pyx_type_9multidict_10_multidict__ViewBaseSet;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ItemsIter) < 0) __PYX_ERR(0, 502, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ItemsIter) < 0) __PYX_ERR(0, 505, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__ItemsIter.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "_ItemsIter", (PyObject *)&__pyx_type_9multidict_10_multidict__ItemsIter) < 0) __PYX_ERR(0, 502, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_ItemsIter", (PyObject *)&__pyx_type_9multidict_10_multidict__ItemsIter) < 0) __PYX_ERR(0, 505, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__ItemsIter = &__pyx_type_9multidict_10_multidict__ItemsIter;
   __pyx_type_9multidict_10_multidict__ItemsView.tp_base = __pyx_ptype_9multidict_10_multidict__ViewBaseSet;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ItemsView) < 0) __PYX_ERR(0, 523, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ItemsView) < 0) __PYX_ERR(0, 526, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__ItemsView.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "_ItemsView", (PyObject *)&__pyx_type_9multidict_10_multidict__ItemsView) < 0) __PYX_ERR(0, 523, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_ItemsView", (PyObject *)&__pyx_type_9multidict_10_multidict__ItemsView) < 0) __PYX_ERR(0, 526, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__ItemsView = &__pyx_type_9multidict_10_multidict__ItemsView;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ValuesIter) < 0) __PYX_ERR(0, 558, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ValuesIter) < 0) __PYX_ERR(0, 561, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__ValuesIter.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "_ValuesIter", (PyObject *)&__pyx_type_9multidict_10_multidict__ValuesIter) < 0) __PYX_ERR(0, 558, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_ValuesIter", (PyObject *)&__pyx_type_9multidict_10_multidict__ValuesIter) < 0) __PYX_ERR(0, 561, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__ValuesIter = &__pyx_type_9multidict_10_multidict__ValuesIter;
   __pyx_type_9multidict_10_multidict__ValuesView.tp_base = __pyx_ptype_9multidict_10_multidict__ViewBase;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ValuesView) < 0) __PYX_ERR(0, 579, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__ValuesView) < 0) __PYX_ERR(0, 582, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__ValuesView.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "_ValuesView", (PyObject *)&__pyx_type_9multidict_10_multidict__ValuesView) < 0) __PYX_ERR(0, 579, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_ValuesView", (PyObject *)&__pyx_type_9multidict_10_multidict__ValuesView) < 0) __PYX_ERR(0, 582, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__ValuesView = &__pyx_type_9multidict_10_multidict__ValuesView;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__KeysIter) < 0) __PYX_ERR(0, 605, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__KeysIter) < 0) __PYX_ERR(0, 608, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__KeysIter.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "_KeysIter", (PyObject *)&__pyx_type_9multidict_10_multidict__KeysIter) < 0) __PYX_ERR(0, 605, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_KeysIter", (PyObject *)&__pyx_type_9multidict_10_multidict__KeysIter) < 0) __PYX_ERR(0, 608, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__KeysIter = &__pyx_type_9multidict_10_multidict__KeysIter;
   __pyx_type_9multidict_10_multidict__KeysView.tp_base = __pyx_ptype_9multidict_10_multidict__ViewBaseSet;
-  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__KeysView) < 0) __PYX_ERR(0, 626, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9multidict_10_multidict__KeysView) < 0) __PYX_ERR(0, 629, __pyx_L1_error)
   __pyx_type_9multidict_10_multidict__KeysView.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "_KeysView", (PyObject *)&__pyx_type_9multidict_10_multidict__KeysView) < 0) __PYX_ERR(0, 626, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "_KeysView", (PyObject *)&__pyx_type_9multidict_10_multidict__KeysView) < 0) __PYX_ERR(0, 629, __pyx_L1_error)
   __pyx_ptype_9multidict_10_multidict__KeysView = &__pyx_type_9multidict_10_multidict__KeysView;
   /*--- Type import code ---*/
   /*--- Variable import code ---*/
@@ -14045,7 +14048,7 @@ PyMODINIT_FUNC PyInit__multidict(void)
   /* "multidict/_multidict.pyx":10
  * 
  * 
- * class upstr(str):             # <<<<<<<<<<<<<<
+ * class istr(str):             # <<<<<<<<<<<<<<
  * 
  *     """Case insensitive str."""
  */
@@ -14056,26 +14059,26 @@ PyMODINIT_FUNC PyInit__multidict(void)
   PyTuple_SET_ITEM(__pyx_t_2, 0, ((PyObject *)(&PyString_Type)));
   __pyx_t_1 = __Pyx_CalculateMetaclass(NULL, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 10, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_Py3MetaclassPrepare(__pyx_t_1, __pyx_t_2, __pyx_n_s_upstr, __pyx_n_s_upstr, (PyObject *) NULL, __pyx_n_s_multidict__multidict, __pyx_kp_s_Case_insensitive_str); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 10, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_Py3MetaclassPrepare(__pyx_t_1, __pyx_t_2, __pyx_n_s_istr, __pyx_n_s_istr, (PyObject *) NULL, __pyx_n_s_multidict__multidict, __pyx_kp_s_Case_insensitive_str); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 10, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
 
   /* "multidict/_multidict.pyx":14
  *     """Case insensitive str."""
  * 
- *     __is_upstr__ = True             # <<<<<<<<<<<<<<
+ *     __is_istr__ = True             # <<<<<<<<<<<<<<
  * 
  *     def __new__(cls, val='',
  */
-  if (PyObject_SetItem(__pyx_t_3, __pyx_n_s_is_upstr, Py_True) < 0) __PYX_ERR(0, 14, __pyx_L1_error)
+  if (PyObject_SetItem(__pyx_t_3, __pyx_n_s_is_istr, Py_True) < 0) __PYX_ERR(0, 14, __pyx_L1_error)
 
   /* "multidict/_multidict.pyx":16
- *     __is_upstr__ = True
+ *     __is_istr__ = True
  * 
  *     def __new__(cls, val='',             # <<<<<<<<<<<<<<
  *                 encoding=sys.getdefaultencoding(), errors='strict'):
- *         if getattr(val, '__is_upstr__', False):
+ *         if getattr(val, '__is_istr__', False):
  */
-  __pyx_t_4 = __Pyx_CyFunction_NewEx(&__pyx_mdef_9multidict_10_multidict_5upstr_1__new__, __Pyx_CYFUNCTION_STATICMETHOD, __pyx_n_s_upstr___new, NULL, __pyx_n_s_multidict__multidict, __pyx_d, ((PyObject *)__pyx_codeobj__10)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 16, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_CyFunction_NewEx(&__pyx_mdef_9multidict_10_multidict_4istr_1__new__, __Pyx_CYFUNCTION_STATICMETHOD, __pyx_n_s_istr___new, NULL, __pyx_n_s_multidict__multidict, __pyx_d, ((PyObject *)__pyx_codeobj__10)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 16, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   if (!__Pyx_CyFunction_InitDefaults(__pyx_t_4, sizeof(__pyx_defaults), 1)) __PYX_ERR(0, 16, __pyx_L1_error)
 
@@ -14083,7 +14086,7 @@ PyMODINIT_FUNC PyInit__multidict(void)
  * 
  *     def __new__(cls, val='',
  *                 encoding=sys.getdefaultencoding(), errors='strict'):             # <<<<<<<<<<<<<<
- *         if getattr(val, '__is_upstr__', False):
+ *         if getattr(val, '__is_istr__', False):
  *             # Faster than instance check
  */
   __pyx_t_6 = __Pyx_GetModuleGlobalName(__pyx_n_s_sys); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 17, __pyx_L1_error)
@@ -14112,76 +14115,88 @@ PyMODINIT_FUNC PyInit__multidict(void)
   __Pyx_CyFunction_Defaults(__pyx_defaults, __pyx_t_4)->__pyx_arg_encoding = __pyx_t_5;
   __Pyx_GIVEREF(__pyx_t_5);
   __pyx_t_5 = 0;
-  __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_4, __pyx_pf_9multidict_10_multidict_5upstr_4__defaults__);
+  __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_4, __pyx_pf_9multidict_10_multidict_4istr_4__defaults__);
   if (PyObject_SetItem(__pyx_t_3, __pyx_n_s_new, __pyx_t_4) < 0) __PYX_ERR(0, 16, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
   /* "multidict/_multidict.pyx":30
  *         return ret
  * 
- *     def upper(self):             # <<<<<<<<<<<<<<
+ *     def title(self):             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __pyx_t_4 = __Pyx_CyFunction_NewEx(&__pyx_mdef_9multidict_10_multidict_5upstr_3upper, 0, __pyx_n_s_upstr_upper, NULL, __pyx_n_s_multidict__multidict, __pyx_d, ((PyObject *)__pyx_codeobj__12)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 30, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_CyFunction_NewEx(&__pyx_mdef_9multidict_10_multidict_4istr_3title, 0, __pyx_n_s_istr_title, NULL, __pyx_n_s_multidict__multidict, __pyx_d, ((PyObject *)__pyx_codeobj__12)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 30, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyObject_SetItem(__pyx_t_3, __pyx_n_s_upper, __pyx_t_4) < 0) __PYX_ERR(0, 30, __pyx_L1_error)
+  if (PyObject_SetItem(__pyx_t_3, __pyx_n_s_title, __pyx_t_4) < 0) __PYX_ERR(0, 30, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
   /* "multidict/_multidict.pyx":10
  * 
  * 
- * class upstr(str):             # <<<<<<<<<<<<<<
+ * class istr(str):             # <<<<<<<<<<<<<<
  * 
  *     """Case insensitive str."""
  */
-  __pyx_t_4 = __Pyx_Py3ClassCreate(__pyx_t_1, __pyx_n_s_upstr, __pyx_t_2, __pyx_t_3, NULL, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 10, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_Py3ClassCreate(__pyx_t_1, __pyx_n_s_istr, __pyx_t_2, __pyx_t_3, NULL, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 10, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_upstr, __pyx_t_4) < 0) __PYX_ERR(0, 10, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_istr, __pyx_t_4) < 0) __PYX_ERR(0, 10, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":86
+  /* "multidict/_multidict.pyx":34
+ * 
+ * 
+ * upstr = istr  # for relaxing backward compatibility problems             # <<<<<<<<<<<<<<
+ * 
+ * 
+ */
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_istr); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 34, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_upstr, __pyx_t_2) < 0) __PYX_ERR(0, 34, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+
+  /* "multidict/_multidict.pyx":89
  *         return s
  * 
  *     def getall(self, key, default=_marker):             # <<<<<<<<<<<<<<
  *         """Return a list of all values matching the key."""
- *         return self._getall(self._upper(key), default)
+ *         return self._getall(self._title(key), default)
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_marker); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 86, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_marker); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 89, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_k__2 = __pyx_t_2;
   __Pyx_GIVEREF(__pyx_t_2);
   __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":105
+  /* "multidict/_multidict.pyx":108
  *         raise KeyError('Key not found: %r' % key)
  * 
  *     def getone(self, key, default=_marker):             # <<<<<<<<<<<<<<
  *         """Get first value matching the key."""
- *         return self._getone(self._upper(key), default)
+ *         return self._getone(self._title(key), default)
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_marker); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 105, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_marker); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 108, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_k__3 = __pyx_t_2;
   __Pyx_GIVEREF(__pyx_t_2);
   __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":215
+  /* "multidict/_multidict.pyx":218
  *         return MultiDict(self._items)
  * 
  * abc.Mapping.register(MultiDictProxy)             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 215, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 218, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_Mapping); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 215, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_Mapping); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 218, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 215, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 218, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_3 = NULL;
@@ -14195,35 +14210,35 @@ PyMODINIT_FUNC PyInit__multidict(void)
     }
   }
   if (!__pyx_t_3) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDictProxy)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 215, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDictProxy)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 218, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
   } else {
-    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 215, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 218, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3); __pyx_t_3 = NULL;
     __Pyx_INCREF(((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDictProxy));
     __Pyx_GIVEREF(((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDictProxy));
     PyTuple_SET_ITEM(__pyx_t_4, 0+1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDictProxy));
-    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_4, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 215, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_4, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 218, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":240
+  /* "multidict/_multidict.pyx":243
  * 
  * 
  * abc.Mapping.register(CIMultiDictProxy)             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 240, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 243, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_Mapping); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 240, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_Mapping); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 243, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 240, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 243, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_4 = NULL;
@@ -14237,48 +14252,48 @@ PyMODINIT_FUNC PyInit__multidict(void)
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDictProxy)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 240, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDictProxy)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 243, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
   } else {
-    __pyx_t_3 = PyTuple_New(1+1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 240, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(1+1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 243, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_INCREF(((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDictProxy));
     __Pyx_GIVEREF(((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDictProxy));
     PyTuple_SET_ITEM(__pyx_t_3, 0+1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDictProxy));
-    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 240, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 243, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":368
+  /* "multidict/_multidict.pyx":371
  *         return default
  * 
  *     def pop(self, key, default=_marker):             # <<<<<<<<<<<<<<
  *         """Remove specified key and return the corresponding value.
  * 
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_marker); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 368, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_marker); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 371, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_k__6 = __pyx_t_2;
   __Pyx_GIVEREF(__pyx_t_2);
   __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":410
+  /* "multidict/_multidict.pyx":413
  * 
  * 
  * abc.MutableMapping.register(MultiDict)             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 410, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 413, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_MutableMapping); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 410, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_MutableMapping); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 413, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 410, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 413, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_3 = NULL;
@@ -14292,35 +14307,35 @@ PyMODINIT_FUNC PyInit__multidict(void)
     }
   }
   if (!__pyx_t_3) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDict)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 410, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDict)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 413, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
   } else {
-    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 410, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 413, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3); __pyx_t_3 = NULL;
     __Pyx_INCREF(((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDict));
     __Pyx_GIVEREF(((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDict));
     PyTuple_SET_ITEM(__pyx_t_4, 0+1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_MultiDict));
-    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_4, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 410, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_4, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 413, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":423
+  /* "multidict/_multidict.pyx":426
  * 
  * 
  * abc.MutableMapping.register(CIMultiDict)             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 423, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 426, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_MutableMapping); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 423, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_MutableMapping); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 426, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 423, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 426, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_4 = NULL;
@@ -14334,35 +14349,35 @@ PyMODINIT_FUNC PyInit__multidict(void)
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDict)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 423, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDict)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 426, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
   } else {
-    __pyx_t_3 = PyTuple_New(1+1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 423, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(1+1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 426, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_INCREF(((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDict));
     __Pyx_GIVEREF(((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDict));
     PyTuple_SET_ITEM(__pyx_t_3, 0+1, ((PyObject *)__pyx_ptype_9multidict_10_multidict_CIMultiDict));
-    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 423, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 426, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":555
+  /* "multidict/_multidict.pyx":558
  * 
  * 
  * abc.ItemsView.register(_ItemsView)             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 555, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 558, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_ItemsView); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 555, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_ItemsView); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 558, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 555, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 558, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_3 = NULL;
@@ -14376,35 +14391,35 @@ PyMODINIT_FUNC PyInit__multidict(void)
     }
   }
   if (!__pyx_t_3) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict__ItemsView)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 555, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict__ItemsView)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 558, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
   } else {
-    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 555, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 558, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3); __pyx_t_3 = NULL;
     __Pyx_INCREF(((PyObject *)__pyx_ptype_9multidict_10_multidict__ItemsView));
     __Pyx_GIVEREF(((PyObject *)__pyx_ptype_9multidict_10_multidict__ItemsView));
     PyTuple_SET_ITEM(__pyx_t_4, 0+1, ((PyObject *)__pyx_ptype_9multidict_10_multidict__ItemsView));
-    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_4, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 555, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_4, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 558, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":602
+  /* "multidict/_multidict.pyx":605
  * 
  * 
  * abc.ValuesView.register(_ValuesView)             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 602, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 605, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_ValuesView); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 602, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_ValuesView); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 605, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 602, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 605, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_4 = NULL;
@@ -14418,33 +14433,33 @@ PyMODINIT_FUNC PyInit__multidict(void)
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict__ValuesView)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 602, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict__ValuesView)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 605, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
   } else {
-    __pyx_t_3 = PyTuple_New(1+1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 602, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(1+1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 605, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_INCREF(((PyObject *)__pyx_ptype_9multidict_10_multidict__ValuesView));
     __Pyx_GIVEREF(((PyObject *)__pyx_ptype_9multidict_10_multidict__ValuesView));
     PyTuple_SET_ITEM(__pyx_t_3, 0+1, ((PyObject *)__pyx_ptype_9multidict_10_multidict__ValuesView));
-    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 602, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 605, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "multidict/_multidict.pyx":658
+  /* "multidict/_multidict.pyx":661
  * 
  * 
  * abc.KeysView.register(_KeysView)             # <<<<<<<<<<<<<<
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 658, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_abc); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 661, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_KeysView); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 658, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_KeysView); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 661, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 658, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_register); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 661, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_3 = NULL;
@@ -14458,16 +14473,16 @@ PyMODINIT_FUNC PyInit__multidict(void)
     }
   }
   if (!__pyx_t_3) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict__KeysView)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 658, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_1, ((PyObject *)__pyx_ptype_9multidict_10_multidict__KeysView)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 661, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
   } else {
-    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 658, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 661, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3); __pyx_t_3 = NULL;
     __Pyx_INCREF(((PyObject *)__pyx_ptype_9multidict_10_multidict__KeysView));
     __Pyx_GIVEREF(((PyObject *)__pyx_ptype_9multidict_10_multidict__KeysView));
     PyTuple_SET_ITEM(__pyx_t_4, 0+1, ((PyObject *)__pyx_ptype_9multidict_10_multidict__KeysView));
-    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_4, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 658, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_4, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 661, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }

--- a/multidict/_multidict.pyx
+++ b/multidict/_multidict.pyx
@@ -7,15 +7,15 @@ from operator import itemgetter
 _marker = object()
 
 
-class upstr(str):
+class istr(str):
 
     """Case insensitive str."""
 
-    __is_upstr__ = True
+    __is_istr__ = True
 
     def __new__(cls, val='',
                 encoding=sys.getdefaultencoding(), errors='strict'):
-        if getattr(val, '__is_upstr__', False):
+        if getattr(val, '__is_istr__', False):
             # Faster than instance check
             return val
         if isinstance(val, (bytes, bytearray, memoryview)):
@@ -24,11 +24,14 @@ class upstr(str):
             pass
         else:
             val = str(val)
-        ret = str.__new__(cls, val.upper())
+        ret = str.__new__(cls, val.title())
         return ret
 
-    def upper(self):
+    def title(self):
         return self
+
+
+upstr = istr  # for relaxing backward compatibility problems
 
 
 cdef _eq(self, other):
@@ -78,19 +81,19 @@ cdef class _Base:
         self._upstr = upstr
         self.marker = _marker
 
-    cdef str _upper(self, s):
+    cdef str _title(self, s):
         if type(s) is self._upstr:
             return <str>s
         return s
 
     def getall(self, key, default=_marker):
         """Return a list of all values matching the key."""
-        return self._getall(self._upper(key), default)
+        return self._getall(self._title(key), default)
 
     cdef _getall(self, str key, default):
         cdef list res
         cdef _Pair item
-        key = self._upper(key)
+        key = self._title(key)
         res = []
         for i in self._items:
             item = <_Pair>i
@@ -104,11 +107,11 @@ cdef class _Base:
 
     def getone(self, key, default=_marker):
         """Get first value matching the key."""
-        return self._getone(self._upper(key), default)
+        return self._getone(self._title(key), default)
 
     cdef _getone(self, str key, default):
         cdef _Pair item
-        key = self._upper(key)
+        key = self._title(key)
         for i in self._items:
             item = <_Pair>i
             if item._key == key:
@@ -120,21 +123,21 @@ cdef class _Base:
     # Mapping interface #
 
     def __getitem__(self, key):
-        return self._getone(self._upper(key), self.marker)
+        return self._getone(self._title(key), self.marker)
 
     def get(self, key, default=None):
         """Get first value matching the key.
 
         The method is alias for .getone().
         """
-        return self._getone(self._upper(key), default)
+        return self._getone(self._title(key), default)
 
     def __contains__(self, key):
-        return self._contains(self._upper(key))
+        return self._contains(self._title(key))
 
     cdef _contains(self, str key):
         cdef _Pair item
-        key = self._upper(key)
+        key = self._title(key)
         for i in self._items:
             item = <_Pair>i
             if item._key == key:
@@ -227,10 +230,10 @@ cdef class CIMultiDictProxy(MultiDictProxy):
         mdict = arg
         self._items = mdict._items
 
-    cdef str _upper(self, s):
+    cdef str _title(self, s):
         if type(s) is self._upstr:
             return <str>s
-        return s.upper()
+        return s.title()
 
     def copy(self):
         """Return a copy of itself."""
@@ -261,7 +264,7 @@ cdef class MultiDict(_Base):
             if isinstance(arg, _Base):
                 for i in (<_Base>arg)._items:
                     item = <_Pair>i
-                    key = self._upper(item._key)
+                    key = self._title(item._key)
                     value = item._value
                     if do_add:
                         self._add(key, value)
@@ -274,7 +277,7 @@ cdef class MultiDict(_Base):
                         key = item._key
                         value = item._value
                     else:
-                        key = self._upper(i[0])
+                        key = self._title(i[0])
                         value = i[1]
                     if do_add:
                         self._add(key, value)
@@ -291,7 +294,7 @@ cdef class MultiDict(_Base):
                             raise TypeError(
                                 "{} takes either dict or list of (key, value) "
                                 "tuples".format(name))
-                        key = self._upper(i[0])
+                        key = self._title(i[0])
                         value = i[1]
                     if do_add:
                         self._add(key, value)
@@ -300,7 +303,7 @@ cdef class MultiDict(_Base):
 
 
         for key, value in kwargs.items():
-            key = self._upper(key)
+            key = self._title(key)
             if do_add:
                 self._add(key, value)
             else:
@@ -315,7 +318,7 @@ cdef class MultiDict(_Base):
 
     def add(self, key, value):
         """Add the key and value, not overwriting any previous value."""
-        self._add(self._upper(key), value)
+        self._add(self._title(key), value)
 
     def copy(self):
         """Return a copy of itself."""
@@ -336,10 +339,10 @@ cdef class MultiDict(_Base):
     # MutableMapping interface #
 
     def __setitem__(self, key, value):
-        self._replace(self._upper(key), value)
+        self._replace(self._title(key), value)
 
     def __delitem__(self, key):
-        self._remove(self._upper(key), True)
+        self._remove(self._title(key), True)
 
     cdef _remove(self, str key, int raise_key_error):
         cdef _Pair item
@@ -357,7 +360,7 @@ cdef class MultiDict(_Base):
         """Return value for key, set value to default if key is not present."""
         cdef str skey
         cdef _Pair item
-        skey = self._upper(key)
+        skey = self._title(key)
         for i in self._items:
             item = <_Pair>i
             if item._key == skey:
@@ -376,7 +379,7 @@ cdef class MultiDict(_Base):
         cdef str skey
         cdef object value
         cdef _Pair item
-        skey = self._upper(key)
+        skey = self._title(key)
         value = None
         found = False
         for i in range(len(self._items) - 1, -1, -1):
@@ -413,10 +416,10 @@ abc.MutableMapping.register(MultiDict)
 cdef class CIMultiDict(MultiDict):
     """An ordered dictionary that can have multiple values for each key."""
 
-    cdef str _upper(self, s):
+    cdef str _title(self, s):
         if type(s) is self._upstr:
             return <str>s
-        return s.upper()
+        return s.title()
 
 
 

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -4,15 +4,15 @@ import sys
 _marker = object()
 
 
-class upstr(str):
+class istr(str):
 
     """Case insensitive str."""
 
-    __is_upstr__ = True
+    __is_istr__ = True
 
     def __new__(cls, val='',
                 encoding=sys.getdefaultencoding(), errors='strict'):
-        if getattr(val, '__is_upstr__', False):
+        if getattr(val, '__is_istr__', False):
             # Faster than instance check
             return val
         if isinstance(val, (bytes, bytearray, memoryview)):
@@ -21,11 +21,14 @@ class upstr(str):
             pass
         else:
             val = str(val)
-        val = val.upper()
+        val = val.title()
         return str.__new__(cls, val)
 
-    def upper(self):
+    def title(self):
         return self
+
+
+upstr = istr  # for relaxing backward compatibility problems
 
 
 class _Base:
@@ -104,24 +107,24 @@ class _CIBase(_Base):
 
     def getall(self, key, default=_marker):
         """Return a list of all values matching the key."""
-        return super().getall(key.upper(), default)
+        return super().getall(key.title(), default)
 
     def getone(self, key, default=_marker):
         """Get first value matching the key."""
-        return super().getone(key.upper(), default)
+        return super().getone(key.title(), default)
 
     def get(self, key, default=None):
         """Get first value matching the key.
 
         The method is alias for .getone().
         """
-        return super().get(key.upper(), default)
+        return super().get(key.title(), default)
 
     def __getitem__(self, key):
-        return super().__getitem__(key.upper())
+        return super().__getitem__(key.title())
 
     def __contains__(self, key):
-        return super().__contains__(key.upper())
+        return super().__contains__(key.title())
 
 
 class MultiDictProxy(_Base, abc.Mapping):
@@ -274,16 +277,16 @@ class CIMultiDict(_CIBase, MultiDict):
 
     def add(self, key, value):
         """Add the key and value, not overwriting any previous value."""
-        super().add(key.upper(), value)
+        super().add(key.title(), value)
 
     def __setitem__(self, key, value):
-        super().__setitem__(key.upper(), value)
+        super().__setitem__(key.title(), value)
 
     def __delitem__(self, key):
-        super().__delitem__(key.upper())
+        super().__delitem__(key.title())
 
     def _replace(self, key, value):
-        super()._replace(key.upper(), value)
+        super()._replace(key.title(), value)
 
     def pop(self, key, default=_marker):
         """Remove specified key and return the corresponding value.
@@ -292,12 +295,12 @@ class CIMultiDict(_CIBase, MultiDict):
         KeyError is raised.
 
         """
-        key = key.upper()
+        key = key.title()
         return super().pop(key, default)
 
     def setdefault(self, key, default=None):
         """Return value for key, set value to default if key is not present."""
-        key = key.upper()
+        key = key.title()
         return super().setdefault(key, default)
 
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -6,12 +6,12 @@ from multidict._multidict import (MultiDictProxy,
                                   MultiDict,
                                   CIMultiDictProxy,
                                   CIMultiDict,
-                                  upstr)
+                                  istr)
 from multidict._multidict_py import (MultiDictProxy as _MultiDictProxy,
                                      MultiDict as _MultiDict,
                                      CIMultiDictProxy as _CIMultiDictProxy,
                                      CIMultiDict as _CIMultiDict,
-                                     upstr as _upstr)
+                                     istr as _istr)
 
 
 class _Root:
@@ -20,7 +20,7 @@ class _Root:
 
     proxy_cls = None
 
-    upstr_cls = None
+    istr_cls = None
 
     def test_exposed_names(self):
         name = self.cls.__name__
@@ -318,7 +318,7 @@ class _CIMultiDictTests(_Root):
 
         self.assertEqual(d.getall('key'), ['value1', 'value2'])
 
-        with self.assertRaisesRegex(KeyError, "SOME_KEY"):
+        with self.assertRaisesRegex(KeyError, "Some_Key"):
             d.getall('some_key')
 
     def test_get(self):
@@ -328,12 +328,12 @@ class _CIMultiDictTests(_Root):
     def test_items__repr__(self):
         d = self.make_dict([('KEY', 'value1')], key='value2')
         self.assertEqual(repr(d.items()),
-                         "_ItemsView('KEY': 'value1', 'KEY': 'value2')")
+                         "_ItemsView('Key': 'value1', 'Key': 'value2')")
 
     def test_keys__repr__(self):
         d = self.make_dict([('KEY', 'value1')], key='value2')
         self.assertEqual(repr(d.keys()),
-                         "_KeysView('KEY', 'KEY')")
+                         "_KeysView('Key', 'Key')")
 
     def test_values__repr__(self):
         d = self.make_dict([('KEY', 'value1')], key='value2')
@@ -343,8 +343,8 @@ class _CIMultiDictTests(_Root):
 
 class _NonProxyCIMultiDict(_CIMultiDictTests):
 
-    def test_extend_with_upstr(self):
-        us = self.upstr_cls('a')
+    def test_extend_with_istr(self):
+        us = self.istr_cls('a')
         d = self.make_dict()
 
         d.extend([(us, 'val')])
@@ -557,7 +557,7 @@ class _CIMutableMultiDictTests(_Root):
 
         self.assertEqual(d.getall('key'), ['value1', 'value2'])
 
-        with self.assertRaisesRegex(KeyError, "SOME_KEY"):
+        with self.assertRaisesRegex(KeyError, "Some_Key"):
             d.getall('some_key')
 
     def test_ctor(self):
@@ -591,18 +591,18 @@ class _CIMutableMultiDictTests(_Root):
 
         self.assertEqual(
             str(d),
-            "<%s('KEY': 'one', 'KEY': 'two')>" % self.cls.__name__)
+            "<%s('Key': 'one', 'Key': 'two')>" % self.cls.__name__)
 
     def test_add(self):
         d = self.make_dict()
 
         self.assertEqual(d, {})
         d['KEY'] = 'one'
-        self.assertEqual(d, {'KEY': 'one'})
+        self.assertEqual(d, {'Key': 'one'})
         self.assertEqual(d.getall('key'), ['one'])
 
         d['KEY'] = 'two'
-        self.assertEqual(d, {'KEY': 'two'})
+        self.assertEqual(d, {'Key': 'two'})
         self.assertEqual(d.getall('key'), ['two'])
 
         d.add('KEY', 'one')
@@ -622,19 +622,19 @@ class _CIMutableMultiDictTests(_Root):
         self.assertEqual(4, len(d))
         itms = d.items()
         # we can't guarantee order of kwargs
-        self.assertTrue(('KEY', 'one') in itms)
-        self.assertTrue(('KEY', 'two') in itms)
-        self.assertTrue(('KEY', 3) in itms)
-        self.assertTrue(('FOO', 'bar') in itms)
+        self.assertTrue(('Key', 'one') in itms)
+        self.assertTrue(('Key', 'two') in itms)
+        self.assertTrue(('Key', 3) in itms)
+        self.assertTrue(('Foo', 'bar') in itms)
 
         other = self.make_dict(bar='baz')
-        self.assertEqual(other, {'BAR': 'baz'})
+        self.assertEqual(other, {'Bar': 'baz'})
 
         d.extend(other)
-        self.assertIn(('BAR', 'baz'), d.items())
+        self.assertIn(('Bar', 'baz'), d.items())
 
-        d.extend({'FOO': 'moo'})
-        self.assertIn(('FOO', 'moo'), d.items())
+        d.extend({'Foo': 'moo'})
+        self.assertIn(('Foo', 'moo'), d.items())
 
         d.extend()
         self.assertEqual(6, len(d))
@@ -662,8 +662,8 @@ class _CIMutableMultiDictTests(_Root):
         d = self.make_dict([('KEY', 'one'), ('key', 'two')], foo='bar')
 
         del d['key']
-        self.assertEqual(d, {'FOO': 'bar'})
-        self.assertEqual(list(d.items()), [('FOO', 'bar')])
+        self.assertEqual(d, {'Foo': 'bar'})
+        self.assertEqual(list(d.items()), [('Foo', 'bar')])
 
         with self.assertRaises(KeyError):
             del d['key']
@@ -680,8 +680,8 @@ class _CIMutableMultiDictTests(_Root):
         d.add('KEY', 'val1')
         d.add('key', 'val2')
 
-        self.assertEqual(('KEY', 'val1'), d.popitem())
-        self.assertEqual([('KEY', 'val2')], list(d.items()))
+        self.assertEqual(('Key', 'val1'), d.popitem())
+        self.assertEqual([('Key', 'val2')], list(d.items()))
 
     def test_popitem_empty_multidict(self):
         d = self.make_dict()
@@ -727,7 +727,7 @@ class _CIMutableMultiDictTests(_Root):
 
         d.update(key='val')
 
-        self.assertEqual([('KEY2', 'val3'), ('KEY', 'val')], list(d.items()))
+        self.assertEqual([('Key2', 'val3'), ('Key', 'val')], list(d.items()))
 
 
 class TestPyMultiDictProxy(_TestProxy, unittest.TestCase):
@@ -752,7 +752,7 @@ class PyCIMutableMultiDictTests(_CIMutableMultiDictTests, _NonProxyCIMultiDict,
                                 unittest.TestCase):
 
     cls = _CIMultiDict
-    upstr_cls = _upstr
+    istr_cls = _istr
     proxy_cls = _CIMultiDictProxy
 
 
@@ -778,11 +778,11 @@ class CIMutableMultiDictTests(_CIMutableMultiDictTests, _NonProxyCIMultiDict,
                               unittest.TestCase):
 
     cls = CIMultiDict
-    upstr_cls = upstr
+    istr_cls = istr
     proxy_cls = CIMultiDictProxy
 
 
-class _UpStrMixin:
+class _IStrMixin:
 
     cls = None
 
@@ -798,7 +798,7 @@ class _UpStrMixin:
         s = self.cls('A')
         self.assertEqual('A', s)
 
-    def test_ctor_upstr(self):
+    def test_ctor_istr(self):
         s = self.cls('A')
         s2 = self.cls(s)
         self.assertEqual('A', s)
@@ -810,21 +810,21 @@ class _UpStrMixin:
 
     def test_ctor_repr(self):
         s = self.cls(None)
-        self.assertEqual('NONE', s)
+        self.assertEqual('None', s)
 
-    def test_upper(self):
+    def test_title(self):
         s = self.cls('a')
-        self.assertIs(s, s.upper())
+        self.assertIs(s, s.title())
 
 
-class TestPyUpStr(_UpStrMixin, unittest.TestCase):
+class TestPyIStr(_IStrMixin, unittest.TestCase):
 
-    cls = _upstr
+    cls = _istr
 
 
-class TestUpStr(_UpStrMixin, unittest.TestCase):
+class TestIStr(_IStrMixin, unittest.TestCase):
 
-    cls = upstr
+    cls = istr
 
 
 class TypesMixin:


### PR DESCRIPTION
1. Rename `upstr` -> `istr`.
2. Use `.title()` instead of `.upper()` for internal representation.