### PR TITLE
Move annoying params from pytest to Makefile/appveyor conf

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ build_script:
   - "tools/build.cmd %PYTHON%\\python.exe setup.py sdist bdist_wheel"
 
 test_script:
-  - "tools/build.cmd %PYTHON%\\python.exe -m pytest"
+  - "tools/build.cmd %PYTHON%\\python.exe -m pytest tests --junitxml=junit-test-results.xml --cov-report term-missing:skip-covered --cov-report xml"
 
 after_test:
   - "tools/build.cmd %PYTHON%\\python.exe -m codecov -f coverage.xml -X gcov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 - pip install -r requirements/ci.txt
 
 script:
-- pytest
+- make test
 
 after_success:
 - codecov

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 norecursedirs=dist build .tox docs requirements tools
-addopts=-v -rxs --doctest-modules --junitxml=junit-test-results.xml --cov=multidict --cov-report term-missing:skip-covered --cov-report xml tests
+addopts=--doctest-modules --cov=multidict
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS


### PR DESCRIPTION
Now pytest.ini config doesn't allow to specify only one test file, it collects everything under 'tests' folder unconditionally.
Also xml output is useless when working on the project locally.