### PR TITLE
Fix strict-prototypes compile warnings

### DIFF
--- a/CHANGES/828.contrib.rst
+++ b/CHANGES/828.contrib.rst
@@ -1,0 +1,8 @@
+Added an explicit ``void`` for arguments in C-function signatures
+which addresses the following compiler warning:
+
+.. code-block:: console
+
+   warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
+
+-- by :user:`hoodmane`

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -1695,7 +1695,7 @@ static PyModuleDef multidict_module = {
 };
 
 PyMODINIT_FUNC
-PyInit__multidict()
+PyInit__multidict(void)
 {
 #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
     multidict_str_lower = PyUnicode_InternFromString("lower");

--- a/multidict/_multilib/iter.h
+++ b/multidict/_multilib/iter.h
@@ -222,7 +222,7 @@ static PyTypeObject multidict_keys_iter_type = {
 };
 
 static inline int
-multidict_iter_init()
+multidict_iter_init(void)
 {
     if (PyType_Ready(&multidict_items_iter_type) < 0 ||
         PyType_Ready(&multidict_values_iter_type) < 0 ||

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -385,7 +385,7 @@ static PyTypeObject multidict_valuesview_type = {
 
 
 static inline int
-multidict_views_init()
+multidict_views_init(void)
 {
     PyObject *reg_func_call_result = NULL;
     PyObject *module = PyImport_ImportModule("multidict._multidict_base");


### PR DESCRIPTION
This fixes three compiler warnings:
```
warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
```