### PR TITLE
Embed pair_list_t structure into MultiDict Python object

### DIFF
--- a/CHANGES/395.feature
+++ b/CHANGES/395.feature
@@ -1,0 +1,1 @@
+Embed pair_list_t structure into MultiDict Python object

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ all: test
 .flake: .install-deps $(shell find multidict -type f) \
                       $(shell find tests -type f)
 	flake8 multidict tests
-	python setup.py check -rms
 	@if ! isort -c -rc multidict tests; then \
             echo "Import sort errors, run 'make isort' to fix them!!!"; \
             isort --diff -rc multidict tests; \

--- a/multidict/_multidict_c.h
+++ b/multidict/_multidict_c.h
@@ -6,10 +6,11 @@ extern "C" {
 #endif
 
 #include <Python.h>
+#include "_pair_list.h"
 
-typedef struct {
-    PyObject_HEAD
-    PyObject *impl;
+typedef struct {  // 16 or 24 for GC prefix
+    PyObject_HEAD  // 16
+    pair_list_t pairs;
 } MultiDictObject;
 
 typedef struct {

--- a/multidict/_multidict_views.c
+++ b/multidict/_multidict_views.c
@@ -74,7 +74,7 @@ multidict_view_clear(_Multidict_ViewObject *self)
 static Py_ssize_t
 multidict_view_len(_Multidict_ViewObject *self)
 {
-    return pair_list_len(((MultiDictObject*)self->md)->impl);
+    return pair_list_len(&((MultiDictObject*)self->md)->pairs);
 }
 
 static PyObject *
@@ -158,7 +158,7 @@ multidict_itemsview_new(PyObject *md)
 static PyObject *
 multidict_itemsview_iter(_Multidict_ViewObject *self)
 {
-    return multidict_items_iter_new(((MultiDictObject*)self->md)->impl);
+    return multidict_items_iter_new(((MultiDictObject*)self->md));
 }
 
 static PyObject *
@@ -312,7 +312,7 @@ multidict_keysview_new(PyObject *md)
 static PyObject *
 multidict_keysview_iter(_Multidict_ViewObject *self)
 {
-    return multidict_keys_iter_new(((MultiDictObject*)self->md)->impl);
+    return multidict_keys_iter_new(((MultiDictObject*)self->md));
 }
 
 static PyObject *
@@ -348,7 +348,7 @@ static PyMethodDef multidict_keysview_methods[] = {
 static int
 multidict_keysview_contains(_Multidict_ViewObject *self, PyObject *key)
 {
-    return pair_list_contains(((MultiDictObject*)self->md)->impl, key);
+    return pair_list_contains(&((MultiDictObject*)self->md)->pairs, key);
 }
 
 static PySequenceMethods multidict_keysview_as_sequence = {
@@ -414,7 +414,7 @@ multidict_valuesview_new(PyObject *md)
 static PyObject *
 multidict_valuesview_iter(_Multidict_ViewObject *self)
 {
-    return multidict_values_iter_new(((MultiDictObject*)self->md)->impl);
+    return multidict_values_iter_new(((MultiDictObject*)self->md));
 }
 
 static PyObject *

--- a/multidict/_pair_list.h
+++ b/multidict/_pair_list.h
@@ -9,46 +9,74 @@ extern "C" {
 #include <stdint.h>
 #include "Python.h"
 
-PyObject* pair_list_new(void);
-PyObject* ci_pair_list_new(void);
+// INTERNAL structures
 
-Py_ssize_t pair_list_len(PyObject *list);
+typedef PyObject * (*calc_identity_func)(PyObject *key);
 
-int pair_list_clear(PyObject *list);
+typedef struct pair {
+    PyObject  *identity;  // 8
+    PyObject  *key;       // 8
+    PyObject  *value;     // 8
+    Py_hash_t  hash;      // 8
+} pair_t;
 
-int pair_list_add(PyObject *list, PyObject *key, PyObject *value);
 
-int _pair_list_next(PyObject *list, Py_ssize_t *ppos,
+typedef struct pair_list {  // 40
+    Py_ssize_t  capacity;   // 8
+    Py_ssize_t  size;       // 8
+    uint64_t  version;      // 8
+    calc_identity_func calc_identity;  // 8
+    pair_t *pairs;          // 8
+} pair_list_t;
+
+
+// INTERNAL API
+
+int pair_list_init(pair_list_t *list);
+int ci_pair_list_init(pair_list_t *list);
+
+Py_ssize_t pair_list_len(pair_list_t *list);
+
+int pair_list_clear(pair_list_t *list);
+
+int pair_list_add(pair_list_t *list, PyObject *key, PyObject *value);
+
+int _pair_list_next(pair_list_t *list, Py_ssize_t *ppos,
                     PyObject **pidentity,
                     PyObject **pkey, PyObject **pvalue, Py_hash_t *hash);
 
-int pair_list_next(PyObject *list, Py_ssize_t *ppos,
+int pair_list_next(pair_list_t *list, Py_ssize_t *ppos,
                    PyObject **pidentity,
                    PyObject **pkey, PyObject **pvalue);
 
-int pair_list_contains(PyObject *list, PyObject *key);
+int pair_list_contains(pair_list_t *list, PyObject *key);
 
-PyObject* pair_list_get_one(PyObject *list, PyObject *key);
-PyObject* pair_list_get_all(PyObject *list, PyObject *key);
+PyObject* pair_list_get_one(pair_list_t *list, PyObject *key);
+PyObject* pair_list_get_all(pair_list_t *list, PyObject *key);
 
-int pair_list_del(PyObject *list, PyObject *key);
+int pair_list_del(pair_list_t *list, PyObject *key);
 
-PyObject* pair_list_set_default(PyObject *list, PyObject *key, PyObject *value);
+PyObject* pair_list_set_default(pair_list_t *list, PyObject *key, PyObject *value);
 
-PyObject* pair_list_pop_one(PyObject *list, PyObject *key);
-PyObject* pair_list_pop_all(PyObject *list, PyObject *key);
-PyObject* pair_list_pop_item(PyObject *list);
+PyObject* pair_list_pop_one(pair_list_t *list, PyObject *key);
+PyObject* pair_list_pop_all(pair_list_t *list, PyObject *key);
+PyObject* pair_list_pop_item(pair_list_t *list);
 
-int pair_list_replace(PyObject *op, PyObject *key, PyObject *value);
+int pair_list_replace(pair_list_t *op, PyObject *key, PyObject *value);
 
-int pair_list_update(PyObject *op1, PyObject *op2);
-int pair_list_update_from_seq(PyObject *op1, PyObject *op2);
+int pair_list_update(pair_list_t *op1, pair_list_t *op2);
+int pair_list_update_from_seq(pair_list_t *op1, PyObject *op2);
 
-int pair_list_eq_to_mapping(PyObject *op, PyObject *other);
+int pair_list_eq_to_mapping(pair_list_t *list, PyObject *other);
 
-uint64_t pair_list_version(PyObject *list);
+uint64_t pair_list_version(pair_list_t *list);
 
-int pair_list_init(PyObject * istr_type);
+int pair_list_traverse(pair_list_t *op, visitproc visit, void *arg);
+int pair_list_clear(pair_list_t *op);
+void pair_list_dealloc(pair_list_t *list);
+
+
+int pair_list_global_init(PyObject * istr_type);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
It removes one indirection level.
No need for extra memalloc, plus multidict with embedded pair-list fits CPU cache a little better.