### PR TITLE
Fix test runners integration mess

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -5,7 +5,6 @@ pyflakes>=1.0.0
 coverage==4.4.1
 sphinx==1.6.4
 alabaster>=0.6.2
-tox==2.8.2
 pytest-cov==2.5.1
 pygments==2.2.0
 mypy==0.521; python_version>="3.5" or platform_system != "Windows"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[aliases]
+test = pytest
+
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ def read(f):
 
 
 NEEDS_PYTEST = {'pytest', 'test'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner']
+pytest_runner = ['pytest-runner'] if NEEDS_PYTEST else []
 
 tests_require = ['pytest']
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import setup, Extension
 from distutils.errors import (CCompilerError, DistutilsExecError,
                               DistutilsPlatformError)
 from distutils.command.build_ext import build_ext
-from setuptools.command.test import test as TestCommand
 
 
 try:
@@ -65,14 +64,8 @@ def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
 
 
-class PyTest(TestCommand):
-    user_options = []
-
-    def run(self):
-        import subprocess
-        errno = subprocess.call([sys.executable, '-m', 'pytest', 'tests'])
-        raise SystemExit(errno)
-
+NEEDS_PYTEST = {'pytest', 'test'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner']
 
 tests_require = ['pytest']
 
@@ -98,10 +91,10 @@ args = dict(
     license='Apache 2',
     packages=['multidict'],
     tests_require=tests_require,
+    setup_requires=pytest_runner,
     include_package_data=True,
     ext_modules=extensions,
-    cmdclass=dict(build_ext=ve_build_ext,
-                  test=PyTest))
+    cmdclass=dict(build_ext=ve_build_ext))
 
 try:
     setup(**args)


### PR DESCRIPTION
* Add pytest-runner integration instead of self-crafted class
* Drop tox from requirements as nobody uses it (there's even no `tox.ini` present)

Includes #145