### PR TITLE
Fix docs: .pop() is an alias to .popitem()

### DIFF
--- a/docs/multidict.rst
+++ b/docs/multidict.rst
@@ -144,7 +144,7 @@ MultiDict
 
    .. method:: pop(key[, default])
 
-      An alias to :meth:`pop`
+      An alias to :meth:`popone`
 
       .. versionchanged:: 3.0
 


### PR DESCRIPTION
...not to itself ➿➿➿

