### PR TITLE
Enable universal wheel build on CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -173,8 +173,11 @@ jobs:
       matrix:
         os: [ubuntu, windows, macos]
         qemu: ['']
+        noextensions: ['0']
         include:
-          # Split ubuntu job for the sake of speed-up
+          # Add a pure python build and qemu builds
+        - os: ubuntu
+          noextensions: '1'
         - os: ubuntu
           qemu: aarch64
         - os: ubuntu
@@ -202,6 +205,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.16.1
       env:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+        CIBW_ENVIRONMENT: MULTIDICT_NO_EXTENSIONS=${{ matrix.noextensions }}
     - uses: actions/upload-artifact@v3
       with:
         name: dist

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Changelog
     file is managed by towncrier. You *may* edit previous change logs to
     fix problems like typo corrections or such.
     To add a new change log entry, please see
-    https://pip.pypa.io/en/latest/development/#adding-a-news-entry
+    https://pip.pypa.io/en/latest/development/contributing/#news-entries
     we named the news folder "changes".
 
     WARNING: Don't drop the next directive!

--- a/CHANGES/881.feature.rst
+++ b/CHANGES/881.feature.rst
@@ -1,0 +1,1 @@
+Enable publishing a universal (pure Python) wheel on PyPI

--- a/multidict/_compat.py
+++ b/multidict/_compat.py
@@ -1,7 +1,7 @@
 import os
 import platform
 
-NO_EXTENSIONS = bool(os.environ.get("MULTIDICT_NO_EXTENSIONS"))
+NO_EXTENSIONS = os.environ.get("MULTIDICT_NO_EXTENSIONS", "0") == "1"
 
 PYPY = platform.python_implementation() == "PyPy"
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 
 from setuptools import Extension, setup
 
-NO_EXTENSIONS = bool(os.environ.get("MULTIDICT_NO_EXTENSIONS"))
+NO_EXTENSIONS = os.environ.get("MULTIDICT_NO_EXTENSIONS", "0") == "1"
 
 if sys.implementation.name != "cpython":
     NO_EXTENSIONS = True


### PR DESCRIPTION
## What do these changes do?

Enable building of universal (pure python) build on the CD release pipeline.

## Are there changes in behavior for the user?

A universal wheel will be available on PyPI.

## Related issue number

Fixes #881

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder

## Details

The PR has not been tested yet: running the workflow in a fork does not work so I'll have to rely on the test results here in the PR...