### PR TITLE
Adapt the CPython 3.9+ C-API usage to use newer macros

### DIFF
--- a/CHANGES/864.bugfix.rst
+++ b/CHANGES/864.bugfix.rst
@@ -1,0 +1,2 @@
+Upgraded the C-API macros that have been deprecated in
+Python 3.9 and later removed in 3.13 -- :user:`webknjaz`.

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -709,20 +709,20 @@ static inline void
 multidict_tp_dealloc(MultiDictObject *self)
 {
     PyObject_GC_UnTrack(self);
-#if PY_VERSION_HEX < 0x03090000
-    Py_TRASHCAN_SAFE_BEGIN(self);
-#else
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
     Py_TRASHCAN_BEGIN(self, multidict_tp_dealloc)
+#else
+    Py_TRASHCAN_SAFE_BEGIN(self);
 #endif
     if (self->weaklist != NULL) {
         PyObject_ClearWeakRefs((PyObject *)self);
     };
     pair_list_dealloc(&self->pairs);
     Py_TYPE(self)->tp_free((PyObject *)self);
-#if PY_VERSION_HEX < 0x03090000
-    Py_TRASHCAN_SAFE_END(self);
-#else
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
     Py_TRASHCAN_END // there should be no code after this
+#else
+    Py_TRASHCAN_SAFE_END(self);
 #endif
 }
 

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -1666,6 +1666,7 @@ getversion(PyObject *self, PyObject *md)
 static inline void
 module_free(void *m)
 {
+    Py_CLEAR(multidict_str_lower);
     Py_CLEAR(collections_abc_mapping);
     Py_CLEAR(collections_abc_mut_mapping);
     Py_CLEAR(collections_abc_mut_multi_mapping);
@@ -1694,6 +1695,11 @@ static PyModuleDef multidict_module = {
 PyMODINIT_FUNC
 PyInit__multidict()
 {
+    multidict_str_lower = PyUnicode_InternFromString("lower");
+    if (multidict_str_lower == NULL) {
+        goto fail;
+    }
+
     PyObject *module = NULL,
              *reg_func_call_result = NULL;
 
@@ -1824,6 +1830,7 @@ PyInit__multidict()
     return module;
 
 fail:
+    Py_XDECREF(multidict_str_lower);
     Py_XDECREF(collections_abc_mapping);
     Py_XDECREF(collections_abc_mut_mapping);
     Py_XDECREF(collections_abc_mut_multi_mapping);

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -1666,7 +1666,9 @@ getversion(PyObject *self, PyObject *md)
 static inline void
 module_free(void *m)
 {
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
     Py_CLEAR(multidict_str_lower);
+#endif
     Py_CLEAR(collections_abc_mapping);
     Py_CLEAR(collections_abc_mut_mapping);
     Py_CLEAR(collections_abc_mut_multi_mapping);
@@ -1695,10 +1697,12 @@ static PyModuleDef multidict_module = {
 PyMODINIT_FUNC
 PyInit__multidict()
 {
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
     multidict_str_lower = PyUnicode_InternFromString("lower");
     if (multidict_str_lower == NULL) {
         goto fail;
     }
+#endif
 
     PyObject *module = NULL,
              *reg_func_call_result = NULL;
@@ -1830,7 +1834,9 @@ PyInit__multidict()
     return module;
 
 fail:
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
     Py_XDECREF(multidict_str_lower);
+#endif
     Py_XDECREF(collections_abc_mapping);
     Py_XDECREF(collections_abc_mut_mapping);
     Py_XDECREF(collections_abc_mut_multi_mapping);

--- a/multidict/_multilib/defs.h
+++ b/multidict/_multilib/defs.h
@@ -5,7 +5,9 @@
 extern "C" {
 #endif
 
+#if PY_VERSION_HEX < 0x0309000
 _Py_IDENTIFIER(lower);
+#endif
 
 /* We link this module statically for convenience.  If compiled as a shared
    library instead, some compilers don't allow addresses of Python objects

--- a/multidict/_multilib/defs.h
+++ b/multidict/_multilib/defs.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#if PY_VERSION_HEX < 0x0309000
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION < 9
 _Py_IDENTIFIER(lower);
 #endif
 

--- a/multidict/_multilib/defs.h
+++ b/multidict/_multilib/defs.h
@@ -5,7 +5,9 @@
 extern "C" {
 #endif
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION < 9
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
+static PyObject *multidict_str_lower = NULL;
+#else
 _Py_IDENTIFIER(lower);
 #endif
 

--- a/multidict/_multilib/istr.h
+++ b/multidict/_multilib/istr.h
@@ -43,10 +43,10 @@ istr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (!ret) {
         goto fail;
     }
-#if PY_VERSION_HEX < 0x03090000
-    s =_PyObject_CallMethodId(ret, &PyId_lower, NULL);
-#else
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
     s = PyObject_CallMethod(ret, "lower", NULL);
+#else
+    s =_PyObject_CallMethodId(ret, &PyId_lower, NULL);
 #endif
     if (!s) {
         goto fail;

--- a/multidict/_multilib/istr.h
+++ b/multidict/_multilib/istr.h
@@ -43,7 +43,11 @@ istr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (!ret) {
         goto fail;
     }
+#if PY_VERSION_HEX < 0x03090000
     s =_PyObject_CallMethodId(ret, &PyId_lower, NULL);
+#else
+    s = PyObject_CallMethod(ret, "lower", NULL);
+#endif
     if (!s) {
         goto fail;
     }

--- a/multidict/_multilib/istr.h
+++ b/multidict/_multilib/istr.h
@@ -44,7 +44,7 @@ istr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         goto fail;
     }
 #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 9
-    s = PyObject_CallMethod(ret, "lower", NULL);
+    s = PyObject_CallMethodNoArgs(ret, multidict_str_lower);
 #else
     s =_PyObject_CallMethodId(ret, &PyId_lower, NULL);
 #endif

--- a/multidict/_multilib/pair_list.h
+++ b/multidict/_multilib/pair_list.h
@@ -8,8 +8,7 @@ extern "C" {
 #include <string.h>
 #include <stddef.h>
 #include <stdint.h>
-
-typedef PyObject * (*calc_identity_func)(PyObject *key);
+#include <stdbool.h>
 
 typedef struct pair {
     PyObject  *identity;  // 8
@@ -38,12 +37,13 @@ HTTP headers into the buffer without allocating an extra memory block.
 #define EMBEDDED_CAPACITY 29
 #endif
 
-typedef struct pair_list {  // 40
-    Py_ssize_t  capacity;   // 8
-    Py_ssize_t  size;       // 8
-    uint64_t  version;      // 8
-    calc_identity_func calc_identity;  // 8
-    pair_t *pairs;          // 8
+typedef struct pair_list {
+    Py_ssize_t capacity;
+    Py_ssize_t size;
+    uint64_t version;
+    bool calc_ci_indentity;
+    PyObject *str_lower;
+    pair_t *pairs;
     pair_t buffer[EMBEDDED_CAPACITY];
 } pair_list_t;
 
@@ -101,7 +101,7 @@ key_to_str(PyObject *key)
 
 
 static inline PyObject *
-ci_key_to_str(PyObject *key)
+ci_key_to_str(PyObject *str_lower, PyObject *key)
 {
     PyObject *ret;
     PyTypeObject *type = Py_TYPE(key);
@@ -111,7 +111,11 @@ ci_key_to_str(PyObject *key)
         return ret;
     }
     if (PyUnicode_Check(key)) {
+#if PY_VERSION_HEX < 0x03090000
         return _PyObject_CallMethodId(key, &PyId_lower, NULL);
+#else
+        return PyObject_CallMethodNoArgs(key, str_lower);
+#endif
     }
     PyErr_SetString(PyExc_TypeError,
                     "CIMultiDict keys should be either str "
@@ -199,29 +203,42 @@ pair_list_shrink(pair_list_t *list)
 
 
 static inline int
-_pair_list_init(pair_list_t *list, calc_identity_func calc_identity)
+_pair_list_init(pair_list_t *list, bool calc_ci_identity)
 {
+    PyObject *str_lower = PyUnicode_InternFromString("lower");
+    if (str_lower == NULL) {
+        return -1;
+    }
+    list->str_lower = str_lower;
+    list->calc_ci_indentity = calc_ci_identity;
     list->pairs = list->buffer;
     list->capacity = EMBEDDED_CAPACITY;
     list->size = 0;
     list->version = NEXT_VERSION();
-    list->calc_identity = calc_identity;
     return 0;
 }
 
 static inline int
 pair_list_init(pair_list_t *list)
 {
-    return _pair_list_init(list, key_to_str);
+    return _pair_list_init(list, /* calc_ci_identity = */ false);
 }
 
 
 static inline int
 ci_pair_list_init(pair_list_t *list)
 {
-    return _pair_list_init(list, ci_key_to_str);
+    return _pair_list_init(list, /* calc_ci_identity = */ true);
 }
 
+
+static inline PyObject *
+pair_list_calc_identity(pair_list_t *list, PyObject *key)
+{
+    if (list->calc_ci_indentity)
+        return ci_key_to_str(list->str_lower, key);
+    return key_to_str(key);
+}
 
 static inline void
 pair_list_dealloc(pair_list_t *list)
@@ -252,6 +269,8 @@ pair_list_dealloc(pair_list_t *list)
         list->pairs = list->buffer;
         list->capacity = EMBEDDED_CAPACITY;
     }
+
+    Py_CLEAR(list->str_lower);
 }
 
 
@@ -304,7 +323,7 @@ pair_list_add(pair_list_t *list,
     PyObject *identity = NULL;
     int ret;
 
-    identity = list->calc_identity(key);
+    identity = pair_list_calc_identity(list, key);
     if (identity == NULL) {
         goto fail;
     }
@@ -412,7 +431,7 @@ pair_list_del(pair_list_t *list, PyObject *key)
     Py_hash_t hash;
     int ret;
 
-    identity = list->calc_identity(key);
+    identity = pair_list_calc_identity(list, key);
     if (identity == NULL) {
         goto fail;
     }
@@ -486,7 +505,7 @@ pair_list_contains(pair_list_t *list, PyObject *key)
     PyObject *identity = NULL;
     int tmp;
 
-    ident = list->calc_identity(key);
+    ident = pair_list_calc_identity(list, key);
     if (ident == NULL) {
         goto fail;
     }
@@ -528,7 +547,7 @@ pair_list_get_one(pair_list_t *list, PyObject *key)
     PyObject *value = NULL;
     int tmp;
 
-    ident = list->calc_identity(key);
+    ident = pair_list_calc_identity(list, key);
     if (ident == NULL) {
         goto fail;
     }
@@ -573,7 +592,7 @@ pair_list_get_all(pair_list_t *list, PyObject *key)
     PyObject *res = NULL;
     int tmp;
 
-    ident = list->calc_identity(key);
+    ident = pair_list_calc_identity(list, key);
     if (ident == NULL) {
         goto fail;
     }
@@ -631,7 +650,7 @@ pair_list_set_default(pair_list_t *list, PyObject *key, PyObject *value)
     PyObject *value2 = NULL;
     int tmp;
 
-    ident = list->calc_identity(key);
+    ident = pair_list_calc_identity(list, key);
     if (ident == NULL) {
         goto fail;
     }
@@ -680,7 +699,7 @@ pair_list_pop_one(pair_list_t *list, PyObject *key)
     int tmp;
     PyObject *ident = NULL;
 
-    ident = list->calc_identity(key);
+    ident = pair_list_calc_identity(list, key);
     if (ident == NULL) {
         goto fail;
     }
@@ -730,7 +749,7 @@ pair_list_pop_all(pair_list_t *list, PyObject *key)
     PyObject *res = NULL;
     PyObject *ident = NULL;
 
-    ident = list->calc_identity(key);
+    ident = pair_list_calc_identity(list, key);
     if (ident == NULL) {
         goto fail;
     }
@@ -826,7 +845,7 @@ pair_list_replace(pair_list_t *list, PyObject * key, PyObject *value)
     PyObject *identity = NULL;
     Py_hash_t hash;
 
-    identity = list->calc_identity(key);
+    identity = pair_list_calc_identity(list, key);
     if (identity == NULL) {
         goto fail;
     }
@@ -1101,7 +1120,7 @@ pair_list_update_from_seq(pair_list_t *list, PyObject *seq)
         Py_INCREF(key);
         Py_INCREF(value);
 
-        identity = list->calc_identity(key);
+        identity = pair_list_calc_identity(list, key);
         if (identity == NULL) {
             goto fail_1;
         }


### PR DESCRIPTION
This patch replaces the C-APIs that have been deprecated in Python 3.9 and later removed in 3.13.

<!-- Thank you for your contribution! -->

## What do these changes do?

1. Fix usage Python C API for version greater than 3.9
2. Fix segfault which I catch here https://github.com/aio-libs/multidict/blob/master/multidict/_multidict.c#L783

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

## Related issue number

Fixes #862