### PR TITLE
Merge istr into _multidict module

### DIFF
--- a/CHANGES/409.feature
+++ b/CHANGES/409.feature
@@ -1,0 +1,1 @@
+Merge `multidict._istr` back with `multidict._multidict`.

--- a/benchmarks/becnhmark.py
+++ b/benchmarks/becnhmark.py
@@ -132,11 +132,14 @@ if __name__ == '__main__':
             continue
 
         runner.timeit(name('setitem istr'),
-                      SET_ITEM, imports + INIT + FILL,
+                      SET_ITEM, imports + INIT + FILL_ISTR,
                       inner_loops=inner_loops)
         runner.timeit(name('getitem istr'),
-                      GET_ITEM, imports + INIT + FILL,
+                      GET_ITEM, imports + INIT + FILL_ISTR,
                       inner_loops=inner_loops)
         runner.timeit(name('add str'),
                       ADD, imports + INIT + FILL + SETUP_ADD,
+                      inner_loops=inner_loops)
+        runner.timeit(name('add istr'),
+                      ADD, imports + INIT + FILL_ISTR + SETUP_ADD,
                       inner_loops=inner_loops)

--- a/multidict/_istr.h
+++ b/multidict/_istr.h
@@ -12,6 +12,9 @@ typedef struct {
     PyObject * canonical;
 } istrobject;
 
+
+PyObject* istr_init(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -1,6 +1,7 @@
 #include "_multidict.h"
 #include "_pair_list.h"
 #include "_multidict_views.h"
+#include "_istr.h"
 
 #include <structmember.h>
 
@@ -1418,8 +1419,10 @@ PyInit__multidict()
         goto fail;                              \
     }
 
-    WITH_MOD("multidict._istr");
-    GET_MOD_ATTR(istr, "istr");
+    istr = istr_init();
+    if (istr == NULL) {
+        goto fail;
+    }
 
     WITH_MOD("collections.abc");
     GET_MOD_ATTR(collections_abc_mapping, "Mapping");

--- a/multidict/_multidict_iter.c
+++ b/multidict/_multidict_iter.c
@@ -159,7 +159,7 @@ multidict_iter_clear(MultidictIter *self)
 static PyObject *
 multidict_iter_len(MultidictIter *self)
 {
-    return PyLong_FromSize_t(pair_list_len(&self->md->pairs));
+    return PyLong_FromLong(pair_list_len(&self->md->pairs));
 }
 
 PyDoc_STRVAR(length_hint_doc,
@@ -191,7 +191,7 @@ static PyMethodDef multidict_iter_methods[] = {
 
 static PyTypeObject multidict_items_iter_type = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
-    "multidict._multidict_iter._itemsiter",         /* tp_name */
+    "multidict._multidict._itemsiter",         /* tp_name */
     sizeof(MultidictIter),                          /* tp_basicsize */
     .tp_dealloc = (destructor)multidict_iter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
@@ -204,7 +204,7 @@ static PyTypeObject multidict_items_iter_type = {
 
 static PyTypeObject multidict_values_iter_type = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
-    "multidict._multidict_iter._valuesiter",         /* tp_name */
+    "multidict._multidict._valuesiter",         /* tp_name */
     sizeof(MultidictIter),                           /* tp_basicsize */
     .tp_dealloc = (destructor)multidict_iter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
@@ -217,7 +217,7 @@ static PyTypeObject multidict_values_iter_type = {
 
 static PyTypeObject multidict_keys_iter_type = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
-    "multidict._multidict_iter._keysiter",         /* tp_name */
+    "multidict._multidict._keysiter",         /* tp_name */
     sizeof(MultidictIter),                         /* tp_basicsize */
     .tp_dealloc = (destructor)multidict_iter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,

--- a/multidict/_multidict_views.c
+++ b/multidict/_multidict_views.c
@@ -244,7 +244,7 @@ static PySequenceMethods multidict_itemsview_as_sequence = {
 
 static PyTypeObject multidict_itemsview_type = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
-    "_ItemsView",                                   /* tp_name */
+    "multidict._multidict._ItemsView",              /* tp_name */
     sizeof(_Multidict_ViewObject),                  /* tp_basicsize */
     .tp_dealloc = (destructor)multidict_view_dealloc,
     .tp_repr = (reprfunc)multidict_itemsview_repr,
@@ -326,7 +326,7 @@ static PySequenceMethods multidict_keysview_as_sequence = {
 
 static PyTypeObject multidict_keysview_type = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
-    "_KeysView",                                   /* tp_name */
+    "multidict._multidict._KeysView",              /* tp_name */
     sizeof(_Multidict_ViewObject),                 /* tp_basicsize */
     .tp_dealloc = (destructor)multidict_view_dealloc,
     .tp_repr = (reprfunc)multidict_keysview_repr,
@@ -378,7 +378,7 @@ static PySequenceMethods multidict_valuesview_as_sequence = {
 
 static PyTypeObject multidict_valuesview_type = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
-    "_ValuesView",                                   /* tp_name */
+    "multidict._multidict._ValuesView",              /* tp_name */
     sizeof(_Multidict_ViewObject),                   /* tp_basicsize */
     .tp_dealloc = (destructor)multidict_view_dealloc,
     .tp_repr = (reprfunc)multidict_valuesview_repr,

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,10 @@ extensions = [
             "multidict/_pair_list.c",
             "multidict/_multidict_iter.c",
             "multidict/_multidict_views.c",
+            "multidict/_istr.c",
         ],
         extra_compile_args=CFLAGS,
     ),
-    Extension("multidict._istr", ["multidict/_istr.c"], extra_compile_args=CFLAGS,),
 ]
 
 


### PR DESCRIPTION
We need the only module for C Extension.

`_istr` used module state for saving global objects, it doesn't work well.
Maybe PEP 573 will be more convenient, I don't care now