### PR TITLE
Improve make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ clean:
 	rm -rf build
 	rm -rf cover
 	make -C docs clean SPHINXBUILD=false
-	python setup.py clean
+	python3 setup.py clean
 	rm -f multidict/_multidict.html
 	rm -f multidict/_multidict.c
 	rm -f multidict/_multidict.*.so

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean:
 	rm -rf coverage
 	rm -rf build
 	rm -rf cover
-	make -C docs clean
+	make -C docs clean SPHINXBUILD=false
 	python setup.py clean
 	rm -f multidict/_multidict.html
 	rm -f multidict/_multidict.c


### PR DESCRIPTION
While packaging multidict for OpenEmbedded I noticed several issues with `make clean`.

This is my proposal on how to fix them.