### PR TITLE
Fix cibuildwheel test-requires

### DIFF
--- a/CHANGES/827.contrib.rst
+++ b/CHANGES/827.contrib.rst
@@ -1,0 +1,2 @@
+Updated the test pins lockfile used in the
+``cibuildwheel`` test stage -- by :user:`hoodmane`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -49,6 +49,7 @@ json
 keepalive
 keepalives
 keepaliving
+lockfile
 lookups
 manylinux
 middleware

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ requires = ["setuptools >= 40"]
 
 
 [tool.cibuildwheel]
-test-requires = "-r requirements/ci.txt"
+test-requires = "-r requirements/pytest.txt"
 test-command = "pytest {project}/tests"
 # don't build PyPy wheels, install from source instead
 skip = "pp*"


### PR DESCRIPTION
requirements-ci includes `-e .` which rebuilts multidict and installs this version. As a result cibuildwheel ends up not testing the wheel it built, instead testing a separate wheel built by `pip install -e .`

cibuildwheel automatically installs the multidict wheel, so we should only install test-requires not multidict itself.
