### PR TITLE
Replace version 3.11-dev by 3.11 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        pyver: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        pyver: ['3.7', '3.8', '3.9', '3.10', '3.11']
         no-extensions: ['', 'Y']
         os: [ubuntu, macos, windows]
         exclude:

--- a/CHANGES/872.feature.rst
+++ b/CHANGES/872.feature.rst
@@ -1,0 +1,1 @@
+Added Python 3.11 support

--- a/CHANGES/872.feature.rst
+++ b/CHANGES/872.feature.rst
@@ -1,1 +1,1 @@
-Added Python 3.11 support
+Declared the official support for Python 3.11 — by :user:`mlegner`.

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ args = dict(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 5 - Production/Stable",
     ],
     author="Andrew Svetlov",


### PR DESCRIPTION
Python 3.11 is now released, so we can replace `3.11-dev` by `3.11`.

Related to #778 