### PR TITLE
Embed the pairs buffer 

### DIFF
--- a/CHANGES/396.feature
+++ b/CHANGES/396.feature
@@ -1,0 +1,1 @@
+Embed multidict pairs for small dictionaries to amortize the memory usage.

--- a/Makefile
+++ b/Makefile
@@ -102,12 +102,7 @@ clean:
 	rm -rf htmlcov
 	make -C docs clean SPHINXBUILD=false
 	python3 setup.py clean
-	rm -f multidict/_multidict.html
-	rm -f multidict/_multidict.c
-	rm -f multidict/_multidict.*.so
-	rm -f multidict/_multidict.*.pyd
-	rm -f multidict/_multidict_c.*.so
-	rm -f multidict/_multidict_c.*.pyd
-	rm -f multidict/_istr.*.so
-	rm -f multidict/_istr.*.pyd
+	rm -f multidict/*.html
+	rm -f multidict/*.so
+	rm -f multidict/*.pyd
 	rm -rf .tox

--- a/multidict/__init__.py
+++ b/multidict/__init__.py
@@ -30,7 +30,6 @@ try:
         CIMultiDictProxy,
         MultiDict,
         CIMultiDict,
-        upstr,
         istr,
     )
 except ImportError:  # pragma: no cover
@@ -39,6 +38,7 @@ except ImportError:  # pragma: no cover
         CIMultiDictProxy,
         MultiDict,
         CIMultiDict,
-        upstr,
         istr,
     )
+
+upstr = istr

--- a/multidict/_pair_list.c
+++ b/multidict/_pair_list.c
@@ -197,10 +197,20 @@ pair_list_dealloc(pair_list_t *list)
         Py_XDECREF(pair->value);
     }
 
+    /*
+    Strictly speaking, resetting size and capacity and
+    assigning pairs to buffer is not necessary.
+    Do it to consistency and idemotency.
+    The cleanup doesn't hurt performance.
+    !!!
+    !!! The buffer deletion is crucial though.
+    !!!
+    */
     list->size = 0;
     if (list->pairs != list->buffer) {
         PyMem_Del(list->pairs);
-        list->pairs = NULL;
+        list->pairs = list->buffer;
+        list->capacity = EMBEDDED_CAPACITY;
     }
 }
 

--- a/multidict/_pair_list.c
+++ b/multidict/_pair_list.c
@@ -94,7 +94,7 @@ pair_list_grow(pair_list_t *list)
     Py_ssize_t new_capacity;
     pair_t *new_pairs;
 
-    if (list_size < list->capacity) {
+    if (list->size < list->capacity) {
         return 0;
     }
 
@@ -1178,7 +1178,12 @@ pair_list_clear(pair_list_t *list)
         Py_CLEAR(pair->value);
     }
     list->size = 0;
-    return pair_list_resize(list, 0);
+    if (list->pairs != list->buffer) {
+        PyMem_Del(list->pairs);
+        list->pairs = list->buffer;
+    }
+
+    return 0;
 }
 
 

--- a/multidict/_pair_list.h
+++ b/multidict/_pair_list.h
@@ -20,6 +20,21 @@ typedef struct pair {
     Py_hash_t  hash;      // 8
 } pair_t;
 
+/* Note about the structure size
+With 29 pairs the MultiDict object size is slightly less than 1KiB
+(1000-1008 bytes depending on Python version,
+plus extra 12 bytes for memory allocator internal structures).
+As the result the max reserved size is 1020 bytes at most.
+
+To fit into 512 bytes, the structure can contain only 13 pairs
+which is too small, e.g. https://www.python.org returns 16 headers
+(9 of them are caching proxy information though).
+
+The embedded buffer intention is to fit the vast majority of possible
+HTTP headers into the buffer without allocating an extra memory block.
+*/
+
+#define EMBEDDED_CAPACITY 29
 
 typedef struct pair_list {  // 40
     Py_ssize_t  capacity;   // 8
@@ -27,6 +42,7 @@ typedef struct pair_list {  // 40
     uint64_t  version;      // 8
     calc_identity_func calc_identity;  // 8
     pair_t *pairs;          // 8
+    pair_t buffer[EMBEDDED_CAPACITY];
 } pair_list_t;
 
 

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -232,6 +232,17 @@ class TestMutableMultiDict:
         with pytest.raises(KeyError, match="key"):
             d.popall("key")
 
+    def test_large_multidict_resizing(self, cls):
+        SIZE = 1024
+        d = cls()
+        for i in range(SIZE):
+            d["key" + str(i)] = i
+
+        for i in range(SIZE - 1):
+            del d["key" + str(i)]
+
+        assert {"key" + str(SIZE - 1): SIZE - 1} == d
+
 
 class TestCIMutableMultiDict:
     @pytest.fixture


### PR DESCRIPTION
To amortize the memory usage of multidicts smaller than 29 elements
I expect that only very few HTTP messages have a bigger amount of headers, 
the same for GET query arguments or multipart forms.
