### PR TITLE
Fix dereference null pointer.

### DIFF
--- a/multidict/_multidict_c.c
+++ b/multidict/_multidict_c.c
@@ -1194,7 +1194,7 @@ static void
 multidict_proxy_tp_dealloc(MultiDictProxyObject *self)
 {
     PyObject_GC_UnTrack(self);
-    Py_DECREF(self->md);
+    Py_XDECREF(self->md);
     PyObject_GC_Del(self);
 }
 


### PR DESCRIPTION
I catch segfault on python 3.7.

If I am right the problem in `multidict_proxy_tp_clear` which invoke` Py_CLEAR` and set `self-> md` to` NULL`.