### PR TITLE
Fix TypeError with MultiDictProxy

### DIFF
--- a/multidict/_multidict.pyx
+++ b/multidict/_multidict.pyx
@@ -142,11 +142,10 @@ cdef class MultiDictProxy(_Base):
         cdef _Base base
         if not isinstance(arg, self._proxy_classes):
             raise TypeError(
-                'ctor requires {} instance'
-                ', not {}'.format(
-                    ' or '.join(self._proxy_classes),
-                    type(arg)))
-
+                "ctor requires {} instance, not {}".format(
+                    " or ".join(x.__name__ for x in self._proxy_classes), type(arg)
+                )
+            )
         base = arg
         self._impl = base._impl
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -45,11 +45,20 @@ def test_create_cimultidict_proxy_from_cimultidict_proxy_from_ci(_multidict):
 
 
 def test_create_cimultidict_proxy_from_nonmultidict(_multidict):
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError,
+        match=(
+            "ctor requires CIMultiDict or CIMultiDictProxy instance, "
+            "not <class 'dict'>"
+        ),
+    ):
         _multidict.CIMultiDictProxy({})
 
 
 def test_create_ci_multidict_proxy_from_multidict(_multidict):
     d = _multidict.MultiDict(key='val')
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=(
+            "ctor requires CIMultiDict or CIMultiDictProxy instance, "
+            "not <class 'multidict._multidict.*.MultiDict'>"
+    )):
         _multidict.CIMultiDictProxy(d)


### PR DESCRIPTION
Previously it would raise:

> TypeError('sequence item 0: expected str instance, type found')

Uses a fixed list/string with non-cython version: https://github.com/blueyed/multidict/blob/44e9ffd672f278499e0f4ef293291d66fd95cd03/multidict/_multidict_py.py#L171-L173