### PR TITLE
823.bugfix | Equality operator fix | fixed  #issue823

### DIFF
--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -117,6 +117,8 @@ class _Base:
             rht = other._impl._items
             if len(lft) != len(rht):
                 return False
+            lft.sort()
+            rht.sort()
             for (i1, k2, v1), (i2, k2, v2) in zip(lft, rht):
                 if i1 != i2 or v1 != v2:
                     return False

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -298,7 +298,13 @@ class BaseMultiDictTest:
         d2 = cls()
 
         assert d1 != d2
-
+        
+    def test_eq4(self, cls: _MultiDictClasses) -> None:
+        d1 = cls({"a": "A", "b": "B"})
+        d2 = cls({"b": "B", "a": "A"})
+        
+        assert d2 == d1
+ 
     def test_eq_other_mapping_contains_more_keys(self, cls: _MultiDictClasses) -> None:
         d1 = cls(foo="bar")
         d2 = dict(foo="bar", bar="baz")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- sorting the list before comparing under `__eq__()` in `_multidict_py.py`
- added `test_eq4 ` for the same in `test_multidict.py`

## Are there changes in behavior for the user?

Before
```
>>> import multidict
>>> a = multidict.CIMultiDict({"a": "A", "b": "B"})
>>> b = multidict.CIMultiDict({"b": "B", "a": "A"})
>>> a == b
False
```
Now
```
>>> import multidict
>>> a = multidict.CIMultiDict({"a": "A", "b": "B"})
>>> b = multidict.CIMultiDict({"b": "B", "a": "A"})
>>> a == b
True
```

## Related issue number
issue : [#823 Equality operator](https://github.com/aio-libs/multidict/issues/823)
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist
 
- [✅] I think the code is well written
- [✅] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
