### PR TITLE
fix pickling of multidicts

### DIFF
--- a/multidict/_multidict.pyx
+++ b/multidict/_multidict.pyx
@@ -247,8 +247,13 @@ cdef class MultiDict(_Base):
 
     def __init__(self, *args, **kwargs):
         self._items = []
-
         self._extend(args, kwargs, 'MultiDict', True)
+
+    def __reduce__(self):
+        return (
+            self.__class__,
+            tuple(self.items()),
+        )
 
     cdef _extend(self, tuple args, dict kwargs, name, bint do_add):
         cdef _Pair item

--- a/multidict/_multidict.pyx
+++ b/multidict/_multidict.pyx
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import pickle
 import sys
 from collections import abc
 from collections.abc import Iterable, Set
@@ -258,7 +257,7 @@ cdef class MultiDictProxy(_Base):
         self._impl = base._impl
 
     def __reduce__(self):
-        raise pickle.PicklingError("Unsupported")
+        raise TypeError("can't pickle {} objects".format(self.__class__.__name__))
 
     def copy(self):
         """Return a copy of itself."""

--- a/multidict/_multidict.pyx
+++ b/multidict/_multidict.pyx
@@ -1,4 +1,4 @@
-import cython
+import pickle
 import sys
 from collections import abc
 from collections.abc import Iterable, Set
@@ -213,10 +213,7 @@ cdef class MultiDictProxy(_Base):
         self._items = base._items
 
     def __reduce__(self):
-        return (
-            self._base_class,
-            tuple([list(self.items())])
-        )
+        raise pickle.PicklingError("Unsupported")
 
     def copy(self):
         """Return a copy of itself."""

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -159,7 +159,7 @@ class MultiDictProxy(_Base, abc.Mapping):
         self._impl = arg._impl
 
     def __reduce__(self):
-        raise pickle.PicklingError("Unsupported")
+        raise TypeError("can't pickle {} objects".format(self.__class__.__name__))
 
     def copy(self):
         """Return a copy of itself."""

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -1,4 +1,5 @@
 from collections import abc
+import pickle
 import sys
 
 _marker = object()
@@ -137,6 +138,9 @@ class MultiDictProxy(_Base, abc.Mapping):
                     type(arg)))
 
         self._items = arg._items
+
+    def __reduce__(self):
+        raise pickle.PicklingError("Unsupported")
 
     def copy(self):
         """Return a copy of itself."""

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -158,7 +158,8 @@ class MultiDictProxy(_Base, abc.Mapping):
         self._impl = arg._impl
 
     def __reduce__(self):
-        raise TypeError("can't pickle {} objects".format(self.__class__.__name__))
+        raise TypeError("can't pickle {} objects".format(
+            self.__class__.__name__))
 
     def copy(self):
         """Return a copy of itself."""

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -1,6 +1,5 @@
 from array import array
 from collections import abc
-import pickle
 import sys
 
 _marker = object()

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -332,7 +332,7 @@ class _MultiDictTests(_BaseTest):
         d = self.make_dict([('a', 1), ('a', 2)])
 
         if isinstance(d, (MultiDictProxy, _MultiDictProxy)):
-            with self.assertRaises(pickle.PickleError):
+            with self.assertRaises(TypeError):
                 pbytes = pickle.dumps(d)
 
             return

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -313,7 +313,15 @@ class _MultiDictTests(_BaseTest):
 
     def test_pickle(self):
         d = self.make_dict([('a', 1), ('a', 2)])
-        pbytes = pickle.dumps(d)
+
+        if isinstance(d, (MultiDictProxy, _MultiDictProxy)):
+            with self.assertRaises(pickle.PickleError):
+                pbytes = pickle.dumps(d)
+                
+            return
+        else:
+            pbytes = pickle.dumps(d)
+
         obj = pickle.loads(pbytes)
         self.assertEqual(dict(d), dict(obj))
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -315,8 +315,7 @@ class _MultiDictTests(_BaseTest):
         d = self.make_dict([('a', 1), ('a', 2)])
         pbytes = pickle.dumps(d)
         obj = pickle.loads(pbytes)
-
-        self.assertEqual(d, obj)
+        self.assertEqual(dict(d), dict(obj))
 
 
 class _CIMultiDictTests(_Root):

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -334,7 +334,7 @@ class _MultiDictTests(_BaseTest):
         if isinstance(d, (MultiDictProxy, _MultiDictProxy)):
             with self.assertRaises(pickle.PickleError):
                 pbytes = pickle.dumps(d)
-                
+
             return
         else:
             pbytes = pickle.dumps(d)

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import pickle
 
 import multidict
 from multidict._multidict import (MultiDictProxy,
@@ -309,6 +310,13 @@ class _MultiDictTests(_BaseTest):
         d = self.make_dict([('key', 'value1')], key='value2')
         self.assertEqual(repr(d.values()),
                          "_ValuesView('value1', 'value2')")
+
+    def test_pickle(self):
+        d = self.make_dict([('a', 1), ('a', 2)])
+        pbytes = pickle.dumps(d)
+        obj = pickle.loads(pbytes)
+
+        self.assertEqual(d, obj)
 
 
 class _CIMultiDictTests(_Root):


### PR DESCRIPTION
fixes: https://github.com/aio-libs/multidict/issues/78
fixes when sending multidicts across processes

testcase:
```python
import asyncio
from concurrent.futures import ProcessPoolExecutor
from aiohttp.web import Response
from multidict import CIMultiDict


class JSONResponseException(Exception):
    def __init__(self, http_status_code:int, payload_object=None, response_headers: CIMultiDict = None):
        self.__http_status_code = http_status_code
        self.__payload_object = payload_object if payload_object is not None else {}
        self.__response_headers = response_headers if response_headers is not None else CIMultiDict()

    @property
    def http_status_code(self):
        return self.__http_status_code

    @property
    def payload_object(self):
        return self.__payload_object

    @property
    def response_headers(self):
        return self.__response_headers


def foo():
    err = JSONResponseException(404)
    raise err

async def main(loop):
    with ProcessPoolExecutor() as executor:
        try:
            await loop.run_in_executor(executor, foo)
        except JSONResponseException as e:
            return Response(body=b'',
                            headers=e.response_headers,
                            status=e.http_status_code,
                            content_type='application/json')

if __name__ == '__main__':
    _loop = asyncio.get_event_loop()
    _loop.run_until_complete(main(_loop))
```