### PR TITLE
Return class from __class_getitem__ to simplify subclassing

### DIFF
--- a/CHANGES/413.bugfix
+++ b/CHANGES/413.bugfix
@@ -1,0 +1,1 @@
+Return class from __class_getitem__ to simplify subclassing

--- a/docs/multidict.rst
+++ b/docs/multidict.rst
@@ -405,3 +405,18 @@ The module provides two ABCs: ``MultiMapping`` and
 :class:`collections.abc.MutableMapping` and inherited from them.
 
 .. versionadded:: 3.3
+
+
+Typing
+======
+
+The library is shipped with embedded type annotations, mypy just picks the annotations
+by default.
+
+:class:`MultiDict`, :class:`CIMultiDict`, :class:`MultiDictProxy`, and
+:class:`CIMultiDictProxy` are *generic* types; please use the corresponding notation for
+multidict value types, e.g. ``md: MultiDict[str] = MultiDict()``.
+
+The type of multidict keys is always :class:`str` or a class derived from a string.
+
+.. versionadded:: 3.7

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -25,6 +25,7 @@ eof
 fallback
 fastpath
 filename
+getitem
 github
 google
 gunicorn
@@ -63,6 +64,7 @@ regex
 regexs
 repo
 runtime
+subclassing
 subprotocol
 subprotocols
 Svetlov

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -51,6 +51,7 @@ multidicts
 Multidicts
 multipart
 Multipart
+mypy
 Nikolay
 param
 params

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -801,7 +801,7 @@ PyDoc_STRVAR(multidict_update_doc,
 "Update the dictionary from *other*, overwriting existing keys.");
 
 static PyObject *
-multidict_class_getitem(PyObject *self, PyObject *args)
+multidict_class_getitem(PyObject *self)
 {
     Py_INCREF(self);
     return self;
@@ -923,7 +923,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "__class_getitem__",
         multidict_class_getitem,
-        METH_VARARGS | METH_CLASS,
+        METH_O | METH_CLASS,
         NULL
     },
     {
@@ -1252,7 +1252,7 @@ static PyMethodDef multidict_proxy_methods[] = {
     {
         "__class_getitem__",
         multidict_class_getitem,
-        METH_VARARGS | METH_CLASS,
+        METH_O | METH_CLASS,
         NULL
     },
     {

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -803,7 +803,8 @@ PyDoc_STRVAR(multidict_update_doc,
 static PyObject *
 multidict_class_getitem(PyObject *self, PyObject *args)
 {
-    Py_RETURN_NONE;
+    Py_INCREF(self);
+    return self;
 }
 
 static PySequenceMethods multidict_sequence = {
@@ -922,7 +923,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "__class_getitem__",
         multidict_class_getitem,
-        METH_VARARGS | METH_STATIC,
+        METH_VARARGS | METH_CLASS,
         NULL
     },
     {
@@ -1251,7 +1252,7 @@ static PyMethodDef multidict_proxy_methods[] = {
     {
         "__class_getitem__",
         multidict_class_getitem,
-        METH_VARARGS | METH_STATIC,
+        METH_VARARGS | METH_CLASS,
         NULL
     },
     {

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,3 @@
 -r ci.txt
+-r lint.txt
 pyperformance==0.9.1

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -75,8 +75,7 @@ def test_proxy_copy(dict_cls, proxy_cls):
     indirect=True,
 )
 def test_class_getitem(cls):
-    # should not fail
-    cls[str]
+    assert cls[str] is cls
 
 
 class BaseMultiDictTest:

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -69,6 +69,8 @@ def test_proxy_copy(dict_cls, proxy_cls):
     assert d1 is not d2
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7),
+                    reason="__class_getitem__ is supported started from Python 3.7")
 @pytest.mark.parametrize(
     "cls",
     ["MultiDict", "CIMultiDict", "MultiDictProxy", "CIMultiDictProxy"],


### PR DESCRIPTION
E.g.
```
class MyDict(MultiDict[str]):
    pass
```

[//]: # (rtdbot-start)

URL of RTD document: https://multidict.readthedocs.io/en/fix-class_getitem/ ![Documentation Status](https://readthedocs.org/projects/multidict/badge/?version=fix-class_getitem)

[//]: # (rtdbot-end)
