### PR TITLE
Fix #79: fix ImportWarning on Python 3.6+

### DIFF
--- a/multidict/_multidict.pyx
+++ b/multidict/_multidict.pyx
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import sys
 from collections import abc
 from collections.abc import Iterable, Set


### PR DESCRIPTION
See https://github.com/cython/cython/issues/1720