### PR TITLE
Tox based tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,17 +16,17 @@ environment:
     - PYTHON: "C:\\Python37-x64"
 
 install:
-  - "tools/build.cmd %PYTHON%\\python.exe -m pip install -U setuptools wheel codecov"
-  - tools/build.cmd %PYTHON%\\python.exe -m pip install -r requirements/ci.txt
+  - "tools/build.cmd %PYTHON%\\python.exe -m pip install -U tox"
+  - "tools/build.cmd %PYTHON%\\python.exe -m tox --notest"  # Pre-populate a virtualenv with dependencies
 
 build_script:
-  - "tools/build.cmd %PYTHON%\\python.exe setup.py sdist bdist_wheel"
+  - "tools/build.cmd %PYTHON%\\python.exe -m tox -e build-dists"
 
 test_script:
-  - "tools/build.cmd %PYTHON%\\python.exe -m pytest tests --junitxml=junit-test-results.xml --cov-report term-missing:skip-covered --cov-report xml"
+  - "tools/build.cmd %PYTHON%\\python.exe -m tox"
 
 after_test:
-  - "tools/build.cmd %PYTHON%\\python.exe -m codecov -f coverage.xml -X gcov"
+  - "tools/build.cmd %PYTHON%\\python.exe -m tox -e codecov"
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\junit-test-results.xml))
@@ -35,12 +35,15 @@ artifacts:
   - path: dist\*
 
 before_deploy:
-  - "tools/build.cmd %PYTHON%\\python.exe -m pip install twine"
+  - ps: >-
+      if($env:appveyor_repo_tag -eq 'True') {
+          Invoke-Expression "tools/build.cmd $env:PYTHON\\python.exe -m tox -e upload-dists --notest"
+      }
 
 deploy_script:
   - ps: >-
       if($env:appveyor_repo_tag -eq 'True') {
-          Invoke-Expression "$env:PYTHON\\python.exe -m twine upload dist/* --username $env:PYPI_USERNAME --password $env:PYPI_PASSWORD"
+          Invoke-Expression "tools/build.cmd $env:PYTHON\\python.exe -m tox -e upload-dists"
       }
 
 #notifications:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,8 @@ environment:
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python37-x64"
 
 install:
   - "tools/build.cmd %PYTHON%\\python.exe -m pip install -U setuptools wheel codecov"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,16 +24,16 @@ jobs:
         ' >> $BASH_ENV
 
     - run: |-
-        for py_ver in 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
+        for py_ver in 3.7.0 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
         do
           pyenv install "$py_ver" &
         done
         wait
-    - run: pyenv global 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
+    - run: pyenv global 3.7.0 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
 
     - run: pip install tox tox-pyenv
     - checkout
-    - run: tox -e py34,py35,py36,pypy3 -- -p no:sugar
+    - run: tox -e py34,py35,py36,py37,pypy3 -- -p no:sugar
 
   linux-build:
     docker:
@@ -42,7 +42,7 @@ jobs:
     steps:
     - checkout
     - run: pip install tox
-    - run: tox -e py34,py35,py36
+    - run: tox -e py34,py35,py36,py37
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ multidict/_istr.html
 /junit-test-results.xml
 
 .pytest_cache
+.testmondata

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,15 @@ python:
 - 3.6-dev
 - nightly
 
-install:
-- &upgrade_python_toolset pip install --upgrade pip wheel setuptools
-- pip install -r requirements/ci.txt
+install: &default_install
+- python -m pip install -U tox
+- python -m tox --notest  # Pre-populate a virtualenv with dependencies
 
-script:
-- make test
+script: &default_script
+- python -m tox
 
 after_success:
-- codecov
+- python -m tox -e codecov
 
 env:
   matrix:
@@ -43,14 +43,11 @@ _helpers:
   stage: &doc_stage_name docs, linting and pre-test checks
   <<: *_mainstream_python_base
   <<: *_reset_steps
-  install:
-  - *upgrade_python_toolset
-  - pip install -U -r requirements/dev.txt
+  install: *default_install
+  script: *default_script
 - &_doc_base
   <<: *_lint_base
-  install:
-  - *upgrade_python_toolset
-  - pip install -U -r requirements/doc.txt -r requirements/dev.txt
+  install: *default_install
   after_failure: cat docs/_build/spelling/output.txt
   addons:
     apt:
@@ -159,29 +156,22 @@ jobs:
   - <<: *_doc_base
     env:
     - docs <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- =
-    script:
-    - make doc-spelling
+    - TOXENV=doc-spelling
 
   - <<: *_lint_base
     env:
     - flake8 <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <=
-    script:
-    - flake8 multidict tests
+    - TOXENV=flake8
 
   - <<: *_lint_base
     env:
     - mypy <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- =
