### PR TITLE
Mention MULTIDICT_NO_EXTENSIONS environment variable in docs.

### DIFF
--- a/CHANGES/393.doc
+++ b/CHANGES/393.doc
@@ -1,0 +1,1 @@
+Mention ``MULTIDICT_NO_EXTENSIONS`` environment variable in docs.

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,31 @@ License
 
 Apache 2
 
+Library Installation
+--------------------
+
+.. code-block:: bash
+
+   $ pip install multidict
+
+The library is Python 3 only!
+
+PyPI contains binary wheels for Linux, Windows and MacOS.  If you want to install
+``multidict`` on another operation system (or *Alpine Linux* inside a Docker) the
+Tarball will be used to compile the library from sources.  It requires C compiler and
+Python headers installed.
+
+To skip the compilation please use `MULTIDICT_NO_EXTENSIONS` environment variable,
+e.g.:
+
+.. code-block:: bash
+
+   $ MULTIDICT_NO_EXTENSIONS=1 pip install multidict
+
+Please note, Pure Python (uncompiled) version is about 20-50 times slower depending on
+the usage scenario!!!
+
+
 
 Changelog
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,21 @@ Library Installation
 
 The library is Python 3 only!
 
+PyPI contains binary wheels for Linux, Windows and MacOS.  If you want to install
+``multidict`` on another operation system (or *Alpine Linux* inside a Docker) the
+Tarball will be used to compile the library from sources.  It requires C compiler and
+Python headers installed.
+
+To skip the compilation please use `MULTIDICT_NO_EXTENSIONS` environment variable,
+e.g.:
+
+.. code-block:: bash
+
+   $ MULTIDICT_NO_EXTENSIONS=1 pip install multidict
+
+Please note, Pure Python (uncompiled) version is about 20-50 times slower depending on
+the usage scenario!!!
+
 
 Source code
 -----------

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -74,6 +74,7 @@ toolbar
 toolset
 tuples
 un
+uncompiled
 upstr
 url
 urlencoded


### PR DESCRIPTION
Fixes #393

[//]: # (rtdbot-start)

URL of RTD document: https://multidict.readthedocs.io/en/readme/ ![Documentation Status](https://readthedocs.org/projects/multidict/badge/?version=readme)

[//]: # (rtdbot-end)
