### PR TITLE
Fix 'Dictionary changed during iteration' exception raising

### DIFF
--- a/CHANGES/620.bugfix
+++ b/CHANGES/620.bugfix
@@ -1,0 +1,1 @@
+Fix pure-python implementation that used to raise "Dictionary changed during iteration" error when iterated view (``.keys()``, ``.values()`` or ``.items()``) was created before the dictionary's content change.

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -435,7 +435,6 @@ class _Iter:
 class _ViewBase:
     def __init__(self, impl):
         self._impl = impl
-        self._version = impl._version
 
     def __len__(self):
         return len(self._impl._items)
@@ -451,11 +450,11 @@ class _ItemsView(_ViewBase, abc.ItemsView):
         return False
 
     def __iter__(self):
-        return _Iter(len(self), self._iter())
+        return _Iter(len(self), self._iter(self._impl._version))
 
-    def _iter(self):
+    def _iter(self, version):
         for i, k, v in self._impl._items:
-            if self._version != self._impl._version:
+            if version != self._impl._version:
                 raise RuntimeError("Dictionary changed during iteration")
             yield k, v
 
@@ -475,11 +474,11 @@ class _ValuesView(_ViewBase, abc.ValuesView):
         return False
 
     def __iter__(self):
-        return _Iter(len(self), self._iter())
+        return _Iter(len(self), self._iter(self._impl._version))
 
-    def _iter(self):
+    def _iter(self, version):
         for item in self._impl._items:
-            if self._version != self._impl._version:
+            if version != self._impl._version:
                 raise RuntimeError("Dictionary changed during iteration")
             yield item[2]
 
@@ -499,11 +498,11 @@ class _KeysView(_ViewBase, abc.KeysView):
         return False
 
     def __iter__(self):
-        return _Iter(len(self), self._iter())
+        return _Iter(len(self), self._iter(self._impl._version))
 
-    def _iter(self):
+    def _iter(self, version):
         for item in self._impl._items:
-            if self._version != self._impl._version:
+            if version != self._impl._version:
                 raise RuntimeError("Dictionary changed during iteration")
             yield item[1]
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -517,7 +517,8 @@ class TestCIMultiDict(BaseMultiDictTest):
         assert repr(d.values()) == "_ValuesView('value1', 'value2')"
 
     def test_mutate_multidict(self, cls):
-        d = cls({'a': '123, 456', 'b': '789'})
+        d = cls({"a": "123, 456", "b": "789"})
         before_mutation_items = d.items()
-        d['c'] = '000'
-        list(before_mutation_items)  # this will raise a RuntimeError when running with pypy
+        d["c"] = "000"
+        # This causes an error on pypy.
+        list(before_mutation_items)

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -515,3 +515,9 @@ class TestCIMultiDict(BaseMultiDictTest):
     def test_values__repr__(self, cls):
         d = cls([("KEY", "value1")], key="value2")
         assert repr(d.values()) == "_ValuesView('value1', 'value2')"
+
+    def test_mutate_multidict(self, cls):
+        d = cls({'a': '123, 456', 'b': '789'})
+        before_mutation_items = d.items()
+        d['c'] = '000'
+        list(before_mutation_items)  # this will raise a RuntimeError when running with pypy

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -515,10 +515,3 @@ class TestCIMultiDict(BaseMultiDictTest):
     def test_values__repr__(self, cls):
         d = cls([("KEY", "value1")], key="value2")
         assert repr(d.values()) == "_ValuesView('value1', 'value2')"
-
-    def test_mutate_multidict(self, cls):
-        d = cls({"a": "123, 456", "b": "789"})
-        before_mutation_items = d.items()
-        d["c"] = "000"
-        # This causes an error on pypy.
-        list(before_mutation_items)

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -484,3 +484,27 @@ class TestCIMutableMultiDict:
     def test_min_sizeof(self, cls):
         md = cls()
         assert sys.getsizeof(md) < 1024
+
+    def test_issue_620_items(self, cls):
+        # https://github.com/aio-libs/multidict/issues/620
+        d = cls({"a": "123, 456", "b": "789"})
+        before_mutation_items = d.items()
+        d["c"] = "000"
+        # This causes an error on pypy.
+        list(before_mutation_items)
+
+    def test_issue_620_keys(self, cls):
+        # https://github.com/aio-libs/multidict/issues/620
+        d = cls({"a": "123, 456", "b": "789"})
+        before_mutation_keys = d.keys()
+        d["c"] = "000"
+        # This causes an error on pypy.
+        list(before_mutation_keys)
+
+    def test_issue_620_values(self, cls):
+        # https://github.com/aio-libs/multidict/issues/620
+        d = cls({"a": "123, 456", "b": "789"})
+        before_mutation_values = d.values()
+        d["c"] = "000"
+        # This causes an error on pypy.
+        list(before_mutation_values)


### PR DESCRIPTION
Don't raise 'Dictionary changed during iteration' when the error should not be thrown

Fix #620