### PR TITLE
Fix typo in Github issues link in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ args = dict(
         "CI: Azure Pipelines": "https://dev.azure.com/aio-libs/multidict/_build",
         "Coverage: codecov": "https://codecov.io/github/aio-libs/multidict",
         "Docs: RTD": "https://multidict.readthedocs.io",
-        "GitHub: issues": "https://github.com/aio-libs/mutlidict/issues",
+        "GitHub: issues": "https://github.com/aio-libs/multidict/issues",
         "GitHub: repo": "https://github.com/aio-libs/multidict",
     },
     license="Apache 2",


### PR DESCRIPTION
## What do these changes do?

Fix a typo in the Github issues link which causes it to be broken in the PyPI website.

## Are there changes in behavior for the user?

No

## Related issue number

N/A

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
