### PR TITLE
Enable OS X builds in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,22 +57,74 @@ _helpers:
     apt:
       packages:
       - libenchant-dev
+- &osx_python_base
+  stage: &stage_test_osx_name test under OS X (last chance to fail before deploy available)
+  os: osx
+  language: generic
+  python: &pypy3 pypy3.5-5.8.0
+  env:
+  - &env_pypy3 PYTHON_VERSION=pypy3.5-5.8.0
+  - &env_pyenv PYENV_ROOT="$HOME/.pyenv"
+  - &env_path PATH="$PYENV_ROOT/bin:$PATH"
+  before_install:
+  - brew update
+  - brew install readline xz
+  - &ensure_pyenv_installed |
+    if [ ! -f "$PYENV_ROOT/bin/pyenv" ]
+    then
+      rm -rf "$PYENV_ROOT"
+      curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
+      eval "$(pyenv init -)"
+      eval "$(pyenv virtualenv-init -)"
+    fi
+    eval "$(pyenv init -)"
+    eval "$(pyenv virtualenv-init -)"
+    pyenv update
+  - &install_python pyenv install --skip-existing --keep --verbose "$PYTHON_VERSION"
+  - &switch_python pyenv shell "$PYTHON_VERSION"
+  - &python_version python --version
+  before_cache:
+  - brew --cache
 
-# doesn't work on MacOSX out of the box -- the system has no Python installed
-# there's a workaround to use `language: generic` and install it, but it's slow
 os: linux
 
 jobs:
   fast_finish: true
 
   include:
-  - python: pypy3.5-5.8.0
+  - python: *pypy3
     env:
     - MULTIDICT_NO_EXTENSIONS=X
 
   - <<: *_doc_base
     script:
     - make doc-spelling
+
+  - <<: *osx_python_base
+    python: 3.4
+    env:
+    - PYTHON_VERSION=3.4.6
+    - *env_pyenv
+    - *env_path
+  - <<: *osx_python_base
+    python: 3.5
+    env:
+    - PYTHON_VERSION=3.5.3
+    - *env_pyenv
+    - *env_path
+  - <<: *osx_python_base
+    python: *mainstream_python
+    env:
+    - PYTHON_VERSION=3.6.1
+    - *env_pyenv
+    - *env_path
+  - <<: *osx_python_base
+    python: nightly
+    env:
+    - PYTHON_VERSION=3.7-dev
+    - *env_pyenv
+    - *env_path
+  # pypy3.5-5.8.0 fails under OS X because it's unsupported
 
   - stage: &deploy_stage_name deploy (PYPI upload itself runs only for tagged commits)
     <<: *_mainstream_python_base
@@ -108,6 +160,8 @@ jobs:
 stages:
 - *doc_stage_name
 - test
+- name: *stage_test_osx_name
+  if: type IN (api, cron) OR tag IS present
 - name: *deploy_stage_name
   # This will prevent deploy unless it's a tagged commit:
   if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,9 @@ os: linux
 
 jobs:
   fast_finish: true
+  allow_failures:
+  - os: osx
+    python: nightly
 
   include:
   - python: *pypy3


### PR DESCRIPTION
* Implemented at their own stage
* Triggered for cron builds, tagged builds or API calls (manually triggered via Travis CI web-interface)