### PR TITLE
Enable windows factors in gh workflows

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,6 +20,8 @@ jobs:
         - ubuntu-18.04
         - ubuntu-16.04
         - macOS-10.14
+        - windows-2019
+        - windows-2016
         env:
         - TOXENV: python
         - TOXENV: python

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -40,6 +40,8 @@ jobs:
     - name: 'Initialize tox envs: ${{ matrix.env.TOXENV }}'
       run: |
         python -m tox --parallel 0 --notest -vv
+        ls -R
+        pwd
       env: ${{ matrix.env }}
     - name: Test with tox
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -45,7 +45,5 @@ jobs:
       env: ${{ matrix.env }}
     - name: Test with tox
       run: |
-        mv multidict multidict.bak
         python -m tox --parallel 0 -- -ra
-        mv multidict.bak multidict
       env: ${{ matrix.env }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -43,5 +43,5 @@ jobs:
       env: ${{ matrix.env }}
     - name: Test with tox
       run: |
-        python -m tox --parallel 0
+        python -m tox --parallel 0 -- -ra
       env: ${{ matrix.env }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,8 +24,8 @@ jobs:
         - windows-2019
         - windows-2016
         env:
-        - TOXENV: python
-        - TOXENV: python
+        - TOXENV: ci
+        - TOXENV: ci
           MULTIDICT_NO_EXTENSIONS: X
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       # max-parallel: 5
       matrix:
         python-version:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,7 +39,7 @@ jobs:
         python -m pip install --upgrade tox
     - name: 'Initialize tox envs: ${{ matrix.env.TOXENV }}'
       run: |
-        python -m tox --parallel auto --notest -vv
+        python -m tox --parallel 0 --notest -vv
       env: ${{ matrix.env }}
     - name: Test with tox
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,9 +39,11 @@ jobs:
         python -m pip install --upgrade tox
     - name: 'Initialize tox envs: ${{ matrix.env.TOXENV }}'
       run: |
-        python -m tox --parallel auto --notest
+        python -m tox --parallel auto --notest -vv
       env: ${{ matrix.env }}
     - name: Test with tox
       run: |
+        mv multidict multidict.bak
         python -m tox --parallel 0 -- -ra
+        mv multidict.bak multidict
       env: ${{ matrix.env }}

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,9 @@ passenv =
 setenv =
     PYTHONDONTWRITEBYTECODE=x
 
+[testenv:ci]
+usedevelop = False
+
 [testenv:profile-dev]
 setenv =
     {[testenv]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     -r requirements/dev.txt
 commands =
     rm -rf .eggs/ multidict/*.so multidict/_multidict.c
-    pytest {posargs}
+    {envpython} -m pytest {posargs}
 usedevelop = True
 
 passenv =
@@ -27,7 +27,16 @@ setenv =
     PYTHONDONTWRITEBYTECODE=x
 
 [testenv:ci]
+isolated_build = True
+skipsdist = True
+skip_install = True
 usedevelop = False
+changedir = {envtmpdir}
+commands_pre =
+    sh -c 'cd "{toxinidir}"; {[testenv:build-dists]commands} --dist-dir="{envtmpdir}/dist"'
+    pip install -f "{envtmpdir}/dist" --no-index multidict
+commands =
+    {[testenv]commands} "{toxinidir}/tests"
 
 [testenv:profile-dev]
 setenv =


### PR DESCRIPTION
@gyermolenko any ideas why `tests/test_pickle.py::test_load_from_file` could be failing under windows2016? https://github.com/aio-libs/multidict/runs/214634068#step:6:611