### PR TITLE
Added Python 3.6 for needed wheels for Python 3.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ environment:
       DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
 
 install:
   - "build.cmd %PYTHON%\\python.exe -m pip install wheel"


### PR DESCRIPTION
Without this pip installing aiohttp is absolutely sure to fail.

This is for yarl to install on python 3.6 as well. See PR https://github.com/aio-libs/yarl/pull/68