### PR TITLE
Fix license files inclusion in wheel metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,20 @@ Changelog
 
 .. towncrier release notes start
 
+4.7.6 (2020-05-15)
+==================
+
+Bugfixes
+--------
+
+- Fixed an issue with some versions of the ``wheel`` dist
+  failing because of being unable to detect the license file.
+  `#481 <https://github.com/aio-libs/multidict/issues/481>`_
+
+
+----
+
+
 4.7.5 (2020-02-21)
 ==================
 

--- a/CHANGES/481.bugfix
+++ b/CHANGES/481.bugfix
@@ -1,0 +1,2 @@
+Fixed an issue with some versions of the ``wheel`` dist
+failing because of being unable to detect the license file.

--- a/CHANGES/481.bugfix
+++ b/CHANGES/481.bugfix
@@ -1,2 +1,0 @@
-Fixed an issue with some versions of the ``wheel`` dist
-failing because of being unable to detect the license file.

--- a/multidict/__init__.py
+++ b/multidict/__init__.py
@@ -20,7 +20,7 @@ __all__ = (
     "getversion"
 )
 
-__version__ = "4.7.5"
+__version__ = "4.7.6"
 
 
 try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,8 @@
 test = pytest
 
 [metadata]
-license_file = LICENSE
+license_files =
+  LICENSE
 long_description = file: README.rst
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change is a workaround for the wheel metadata 1.0 upgrade.
W/o it, building dists fails under some wheel dist versions.

## Are there changes in behavior for the user?

N/A

## Related issue number

N/A

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