-    script:
-    - make mypy
+    - TOXENV=mypy
 
   - <<: *_lint_base
     env:
     - dist setup check <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- =
-    install:
-    - *upgrade_python_toolset
-    - pip install docutils
-    script:
-    - python setup.py check --metadata --restructuredtext --strict --verbose
+    - TOXENV=setup-check
 
   - <<: *osx_python_base
     python: 3.4
@@ -212,14 +202,13 @@ jobs:
   # Build and deploy manylinux1 binary wheels and source distribution
   - <<: *generic_deploy_base
     <<: *_reset_steps
-    env: Build and deploy to PYPI of manylinux1 binary wheels for all supported Pythons and source distribution=
+    env:
+    - Build and deploy to PYPI of manylinux1 binary wheels for all supported Pythons and source distribution=
+    - TOXENV=manylinux1
     dist: trusty
     group: edge
     services:
     - docker
-    script:
-    - ./tools/run_docker.sh "multidict"
-    - pip install -r requirements/ci.txt  # to compile *.c files by Cython
 
     # Build and deploy MacOS binary wheels for each OSX+Python combo possible
     # OS X 10.10, Python 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,10 @@ _helpers:
   - *env_py36
   - *env_pyenv
   - *env_path
+- &linux_py37
+  python: 3.7
+  dist: xenial
+  sudo: required
 
 os: linux
 
@@ -140,6 +144,14 @@ jobs:
     python: nightly
 
   include:
+  - <<: *linux_py37
+    env:
+      tests with extensions enabled <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <- <-:
+
+  - <<: *linux_py37
+    env:
+      MULTIDICT_NO_EXTENSIONS: X
+
   - python: *pypy3
     env:
     - MULTIDICT_NO_EXTENSIONS=X
@@ -190,9 +202,9 @@ jobs:
     - *env_pyenv
     - *env_path
   - <<: *osx_python_base
-    python: nightly
+    python: 3.7.0
     env:
-    - PYTHON_VERSION=3.7-dev
+    - PYTHON_VERSION=3.7.0
     - *env_pyenv
     - *env_path
   # pypy3.5-5.10.0 fails under OS X because it's unsupported
@@ -233,6 +245,13 @@ jobs:
     - *env_py36
     - *env_pyenv
     - *env_path
+    # OS X 10.10, Python 3.7
+  - <<: *osx_pypi_deploy_base_1010
+    env:
+    - *env_os1010_msg
+    - &env_py37 PYTHON_VERSION=3.7.0
+    - *env_pyenv
+    - *env_path
     # OS X 10.11, Python 3.4
   - <<: *osx_pypi_deploy_base_1011
     python: 3.4
@@ -256,6 +275,13 @@ jobs:
     - *env_py36
     - *env_pyenv
     - *env_path
+    # OS X 10.11, Python 3.7
+  - <<: *osx_pypi_deploy_base_1011
+    env:
+    - *env_os1011_msg
+    - *env_py37
+    - *env_pyenv
+    - *env_path
     # OS X 10.12, Python 3.4
   - <<: *osx_pypi_deploy_base_1012
     python: 3.4
@@ -277,6 +303,13 @@ jobs:
     env:
     - *env_os1012_msg
     - *env_py36
+    - *env_pyenv
+    - *env_path
+    # OS X 10.12, Python 3.7
+  - <<: *osx_pypi_deploy_base_1012
+    env:
+    - *env_os1012_msg
+    - *env_py37
     - *env_pyenv
     - *env_path
 

--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,12 @@ profile-dev-base: .install-deps
 
 
 cov-dev: profile-dev-base rmcache mypy
-	pytest --cov=multidict --cov-report=term --cov-report=html tests 
+	pytest --cov-report=term --cov-report=html tests 
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 cov-dev-full: profile-dev-base rmcache mypy
-	AIOHTTPMULTIDICT_NO_EXTENSIONS=1 pytest --cov=multidict --cov-append tests 
-	pytest --cov=multidict --cov-report=term --cov-report=html tests 
+	MULTIDICT_NO_EXTENSIONS=1 pytest --cov-append tests 
+	pytest --cov-report=term --cov-report=html tests 
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 clean:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
-norecursedirs=dist build .tox docs requirements tools
-addopts=--doctest-modules --cov=multidict
-doctest_optionflags=ALLOW_UNICODE ELLIPSIS
+testpaths = tests
+norecursedirs = dist build .tox docs requirements tools
+addopts = --doctest-modules --cov=multidict --cov-report term-missing:skip-covered --cov-report xml --junitxml=junit-test-results.xml -v
+doctest_optionflags = ALLOW_UNICODE ELLIPSIS

--- a/shippable.yml
+++ b/shippable.yml
@@ -11,6 +11,5 @@ env:
 
 build:
   ci:
