### PR TITLE
Removed LICENSE filename extension @ MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE.txt
+include LICENSE
 include CHANGES.rst
 include README.rst
 include Makefile


### PR DESCRIPTION
Hello,
LICENSE file is not included correctly at MANIFEST.in file. I've removed the left over ".txt" extension. 

Thanks.
Carlos Carrizosa