### PR TITLE
Drop Python 3.5 from setup.py

### DIFF
--- a/CHANGES/552.bugfix
+++ b/CHANGES/552.bugfix
@@ -1,0 +1,1 @@
+Synchronize the declared supported Python versions in ``setup.py`` with actually supported and tested ones.

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,10 @@ args = dict(
         "Intended Audience :: Developers",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Development Status :: 5 - Production/Stable",
     ],
     author="Andrew Svetlov",
@@ -80,14 +80,14 @@ args = dict(
     },
     license="Apache 2",
     packages=["multidict"],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     include_package_data=True,
 )
 
 if not NO_EXTENSIONS:
-    print("**********************")
-    print("* Accellerated build *")
-    print("**********************")
+    print("*********************")
+    print("* Accelerated build *")
+    print("*********************")
     setup(ext_modules=extensions, **args)
 else:
     print("*********************")


### PR DESCRIPTION
We don't test CI on 3.5 anyway; the *declared* support exists by oversight.

Python 3.9 *is* tested actually; we provide 3.9 binary wheels on PyPI