-  - pip install --upgrade pip wheel setuptools
-  - pip install -r requirements/ci.txt
-  - make test
+  - pip install -U tox
+  - python -m tox

--- a/tools/build-wheels.sh
+++ b/tools/build-wheels.sh
@@ -6,7 +6,7 @@ fi
 set -euo pipefail
 # ref: https://coderwall.com/p/fkfaqq/safer-bash-scripts-with-set-euxo-pipefail
 
-PYTHON_VERSIONS="cp34-cp34m cp35-cp35m cp36-cp36m"
+PYTHON_VERSIONS="cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m"
 
 # Avoid creation of __pycache__/*.py[c|o]
 export PYTHONDONTWRITEBYTECODE=1

--- a/tox.ini
+++ b/tox.ini
@@ -1,44 +1,116 @@
 [tox]
-minversion = 2.4
+minversion = 3.0.0
 envlist = python
 
 [testenv]
-deps = -rrequirements/ci.txt
+whitelist_externals =
+    rm
+deps =
+    -r requirements/dev.txt
+    setuptools
+    wheel
 commands =
-    rm -rf .eggs/
-    pytest tests/ --cov-report term-missing:skip-covered --cov-report xml {posargs}
-    codecov -f coverage.xml -X gcov
+    rm -rf .eggs/ multidict/*.so multidict/_multidict.c
+    pytest {posargs}
 usedevelop = True
 
 passenv =
-  CI
-  TRAVIS
-  TRAVIS_*
-  APPVEYOR
-  APPVEYOR_*
-  CIRCLECI
-  CIRCLE_*
-  PYTHONDONTWRITEBYTECODE
+    CI
+    TRAVIS
+    TRAVIS_*
+    APPVEYOR
+    APPVEYOR_*
+    CIRCLECI
+    CIRCLE_*
+    MULTIDICT_NO_EXTENSIONS
 setenv =
-  PYTHONDONTWRITEBYTECODE=x
+    PYTHONDONTWRITEBYTECODE=x
 
 [testenv:watch]
 deps =
+    {[testenv]deps}
     pytest-testmon
     pytest-watch
 commands = ptw --runner=pytest -- --testmon
 
+[testenv:codecov]
+skipsdist = True
+skip_install = True
+deps = codecov
+commands = codecov -f coverage.xml -X gcov
+
+[testenv:flake8]
+skipsdist = True
+skip_install = True
+deps = flake8
+commands = flake8 multidict tests
+
+[testenv:mypy]
+skipsdist = True
+skip_install = True
+deps = mypy
+commands = mypy multidict tests
+
+[testenv:manylinux1]
+whitelist_externals =
+    bash
+skipsdist = True
+skip_install = True
+deps =
+commands = bash tools/run_docker.sh "multidict"
+
+[testenv:doc-spelling]
+whitelist_externals =
+    make
+skipsdist = True
+skip_install = True
+deps =
+    -r requirements/doc.txt
+commands = make -C docs spelling
+
+[testenv:doc-html]
+skipsdist = True
+skip_install = True
+whitelist_externals =
+    make
+deps =
+commands = make -C docs html
+
 [testenv:pre-commit]
+skipsdist = True
+skip_install = True
 deps = pre-commit
 commands = pre-commit run --all-files {posargs}
 
 [testenv:pre-commit-pep257]
+skipsdist = True
+skip_install = True
 deps = pre-commit
 commands =
     pre-commit run --config .pre-commit-config.yaml.pep257 --all-files {posargs}
 
 [testenv:setup-check]
-usedevelop = False
+skipsdist = True
+skip_install = True
 deps = docutils
 commands =
-    python -m setup checkdocs check --metadata --restructuredtext --strict --verbose
+    python -m setup check --metadata --restructuredtext --strict --verbose
+
+[testenv:build-dists]
+skipsdist = True
+skip_install = True
+deps =
+    -U
+    setuptools
+    wheel
+commands =
+    python -m setup sdist bdist_wheel
+
+[testenv:upload-dists]
+skipsdist = True
+skip_install = True
+deps =
+    -U
+    twine
+commands =
+    python -m twine upload dist/* --username "{env:PYPI_USERNAME:aio-libs-bot}" --password "{env:PYPI_PASSWORD}" --skip-existing

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,11 @@ passenv =
 setenv =
     PYTHONDONTWRITEBYTECODE=x
 
+[testenv:profile-dev]
+setenv =
+    {[testenv]setenv}
+    PROFILE_BUILD=x
+
 [testenv:watch]
 deps =
     {[testenv]deps}


### PR DESCRIPTION
This attempts to make tox a single source of truth for all the test envs (mainly CI, but it wires it into GNU make as well.

I didn't test deployment flow yet, but current results look promising in terms of clearly separating different envs/tasks + there's a nice ~10% speedup in Travis.