### PR TITLE
Slightly reorganize initialization code

### DIFF
--- a/CHANGES/432.bugfix
+++ b/CHANGES/432.bugfix
@@ -1,0 +1,1 @@
+Fix crashing when multidict is used pyinstaller

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -60,6 +60,7 @@ pickable
 pre
 proxied
 pyenv
+pyinstaller
 refactor
 refactored
 regex

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -13,7 +13,6 @@
 static PyObject *collections_abc_mapping;
 static PyObject *collections_abc_mut_mapping;
 static PyObject *collections_abc_mut_multi_mapping;
-static PyObject *istr;
 
 static PyTypeObject multidict_type;
 static PyTypeObject cimultidict_type;
@@ -1436,7 +1435,6 @@ getversion(PyObject *self, PyObject *md)
 static void
 module_free(void *m)
 {
-    Py_CLEAR(istr);
     Py_CLEAR(collections_abc_mapping);
     Py_CLEAR(collections_abc_mut_mapping);
     Py_CLEAR(collections_abc_mut_multi_mapping);
@@ -1481,8 +1479,7 @@ PyInit__multidict()
         goto fail;                              \
     }
 
-    istr = istr_init();
-    if (istr == NULL) {
+    if (istr_init() < 0) {
         goto fail;
     }
 
@@ -1498,8 +1495,7 @@ PyInit__multidict()
     WITH_MOD("multidict._multidict_base");
     GET_MOD_ATTR(repr_func, "_mdrepr");
 
-    if (pair_list_global_init(istr) < 0 ||
-        multidict_views_init() < 0) {
+    if (multidict_views_init() < 0) {
         goto fail;
     }
 
@@ -1555,9 +1551,9 @@ PyInit__multidict()
     /* Instantiate this module */
     module = PyModule_Create(&multidict_module);
 
-    Py_INCREF(istr);
+    Py_INCREF(&istr_type);
     if (PyModule_AddObject(
-            module, "istr", (PyObject*)istr) < 0)
+            module, "istr", (PyObject*)&istr_type) < 0)
     {
         goto fail;
     }
@@ -1596,11 +1592,6 @@ fail:
     Py_XDECREF(collections_abc_mapping);
     Py_XDECREF(collections_abc_mut_mapping);
     Py_XDECREF(collections_abc_mut_multi_mapping);
-    Py_XDECREF(istr);
-    Py_XDECREF(&multidict_type);
-    Py_XDECREF(&cimultidict_type);
-    Py_XDECREF(&multidict_proxy_type);
-    Py_XDECREF(&cimultidict_proxy_type);
 
     return NULL;
 

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -1479,7 +1479,23 @@ PyInit__multidict()
         goto fail;                              \
     }
 
+    if (multidict_views_init() < 0) {
+        goto fail;
+    }
+
+    if (multidict_iter_init() < 0) {
+        goto fail;
+    }
+
     if (istr_init() < 0) {
+        goto fail;
+    }
+
+    if (PyType_Ready(&multidict_type) < 0 ||
+        PyType_Ready(&cimultidict_type) < 0 ||
+        PyType_Ready(&multidict_proxy_type) < 0 ||
+        PyType_Ready(&cimultidict_proxy_type) < 0)
+    {
         goto fail;
     }
 
@@ -1494,18 +1510,6 @@ PyInit__multidict()
 
     WITH_MOD("multidict._multidict_base");
     GET_MOD_ATTR(repr_func, "_mdrepr");
-
-    if (multidict_views_init() < 0) {
-        goto fail;
-    }
-
-    if (PyType_Ready(&multidict_type) < 0 ||
-        PyType_Ready(&cimultidict_type) < 0 ||
-        PyType_Ready(&multidict_proxy_type) < 0 ||
-        PyType_Ready(&cimultidict_proxy_type) < 0)
-    {
-        goto fail;
-    }
 
     /* Register in _abc mappings (CI)MultiDict and (CI)MultiDictProxy */
     reg_func_call_result = PyObject_CallMethod(

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -54,7 +54,7 @@ _multidict_getone(MultiDictObject *self, PyObject *key, PyObject *_default)
     return val;
 }
 
-static int
+static inline int
 _multidict_eq(MultiDictObject *self, MultiDictObject *other)
 {
     Py_ssize_t pos1 = 0,
@@ -107,7 +107,7 @@ _multidict_update_items(MultiDictObject *self, pair_list_t *pairs)
     return pair_list_update(&self->pairs, pairs);
 }
 
