### PR TITLE
Fix return type for MultiDictProxy.copy

### DIFF
--- a/CHANGES/427.bugfix
+++ b/CHANGES/427.bugfix
@@ -1,0 +1,1 @@
+`CIMultiDictProxy.copy` return object type `multidict._multidict.CIMultiDict`

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -384,9 +384,6 @@ _multidict_proxy_copy(MultiDictProxyObject *self, PyTypeObject *type)
 fail:
     Py_XDECREF(new_multidict);
     return NULL;
-
-
-
 }
 
 /******************** Base Methods ********************/

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -363,6 +363,32 @@ fail:
     return NULL;
 }
 
+static inline PyObject *
+_multidict_proxy_copy(MultiDictProxyObject *self, PyTypeObject *type)
+{
+    PyObject *new_multidict = PyType_GenericNew(type, NULL, NULL);
+    if (new_multidict == NULL) {
+        goto fail;
+    }
+    if (type->tp_init(new_multidict, NULL, NULL) < 0) {
+        goto fail;
+    }
+    if (_multidict_extend_with_args(
+        (MultiDictObject*)new_multidict, (PyObject*)self, NULL, "copy", 1) < 0)
+    {
+        goto fail;
+    }
+
+    return new_multidict;
+
+fail:
+    Py_XDECREF(new_multidict);
+    return NULL;
+
+
+
+}
+
 /******************** Base Methods ********************/
 
 static PyObject *
@@ -1103,24 +1129,7 @@ multidict_proxy_values(MultiDictProxyObject *self)
 static PyObject *
 multidict_proxy_copy(MultiDictProxyObject *self)
 {
-    PyObject *new_multidict = PyType_GenericNew(&multidict_type, NULL, NULL);
-    if (new_multidict == NULL) {
-        goto fail;
-    }
-    if (multidict_tp_init((MultiDictObject*)new_multidict, NULL, NULL) < 0) {
-        goto fail;
-    }
-    if (_multidict_extend_with_args(
-        (MultiDictObject*)new_multidict, (PyObject*)self, NULL, "copy", 1) < 0)
-    {
-        goto fail;
-    }
-
-    return new_multidict;
-
-fail:
-    Py_XDECREF(new_multidict);
-    return NULL;
+    return _multidict_proxy_copy(self, &multidict_type);
 }
 
 static PyObject *
@@ -1329,10 +1338,31 @@ cimultidict_proxy_tp_init(MultiDictProxyObject *self, PyObject *args,
     return 0;
 }
 
+static PyObject * 
+cimultidict_proxy_copy(MultiDictProxyObject *self)
+{
+    return _multidict_proxy_copy(self, &cimultidict_type);
+}
+
 
 PyDoc_STRVAR(CIMultDictProxy_doc,
 "Read-only proxy for CIMultiDict instance.");
 
+PyDoc_STRVAR(cimultidict_proxy_copy_doc,
+"Return copy of itself");
+
+static PyMethodDef cimultidict_proxy_methods[] = {
+    {
+        "copy",
+        (PyCFunction)cimultidict_proxy_copy,
+        METH_NOARGS,
+        cimultidict_proxy_copy_doc
+    },
+    {
+        NULL,
+        NULL
+    }   /* sentinel */
+};
 
 static PyTypeObject cimultidict_proxy_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -1345,7 +1375,7 @@ static PyTypeObject cimultidict_proxy_type = {
     .tp_clear = (inquiry)multidict_proxy_tp_clear,
     .tp_richcompare = (richcmpfunc)multidict_proxy_tp_richcompare,
     .tp_weaklistoffset = offsetof(MultiDictProxyObject, weaklist),
-    .tp_methods = multidict_proxy_methods,
+    .tp_methods = cimultidict_proxy_methods,
     .tp_base = &multidict_proxy_type,
     .tp_init = (initproc)cimultidict_proxy_tp_init,
     .tp_alloc = PyType_GenericAlloc,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -17,6 +17,18 @@ def test_dict_not_inherited_from_proxy(_multidict):
     assert not issubclass(_multidict.MultiDict, _multidict.MultiDictProxy)
 
 
+def test_multidict_proxy_copy_type(_multidict):
+    d = _multidict.MultiDict(key="val")
+    p = _multidict.MultiDictProxy(d)
+    assert isinstance(p.copy(), _multidict.MultiDict)
+
+
+def test_cimultidict_proxy_copy_type(_multidict):
+    d = _multidict.CIMultiDict(key="val")
+    p = _multidict.CIMultiDictProxy(d)
+    assert isinstance(p.copy(), _multidict.CIMultiDict)
+
+
 def test_create_multidict_proxy_from_nonmultidict(_multidict):
     with pytest.raises(TypeError):
         _multidict.MultiDictProxy({})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Fix return type for MultiDictProxy.copy

## Are there changes in behavior for the user?

Restores the behaviour from 4.6.1

## Related issue number

fixes https://github.com/aio-libs/multidict/issues/427

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
