### PR TITLE
Exclude _istr.pyd from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,4 +11,5 @@ exclude multidict/_multidict.html
 exclude multidict/_multidict.*.so
 exclude multidict/_multidict.pyd
 exclude multidict/_multidict.*.pyd
+exclude multidict/_istr.pyd
 prune docs/_build


### PR DESCRIPTION
`multidict-4.4.0.tar.gz` on PyPI contains `_istr.pyd`.