### PR TITLE
Fix update order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@
 * Refactor internal data structures: main dict operations are about
   100% faster now.
 
+* Preserve order on multidict updates #68
+
+  Updates are `md[key] = val` and `md.update(...)` calls.
+
+  Now **the last** entry is replaced with new key/value pair, all
+  previous occurrences are removed.
+
+  If key is not present in dictionary the pair is added to the end
 
 2.1.7 (2017-05-29)
 ------------------

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -272,9 +272,29 @@ class MultiDict(_Base, abc.MutableMapping):
         self._extend(args, kwargs, 'update', self._replace)
 
     def _replace(self, key, value):
-        if key in self:
-            del self[key]
-        self.add(key, value)
+        identity = self._title(key)
+        items = self._items
+
+        for i in range(len(items)-1, -1, -1):
+            item = items[i]
+            if item[0] == identity:
+                items[i] = (identity, key, value)
+                # i points to last found item
+                rgt = i
+                break
+        else:
+            self._items.append((identity, key, value))
+            return
+
+        # remove all precending items
+        i = 0
+        while i < rgt:
+            item = items[i]
+            if item[0] == identity:
+                del items[i]
+                rgt -= 1
+            else:
+                i += 1
 
 
 class CIMultiDict(_CIBase, MultiDict):

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -582,7 +582,20 @@ class _BaseMutableMultiDictTests(_BaseTest):
 
         d.update(key='val')
 
-        self.assertEqual([('key2', 'val3'), ('key', 'val')], list(d.items()))
+        self.assertEqual([('key', 'val'), ('key2', 'val3')], list(d.items()))
+
+    def test_replacement_order(self):
+        d = self.make_dict()
+        d.add('key1', 'val1')
+        d.add('key2', 'val2')
+        d.add('key1', 'val3')
+        d.add('key2', 'val4')
+
+        d['key1'] = 'val5'
+
+        self.assertEqual([('key2', 'val2'),
+                          ('key1', 'val5'),
+                          ('key2', 'val4')], list(d.items()))
 
 
 class _CIMutableMultiDictTests(_Root):
@@ -771,7 +784,7 @@ class _CIMutableMultiDictTests(_Root):
 
         d.update(Key='val')
 
-        self.assertEqual([('key2', 'val3'), ('Key', 'val')], list(d.items()))
+        self.assertEqual([('Key', 'val'), ('key2', 'val3')], list(d.items()))
 
     def test_update_istr(self):
         d = self.make_dict()
@@ -781,7 +794,7 @@ class _CIMutableMultiDictTests(_Root):
 
         d.update({istr('key'): 'val'})
 
-        self.assertEqual([('key2', 'val3'), ('Key', 'val')], list(d.items()))
+        self.assertEqual([('Key', 'val'), ('key2', 'val3')], list(d.items()))
 
     def test_copy_istr(self):
         d = self.make_dict({istr('Foo'): 'bar'})

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -591,10 +591,10 @@ class _BaseMutableMultiDictTests(_BaseTest):
         d.add('key1', 'val3')
         d.add('key2', 'val4')
 
-        d['key1'] = 'val5'
+        d['key1'] = 'val'
 
         self.assertEqual([('key2', 'val2'),
-                          ('key1', 'val5'),
+                          ('key1', 'val'),
                           ('key2', 'val4')], list(d.items()))
 
 


### PR DESCRIPTION
Preserve order on multidict updates #68

Updates are `md[key] = val` and `md.update(...)` calls.

Now **the last** entry is replaced with new key/value pair, all
previous occurrences are removed.

If key is not present in dictionary the pair is added to the end
