### PR TITLE
Fix work with naming argument in method add

### DIFF
--- a/CHANGES/421.bugfix
+++ b/CHANGES/421.bugfix
@@ -1,0 +1,1 @@
+`CIMultiDict.add` may be called with keyword arguments

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -639,12 +639,15 @@ multidict_tp_init(MultiDictObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
-multidict_add(MultiDictObject *self, PyObject *args)
+multidict_add(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *key = NULL,
              *val = NULL;
 
-    if (!PyArg_UnpackTuple(args, "set", 2, 2, &key, &val)) {
+    static char *kwlist[] = {"key", "value", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO:set",
+                                     kwlist, &key, &val))
+    {
         return NULL;
     }
 
@@ -857,7 +860,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "add",
         (PyCFunction)multidict_add,
-        METH_VARARGS,
+        METH_VARARGS | METH_KEYWORDS,
         multidict_add_doc
     },
     {

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -645,7 +645,7 @@ multidict_add(MultiDictObject *self, PyObject *args, PyObject *kwds)
              *val = NULL;
 
     static char *kwlist[] = {"key", "value", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO:set",
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO:add",
                                      kwlist, &key, &val))
     {
         return NULL;

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -328,7 +328,7 @@ class TestCIMutableMultiDict:
         assert d.getall("foo") == ["bar"]
 
         d.add(key='test', value='test')
-        assert ("test", "bar") in d.items()
+        assert ("test", "test") in d.items()
         assert 4 == len(d)
         assert d.getall("test") == ["test"]
 

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -327,6 +327,11 @@ class TestCIMutableMultiDict:
         assert 3 == len(d)
         assert d.getall("foo") == ["bar"]
 
+        d.add(key='test', value='test')
+        assert ("test", "bar") in d.items()
+        assert 4 == len(d)
+        assert d.getall("test") == ["test"]
+
     def test_extend(self, cls):
         d = cls()
         assert d == {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`CIMultiDict.add` may be called with keyword arguments

## Are there changes in behavior for the user?

Restores the behaviour from 4.6.1

## Related issue number

fixes https://github.com/aio-libs/multidict/issues/421

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
