### PR TITLE
Fix setuptools warning: "multidict._multilib not in packages list"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ args = dict(
         "GitHub: repo": "https://github.com/aio-libs/multidict",
     },
     license="Apache 2",
-    packages=["multidict"],
+    packages=["multidict", "multidict._multilib"],
     python_requires=">=3.7",
     include_package_data=True,
     exclude_package_data={"": ["*.c", "*.h"]},


### PR DESCRIPTION
This fixes the following build warning:

```
    ############################
    # Package would be ignored #
    ############################
    Python recognizes 'multidict._multilib' as an importable package,
    but it is not listed in the `packages` configuration of setuptools.

    'multidict._multilib' has been automatically added to the distribution only
    because it may contain data files, but this behavior is likely to change
    in future versions of setuptools (and therefore is considered deprecated).

    Please make sure that 'multidict._multilib' is included as a package by using
    the `packages` configuration field or the proper discovery methods
    (for example by using `find_namespace_packages(...)`/`find_namespace:`
    instead of `find_packages(...)`/`find:`).

    You can read more about "package discovery" and "data files" on setuptools
    documentation page.
```