### PR TITLE
Do not install C sources in binary distributions

### DIFF
--- a/CHANGES/659.misc
+++ b/CHANGES/659.misc
@@ -1,0 +1,1 @@
+ Do not install C sources with binary distributions.

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ args = dict(
     packages=["multidict"],
     python_requires=">=3.6",
     include_package_data=True,
+    exclude_package_data={"": ["*.c", "*.h"]},
 )
 
 if not NO_EXTENSIONS:


### PR DESCRIPTION
This does not affect source distributions.

Fixes #659.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Prevent C sources (`_multidict.c` and `_multilib/*.h`) from being included in binary distributions such as wheels, without affecting source distributions.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Nothing changes except that the binary wheels are a bit smaller.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/aio-libs/multidict/issues/659

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist **This doesn’t seem necessary.**
- [ ] Documentation reflects the changes **No changes seem necessary.**
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