-static int
+static inline int
 _multidict_append_items(MultiDictObject *self, pair_list_t *pairs)
 {
     PyObject *key   = NULL,
@@ -124,7 +124,7 @@ _multidict_append_items(MultiDictObject *self, pair_list_t *pairs)
     return 0;
 }
 
-static int
+static inline int
 _multidict_append_items_seq(MultiDictObject *self, PyObject *arg,
                             const char *name)
 {
@@ -197,7 +197,7 @@ fail:
     return -1;
 }
 
-static int
+static inline int
 _multidict_list_extend(PyObject *list, PyObject *target_list)
 {
     PyObject *item = NULL,
@@ -225,7 +225,7 @@ _multidict_list_extend(PyObject *list, PyObject *target_list)
     return 0;
 }
 
-static int
+static inline int
 _multidict_extend_with_args(MultiDictObject *self, PyObject *arg,
                             PyObject *kwds, const char *name, int do_add)
 {
@@ -308,7 +308,7 @@ _multidict_extend_with_kwds(MultiDictObject *self, PyObject *kwds,
     return err;
 }
 
-static int
+static inline int
 _multidict_extend(MultiDictObject *self, PyObject *args, PyObject *kwds,
                   const char *name, int do_add)
 {
@@ -418,7 +418,7 @@ fail:
 
 /******************** Base Methods ********************/
 
-static PyObject *
+static inline PyObject *
 multidict_getall(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *list     = NULL,
@@ -447,7 +447,7 @@ multidict_getall(MultiDictObject *self, PyObject *args, PyObject *kwds)
     return list;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_getone(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *key      = NULL,
@@ -464,7 +464,7 @@ multidict_getone(MultiDictObject *self, PyObject *args, PyObject *kwds)
     return _multidict_getone(self, key, _default);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_get(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *key      = NULL,
@@ -484,25 +484,25 @@ multidict_get(MultiDictObject *self, PyObject *args, PyObject *kwds)
     return ret;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_keys(MultiDictObject *self)
 {
     return multidict_keysview_new((PyObject*)self);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_items(MultiDictObject *self)
 {
     return multidict_itemsview_new((PyObject*)self);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_values(MultiDictObject *self)
 {
     return multidict_valuesview_new((PyObject*)self);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_reduce(MultiDictObject *self)
 {
     PyObject *items      = NULL,
@@ -535,26 +535,26 @@ ret:
     return result;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_repr(PyObject *self)
 {
     return PyObject_CallFunctionObjArgs(
         repr_func, self, NULL);
 }
 
-static Py_ssize_t
+static inline Py_ssize_t
 multidict_mp_len(MultiDictObject *self)
 {
     return pair_list_len(&self->pairs);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_mp_subscript(MultiDictObject *self, PyObject *key)
 {
     return _multidict_getone(self, key, NULL);
 }
 
-static int
+static inline int
 multidict_mp_as_subscript(MultiDictObject *self, PyObject *key, PyObject *val)
 {
     if (val == NULL) {
@@ -564,19 +564,19 @@ multidict_mp_as_subscript(MultiDictObject *self, PyObject *key, PyObject *val)
     }
 }
 
-static int
+static inline int
 multidict_sq_contains(MultiDictObject *self, PyObject *key)
 {
     return pair_list_contains(&self->pairs, key);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_tp_iter(MultiDictObject *self)
 {
     return PyObject_GetIter(multidict_keysview_new((PyObject*)self));
 }
 
-static PyObject *
+static inline PyObject *
 multidict_tp_richcompare(PyObject *self, PyObject *other, int op)
 {
     // TODO: refactoring me with love
@@ -634,7 +634,7 @@ multidict_tp_richcompare(PyObject *self, PyObject *other, int op)
     Py_RETURN_NOTIMPLEMENTED;
 }
 
-static void
+static inline void
 multidict_tp_dealloc(MultiDictObject *self)
 {
     PyObject_GC_UnTrack(self);
@@ -647,13 +647,13 @@ multidict_tp_dealloc(MultiDictObject *self)
     Py_TRASHCAN_SAFE_END(self);
 }
 
-static int
+static inline int
 multidict_tp_traverse(MultiDictObject *self, visitproc visit, void *arg)
 {
     return pair_list_traverse(&self->pairs, visit, arg);
 }
 
-static int
+static inline int
 multidict_tp_clear(MultiDictObject *self)
 {
     return pair_list_clear(&self->pairs);
@@ -679,7 +679,7 @@ PyDoc_STRVAR(multidict_values_doc,
 
 /******************** MultiDict ********************/
 
-static int
+static inline int
 multidict_tp_init(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     if (pair_list_init(&self->pairs) < 0) {
@@ -691,7 +691,7 @@ multidict_tp_init(MultiDictObject *self, PyObject *args, PyObject *kwds)
     return 0;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_add(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *key = NULL,
@@ -711,13 +711,13 @@ multidict_add(MultiDictObject *self, PyObject *args, PyObject *kwds)
     Py_RETURN_NONE;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_copy(MultiDictObject *self)
 {
     return _multidict_copy(self, &multidict_type);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_extend(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     if (_multidict_extend(self, args, kwds, "extend", 1) < 0) {
@@ -727,7 +727,7 @@ multidict_extend(MultiDictObject *self, PyObject *args, PyObject *kwds)
     Py_RETURN_NONE;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_clear(MultiDictObject *self)
 {
     if (pair_list_clear(&self->pairs) < 0) {
@@ -737,7 +737,7 @@ multidict_clear(MultiDictObject *self)
     Py_RETURN_NONE;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_setdefault(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *key      = NULL,
@@ -753,7 +753,7 @@ multidict_setdefault(MultiDictObject *self, PyObject *args, PyObject *kwds)
     return pair_list_set_default(&self->pairs, key, _default);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_popone(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *key      = NULL,
@@ -781,7 +781,7 @@ multidict_popone(MultiDictObject *self, PyObject *args, PyObject *kwds)
     return ret_val;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_popall(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *key      = NULL,
@@ -809,13 +809,13 @@ multidict_popall(MultiDictObject *self, PyObject *args, PyObject *kwds)
     return ret_val;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_popitem(MultiDictObject *self)
 {
     return pair_list_pop_item(&self->pairs);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_update(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     if (_multidict_extend(self, args, kwds, "update", 0) < 0) {
@@ -856,7 +856,7 @@ PyDoc_STRVAR(multidict_popitem_doc,
 PyDoc_STRVAR(multidict_update_doc,
 "Update the dictionary from *other*, overwriting existing keys.");
 
-static PyObject *
+static inline PyObject *
 multidict_class_getitem(PyObject *self, PyObject *arg)
 {
     Py_INCREF(self);
@@ -1017,7 +1017,7 @@ static PyTypeObject multidict_type = {
 
 /******************** CIMultiDict ********************/
 
-static int
+static inline int
 cimultidict_tp_init(MultiDictObject *self, PyObject *args, PyObject *kwds)
 {
     if (ci_pair_list_init(&self->pairs) < 0) {
@@ -1029,7 +1029,7 @@ cimultidict_tp_init(MultiDictObject *self, PyObject *args, PyObject *kwds)
     return 0;
 }
 
-static PyObject *
+static inline PyObject *
 cimultidict_copy(MultiDictObject *self)
 {
     return _multidict_copy(self, &cimultidict_type);
@@ -1075,7 +1075,7 @@ static PyTypeObject cimultidict_type = {
 
 /******************** MultiDictProxy ********************/
 
-static int
+static inline int
 multidict_proxy_tp_init(MultiDictProxyObject *self, PyObject *args,
                         PyObject *kwds)
 {
@@ -1117,52 +1117,52 @@ multidict_proxy_tp_init(MultiDictProxyObject *self, PyObject *args,
     return 0;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_getall(MultiDictProxyObject *self, PyObject *args,
                        PyObject *kwds)
 {
     return multidict_getall(self->md, args, kwds);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_getone(MultiDictProxyObject *self, PyObject *args,
                        PyObject *kwds)
 {
     return multidict_getone(self->md, args, kwds);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_get(MultiDictProxyObject *self, PyObject *args,
                        PyObject *kwds)
 {
     return multidict_get(self->md, args, kwds);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_keys(MultiDictProxyObject *self)
 {
     return multidict_keys(self->md);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_items(MultiDictProxyObject *self)
 {
     return multidict_items(self->md);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_values(MultiDictProxyObject *self)
 {
     return multidict_values(self->md);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_copy(MultiDictProxyObject *self)
 {
     return _multidict_proxy_copy(self, &multidict_type);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_reduce(MultiDictProxyObject *self)
 {
     PyErr_Format(
@@ -1173,38 +1173,38 @@ multidict_proxy_reduce(MultiDictProxyObject *self)
     return NULL;
 }
 
-static Py_ssize_t
+static inline Py_ssize_t
 multidict_proxy_mp_len(MultiDictProxyObject *self)
 {
     return multidict_mp_len(self->md);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_mp_subscript(MultiDictProxyObject *self, PyObject *key)
 {
     return multidict_mp_subscript(self->md, key);
 }
 
-static int
+static inline int
 multidict_proxy_sq_contains(MultiDictProxyObject *self, PyObject *key)
 {
     return multidict_sq_contains(self->md, key);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_tp_iter(MultiDictProxyObject *self)
 {
     return multidict_tp_iter(self->md);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_proxy_tp_richcompare(MultiDictProxyObject *self, PyObject *other,
                                int op)
 {
     return multidict_tp_richcompare((PyObject*)self->md, other, op);
 }
 
-static void
+static inline void
 multidict_proxy_tp_dealloc(MultiDictProxyObject *self)
 {
     PyObject_GC_UnTrack(self);
@@ -1215,7 +1215,7 @@ multidict_proxy_tp_dealloc(MultiDictProxyObject *self)
     Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-static int
+static inline int
 multidict_proxy_tp_traverse(MultiDictProxyObject *self, visitproc visit,
                             void *arg)
 {
@@ -1223,7 +1223,7 @@ multidict_proxy_tp_traverse(MultiDictProxyObject *self, visitproc visit,
     return 0;
 }
 
-static int
+static inline int
 multidict_proxy_tp_clear(MultiDictProxyObject *self)
 {
     Py_CLEAR(self->md);
@@ -1329,7 +1329,7 @@ static PyTypeObject multidict_proxy_type = {
 
 /******************** CIMultiDictProxy ********************/
 
-static int
+static inline int
 cimultidict_proxy_tp_init(MultiDictProxyObject *self, PyObject *args,
                           PyObject *kwds)
 {
@@ -1368,7 +1368,7 @@ cimultidict_proxy_tp_init(MultiDictProxyObject *self, PyObject *args,
     return 0;
 }
 
-static PyObject *
+static inline PyObject *
 cimultidict_proxy_copy(MultiDictProxyObject *self)
 {
     return _multidict_proxy_copy(self, &cimultidict_type);
@@ -1415,7 +1415,7 @@ static PyTypeObject cimultidict_proxy_type = {
 
 /******************** Other functions ********************/
 
-static PyObject *
+static inline PyObject *
 getversion(PyObject *self, PyObject *md)
 {
     pair_list_t *pairs = NULL;
@@ -1432,7 +1432,7 @@ getversion(PyObject *self, PyObject *md)
 
 /******************** Module ********************/
 
-static void
+static inline void
 module_free(void *m)
 {
     Py_CLEAR(collections_abc_mapping);

--- a/multidict/_multilib/istr.h
+++ b/multidict/_multilib/istr.h
@@ -68,15 +68,13 @@ static PyTypeObject istr_type = {
 };
 
 
-PyObject* istr_init(void)
+static int istr_init(void)
 {
     istr_type.tp_base = &PyUnicode_Type;
     if (PyType_Ready(&istr_type) < 0) {
-        return NULL;
+        return -1;
     }
-
-    Py_INCREF(&istr_type);
-    return (PyObject *)&istr_type;
+    return 0;
 }
 
 #ifdef __cplusplus

--- a/multidict/_multilib/istr.h
+++ b/multidict/_multilib/istr.h
@@ -14,13 +14,14 @@ PyDoc_STRVAR(istr__doc__, "istr class implementation");
 
 static PyTypeObject istr_type;
 
-void istr_dealloc(istrobject *self)
+static inline void
+istr_dealloc(istrobject *self)
 {
     Py_XDECREF(self->canonical);
     PyUnicode_Type.tp_dealloc((PyObject*)self);
 }
 
-static PyObject *
+static inline PyObject *
 istr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *x = NULL;
@@ -68,7 +69,8 @@ static PyTypeObject istr_type = {
 };
 
 
-static int istr_init(void)
+static inline int
+istr_init(void)
 {
     istr_type.tp_base = &PyUnicode_Type;
     if (PyType_Ready(&istr_type) < 0) {

--- a/multidict/_multilib/iter.h
+++ b/multidict/_multilib/iter.h
@@ -26,7 +26,7 @@ _init_iter(MultidictIter *it, MultiDictObject *md)
     it->version = pair_list_version(&md->pairs);
 }
 
-PyObject *
+static inline PyObject *
 multidict_items_iter_new(MultiDictObject *md)
 {
     MultidictIter *it = PyObject_GC_New(
@@ -41,7 +41,7 @@ multidict_items_iter_new(MultiDictObject *md)
     return (PyObject *)it;
 }
 
-PyObject *
+static inline PyObject *
 multidict_keys_iter_new(MultiDictObject *md)
 {
     MultidictIter *it = PyObject_GC_New(
@@ -56,7 +56,7 @@ multidict_keys_iter_new(MultiDictObject *md)
     return (PyObject *)it;
 }
 
-PyObject *
+static inline PyObject *
 multidict_values_iter_new(MultiDictObject *md)
 {
     MultidictIter *it = PyObject_GC_New(
@@ -71,7 +71,7 @@ multidict_values_iter_new(MultiDictObject *md)
     return (PyObject *)it;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_items_iter_iternext(MultidictIter *self)
 {
     PyObject *key = NULL;
@@ -96,7 +96,7 @@ multidict_items_iter_iternext(MultidictIter *self)
     return ret;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_values_iter_iternext(MultidictIter *self)
 {
     PyObject *value = NULL;
@@ -116,7 +116,7 @@ multidict_values_iter_iternext(MultidictIter *self)
     return value;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_keys_iter_iternext(MultidictIter *self)
 {
     PyObject *key = NULL;
@@ -136,7 +136,7 @@ multidict_keys_iter_iternext(MultidictIter *self)
     return key;
 }
 
-static void
+static inline void
 multidict_iter_dealloc(MultidictIter *self)
 {
     PyObject_GC_UnTrack(self);
@@ -144,21 +144,21 @@ multidict_iter_dealloc(MultidictIter *self)
     PyObject_GC_Del(self);
 }
 
-static int
+static inline int
 multidict_iter_traverse(MultidictIter *self, visitproc visit, void *arg)
 {
     Py_VISIT(self->md);
     return 0;
 }
 
-static int
+static inline int
 multidict_iter_clear(MultidictIter *self)
 {
     Py_CLEAR(self->md);
     return 0;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_iter_len(MultidictIter *self)
 {
     return PyLong_FromLong(pair_list_len(&self->md->pairs));
@@ -185,7 +185,7 @@ static PyMethodDef multidict_iter_methods[] = {
 static PyTypeObject multidict_items_iter_type = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
     "multidict._multidict._itemsiter",         /* tp_name */
-    sizeof(MultidictIter),                          /* tp_basicsize */
+    sizeof(MultidictIter),                     /* tp_basicsize */
     .tp_dealloc = (destructor)multidict_iter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = (traverseproc)multidict_iter_traverse,
@@ -198,7 +198,7 @@ static PyTypeObject multidict_items_iter_type = {
 static PyTypeObject multidict_values_iter_type = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
     "multidict._multidict._valuesiter",         /* tp_name */
-    sizeof(MultidictIter),                           /* tp_basicsize */
+    sizeof(MultidictIter),                      /* tp_basicsize */
     .tp_dealloc = (destructor)multidict_iter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = (traverseproc)multidict_iter_traverse,
@@ -211,7 +211,7 @@ static PyTypeObject multidict_values_iter_type = {
 static PyTypeObject multidict_keys_iter_type = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
     "multidict._multidict._keysiter",         /* tp_name */
-    sizeof(MultidictIter),                         /* tp_basicsize */
+    sizeof(MultidictIter),                    /* tp_basicsize */
     .tp_dealloc = (destructor)multidict_iter_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = (traverseproc)multidict_iter_traverse,
@@ -221,7 +221,7 @@ static PyTypeObject multidict_keys_iter_type = {
     .tp_methods = multidict_iter_methods,
 };
 
-static int
+static inline int
 multidict_iter_init()
 {
     if (PyType_Ready(&multidict_items_iter_type) < 0 ||

--- a/multidict/_multilib/iter.h
+++ b/multidict/_multilib/iter.h
@@ -221,7 +221,7 @@ static PyTypeObject multidict_keys_iter_type = {
     .tp_methods = multidict_iter_methods,
 };
 
-int
+static int
 multidict_iter_init()
 {
     if (PyType_Ready(&multidict_items_iter_type) < 0 ||

--- a/multidict/_multilib/pair_list.h
+++ b/multidict/_multilib/pair_list.h
@@ -50,8 +50,6 @@ typedef struct pair_list {  // 40
 #define MIN_CAPACITY 63
 #define CAPACITY_STEP 64
 
-static PyObject * _istr_type;
-
 /* Global counter used to set ma_version_tag field of dictionary.
  * It is incremented each time that a dictionary is created and each
  * time that a dictionary is modified. */
@@ -83,7 +81,7 @@ key_to_str(PyObject *key)
 {
     PyObject *ret;
     PyTypeObject *type = Py_TYPE(key);
-    if ((PyObject *)type == _istr_type) {
+    if (type == &istr_type) {
         ret = ((istrobject*)key)->canonical;
         Py_INCREF(ret);
         return ret;
@@ -107,7 +105,7 @@ ci_key_to_str(PyObject *key)
 {
     PyObject *ret;
     PyTypeObject *type = Py_TYPE(key);
-    if ((PyObject *)type == _istr_type) {
+    if (type == &istr_type) {
         ret = ((istrobject*)key)->canonical;
         Py_INCREF(ret);
         return ret;
@@ -1238,15 +1236,6 @@ pair_list_clear(pair_list_t *list)
     return 0;
 }
 
-
-
-int
-pair_list_global_init(PyObject *istr_type)
-{
-    Py_INCREF(istr_type);
-    _istr_type = istr_type;
-    return 0;
-}
 
 #ifdef __cplusplus
 }

--- a/multidict/_multilib/pair_list.h
+++ b/multidict/_multilib/pair_list.h
@@ -100,7 +100,7 @@ key_to_str(PyObject *key)
 }
 
 
-static PyObject *
+static inline PyObject *
 ci_key_to_str(PyObject *key)
 {
     PyObject *ret;
@@ -209,21 +209,21 @@ _pair_list_init(pair_list_t *list, calc_identity_func calc_identity)
     return 0;
 }
 
-int
+static inline int
 pair_list_init(pair_list_t *list)
 {
     return _pair_list_init(list, key_to_str);
 }
 
 
-int
+static inline int
 ci_pair_list_init(pair_list_t *list)
 {
     return _pair_list_init(list, ci_key_to_str);
 }
 
 
-void
+static inline void
 pair_list_dealloc(pair_list_t *list)
 {
     pair_t *pair;
@@ -255,7 +255,7 @@ pair_list_dealloc(pair_list_t *list)
 }
 
 
-Py_ssize_t
+static inline Py_ssize_t
 pair_list_len(pair_list_t *list)
 {
     return list->size;
@@ -295,7 +295,7 @@ _pair_list_add_with_hash(pair_list_t *list,
 }
 
 
-int
+static inline int
 pair_list_add(pair_list_t *list,
               PyObject *key,
               PyObject *value)
@@ -321,7 +321,7 @@ fail:
 }
 
 
-static int
+static inline int
 pair_list_del_at(pair_list_t *list, Py_ssize_t pos)
 {
     // return 1 on success, -1 on failure
@@ -351,7 +351,7 @@ pair_list_del_at(pair_list_t *list, Py_ssize_t pos)
 }
 
 
-int
+static inline int
 _pair_list_drop_tail(pair_list_t *list, PyObject *identity, Py_hash_t hash,
                      Py_ssize_t pos)
 {
@@ -385,7 +385,7 @@ _pair_list_drop_tail(pair_list_t *list, PyObject *identity, Py_hash_t hash,
     return found;
 }
 
-static int
+static inline int
 _pair_list_del_hash(pair_list_t *list, PyObject *identity,
                     PyObject *key, Py_hash_t hash)
 {
@@ -405,7 +405,7 @@ _pair_list_del_hash(pair_list_t *list, PyObject *identity,
 }
 
 
-int
+static inline int
 pair_list_del(pair_list_t *list, PyObject *key)
 {
     PyObject *identity = NULL;
@@ -431,14 +431,14 @@ fail:
 }
 
 
-uint64_t
+static inline uint64_t
 pair_list_version(pair_list_t *list)
 {
     return list->version;
 }
 
 
-inline int
+static inline int
 _pair_list_next(pair_list_t *list, Py_ssize_t *ppos, PyObject **pidentity,
                 PyObject **pkey, PyObject **pvalue, Py_hash_t *phash)
 {
@@ -477,7 +477,7 @@ pair_list_next(pair_list_t *list, Py_ssize_t *ppos, PyObject **pidentity,
 }
 
 
-int
+static inline int
 pair_list_contains(pair_list_t *list, PyObject *key)
 {
     Py_hash_t hash1, hash2;
@@ -518,7 +518,7 @@ fail:
 }
 
 
-PyObject *
+static inline PyObject *
 pair_list_get_one(pair_list_t *list, PyObject *key)
 {
     Py_hash_t hash1, hash2;
@@ -562,7 +562,7 @@ fail:
 }
 
 
-PyObject *
+static inline PyObject *
 pair_list_get_all(pair_list_t *list, PyObject *key)
 {
     Py_hash_t hash1, hash2;
@@ -621,7 +621,7 @@ fail:
 }
 
 
-PyObject *
+static inline PyObject *
 pair_list_set_default(pair_list_t *list, PyObject *key, PyObject *value)
 {
     Py_hash_t hash1, hash2;
@@ -669,7 +669,7 @@ fail:
 }
 
 
-PyObject *
+static inline PyObject *
 pair_list_pop_one(pair_list_t *list, PyObject *key)
 {
     pair_t *pair;
@@ -720,7 +720,7 @@ fail:
 }
 
 
-PyObject *
+static inline PyObject *
 pair_list_pop_all(pair_list_t *list, PyObject *key)
 {
     Py_hash_t hash;
@@ -788,7 +788,7 @@ fail:
 }
 
 
-PyObject *
+static inline PyObject *
 pair_list_pop_item(pair_list_t *list)
 {
     PyObject *ret;
@@ -814,7 +814,7 @@ pair_list_pop_item(pair_list_t *list)
 }
 
 
-int
+static inline int
 pair_list_replace(pair_list_t *list, PyObject * key, PyObject *value)
 {
     pair_t *pair;
@@ -879,7 +879,7 @@ fail:
 }
 
 
-static int
+static inline int
 _dict_set_number(PyObject *dict, PyObject *key, Py_ssize_t num)
 {
     PyObject *tmp = PyLong_FromSsize_t(num);
@@ -896,7 +896,7 @@ _dict_set_number(PyObject *dict, PyObject *key, Py_ssize_t num)
 }
 
 
-static int
+static inline int
 _pair_list_post_update(pair_list_t *list, PyObject* used_keys, Py_ssize_t pos)
 {
     pair_t *pair;
@@ -1000,7 +1000,7 @@ _pair_list_update(pair_list_t *list, PyObject *key,
 }
 
 
-int
+static inline int
 pair_list_update(pair_list_t *list, pair_list_t *other)
 {
     PyObject *used_keys = NULL;
@@ -1038,7 +1038,7 @@ fail:
 }
 
 
-int
+static inline int
 pair_list_update_from_seq(pair_list_t *list, PyObject *seq)
 {
     PyObject *it = NULL; // iter(seq)
@@ -1143,7 +1143,7 @@ fail_2:
     return -1;
 }
 
-int
+static inline int
 pair_list_eq_to_mapping(pair_list_t *list, PyObject *other)
 {
     PyObject *key = NULL;
@@ -1193,7 +1193,7 @@ pair_list_eq_to_mapping(pair_list_t *list, PyObject *other)
 
 /***********************************************************************/
 
-int
+static inline int
 pair_list_traverse(pair_list_t *list, visitproc visit, void *arg)
 {
     pair_t *pair = NULL;
@@ -1210,7 +1210,7 @@ pair_list_traverse(pair_list_t *list, visitproc visit, void *arg)
 }
 
 
-int
+static inline int
 pair_list_clear(pair_list_t *list)
 {
     pair_t *pair = NULL;

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -42,7 +42,7 @@ _init_view(_Multidict_ViewObject *self, PyObject *md)
     self->md = md;
 }
 
-static void
+static inline void
 multidict_view_dealloc(_Multidict_ViewObject *self)
 {
     PyObject_GC_UnTrack(self);
@@ -50,27 +50,27 @@ multidict_view_dealloc(_Multidict_ViewObject *self)
     PyObject_GC_Del(self);
 }
 
-static int
+static inline int
 multidict_view_traverse(_Multidict_ViewObject *self, visitproc visit, void *arg)
 {
     Py_VISIT(self->md);
     return 0;
 }
 
-static int
+static inline int
 multidict_view_clear(_Multidict_ViewObject *self)
 {
     Py_CLEAR(self->md);
     return 0;
 }
 
-static Py_ssize_t
+static inline Py_ssize_t
 multidict_view_len(_Multidict_ViewObject *self)
 {
     return pair_list_len(&((MultiDictObject*)self->md)->pairs);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_view_richcompare(PyObject *self, PyObject *other, int op)
 {
     PyObject *ret;
@@ -84,28 +84,28 @@ multidict_view_richcompare(PyObject *self, PyObject *other, int op)
     return ret;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_view_and(PyObject *self, PyObject *other)
 {
     return PyObject_CallFunctionObjArgs(
         viewbaseset_and_func, self, other, NULL);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_view_or(PyObject *self, PyObject *other)
 {
     return PyObject_CallFunctionObjArgs(
         viewbaseset_or_func, self, other, NULL);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_view_sub(PyObject *self, PyObject *other)
 {
     return PyObject_CallFunctionObjArgs(
         viewbaseset_sub_func, self, other, NULL);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_view_xor(PyObject *self, PyObject *other)
 {
     return PyObject_CallFunctionObjArgs(
@@ -121,7 +121,7 @@ static PyNumberMethods multidict_view_as_number = {
 
 /********** Items **********/
 
-PyObject *
+static inline PyObject *
 multidict_itemsview_new(PyObject *md)
 {
     _Multidict_ViewObject *mv = PyObject_GC_New(
@@ -136,20 +136,20 @@ multidict_itemsview_new(PyObject *md)
     return (PyObject *)mv;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_itemsview_iter(_Multidict_ViewObject *self)
 {
     return multidict_items_iter_new((MultiDictObject*)self->md);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_itemsview_repr(_Multidict_ViewObject *self)
 {
     return PyObject_CallFunctionObjArgs(
         itemsview_repr_func, self, NULL);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_itemsview_isdisjoint(_Multidict_ViewObject *self, PyObject *other)
 {
     return PyObject_CallFunctionObjArgs(
@@ -172,7 +172,7 @@ static PyMethodDef multidict_itemsview_methods[] = {
     }   /* sentinel */
 };
 
-static int
+static inline int
 multidict_itemsview_contains(_Multidict_ViewObject *self, PyObject *obj)
 {
     PyObject *akey  = NULL,
@@ -255,7 +255,7 @@ static PyTypeObject multidict_itemsview_type = {
 
 /********** Keys **********/
 
-PyObject *
+static inline PyObject *
 multidict_keysview_new(PyObject *md)
 {
     _Multidict_ViewObject *mv = PyObject_GC_New(
@@ -270,20 +270,20 @@ multidict_keysview_new(PyObject *md)
     return (PyObject *)mv;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_keysview_iter(_Multidict_ViewObject *self)
 {
     return multidict_keys_iter_new(((MultiDictObject*)self->md));
 }
 
-static PyObject *
+static inline PyObject *
 multidict_keysview_repr(_Multidict_ViewObject *self)
 {
     return PyObject_CallFunctionObjArgs(
         keysview_repr_func, self, NULL);
 }
 
-static PyObject *
+static inline PyObject *
 multidict_keysview_isdisjoint(_Multidict_ViewObject *self, PyObject *other)
 {
     return PyObject_CallFunctionObjArgs(
@@ -306,7 +306,7 @@ static PyMethodDef multidict_keysview_methods[] = {
     }   /* sentinel */
 };
 
-static int
+static inline int
 multidict_keysview_contains(_Multidict_ViewObject *self, PyObject *key)
 {
     return pair_list_contains(&((MultiDictObject*)self->md)->pairs, key);
@@ -337,7 +337,7 @@ static PyTypeObject multidict_keysview_type = {
 
 /********** Values **********/
 
-PyObject *
+static inline PyObject *
 multidict_valuesview_new(PyObject *md)
 {
     _Multidict_ViewObject *mv = PyObject_GC_New(
@@ -352,13 +352,13 @@ multidict_valuesview_new(PyObject *md)
     return (PyObject *)mv;
 }
 
-static PyObject *
+static inline PyObject *
 multidict_valuesview_iter(_Multidict_ViewObject *self)
 {
     return multidict_values_iter_new(((MultiDictObject*)self->md));
 }
 
-static PyObject *
+static inline PyObject *
 multidict_valuesview_repr(_Multidict_ViewObject *self)
 {
     return PyObject_CallFunctionObjArgs(
@@ -384,7 +384,7 @@ static PyTypeObject multidict_valuesview_type = {
 };
 
 
-static int
+static inline int
 multidict_views_init()
 {
     PyObject *reg_func_call_result = NULL;

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -383,7 +383,8 @@ static PyTypeObject multidict_valuesview_type = {
     .tp_iter = (getiterfunc)multidict_valuesview_iter,
 };
 
-int
+
+static int
 multidict_views_init()
 {
     PyObject *reg_func_call_result = NULL;
@@ -415,10 +416,6 @@ multidict_views_init()
     GET_MOD_ATTR(keysview_isdisjoint_func, "_keysview_isdisjoint");
 
     GET_MOD_ATTR(valuesview_repr_func, "_valuesview_repr");
-
-    if (multidict_iter_init() < 0) {
-        goto fail;
-    }
 
     if (PyType_Ready(&multidict_itemsview_type) < 0 ||
         PyType_Ready(&multidict_valuesview_type) < 0 ||


### PR DESCRIPTION
Curiously, #432 problem seems gone. 
I don't understand clearly why but the code doesn't contain explicit tricks, it is clearly readable at least.

[//]: # (rtdbot-start)

URL of RTD document: https://multidict.readthedocs.io/en/cleanup/ ![Documentation Status](https://readthedocs.org/projects/multidict/badge/?version=cleanup)

[//]: # (rtdbot-end)
