### PR TITLE
Remove pip from build requirements

### DIFF
--- a/CHANGES/503.misc
+++ b/CHANGES/503.misc
@@ -1,0 +1,2 @@
+Removed pip as a PEP 518 build dependency
+which was not required to build multidict.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["pip>=18", "setuptools>=40", "wheel"]
+requires = ["setuptools>=40", "wheel"]
 
 
 [tool.towncrier]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

I have removed pip from the PEP 518 build table because it is not required to build multidict.

## Are there changes in behavior for the user?

No.  Simply, pip won't be installed in the build environment unnecessarily when building from an sdist.

## Related issue number

—

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
