### PR TITLE
Fix segfaults when using kwargs on py3.12

### DIFF
--- a/CHANGES/868.bugfix
+++ b/CHANGES/868.bugfix
@@ -1,0 +1,1 @@
+Fix segfaults when using keyword arguments on python 3.12

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -455,7 +455,11 @@ multidict_getall(MultiDictObject *self, PyObject *const *args,
         return NULL;
     }
 #else
-    static _PyArg_Parser _parser = {NULL, _keywords, "getall", 0};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "getall",
+        .kwtuple = NULL,
+    };
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames,
@@ -500,7 +504,11 @@ multidict_getone(MultiDictObject *self, PyObject *const *args,
         return NULL;
     }
 #else
-    static _PyArg_Parser _parser = {NULL, _keywords, "getone", 0};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "getone",
+        .kwtuple = NULL,
+    };
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames,
@@ -535,7 +543,11 @@ multidict_get(MultiDictObject *self, PyObject *const *args,
         return NULL;
     }
 #else
-    static _PyArg_Parser _parser = {NULL, _keywords, "get", 0};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "get",
+        .kwtuple = NULL,
+    };
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames,
@@ -777,7 +789,11 @@ multidict_add(MultiDictObject *self, PyObject *const *args,
         return NULL;
     }
 #else
-    static _PyArg_Parser _parser = {NULL, _keywords, "add", 0};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "add",
+        .kwtuple = NULL,
+    };
     PyObject *argsbuf[2];
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames,
@@ -836,7 +852,11 @@ multidict_setdefault(MultiDictObject *self, PyObject *const *args,
         return NULL;
     }
 #else
-    static _PyArg_Parser _parser = {NULL, _keywords, "setdefault", 0};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "setdefault",
+        .kwtuple = NULL,
+    };
     PyObject *argsbuf[3];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
 
@@ -872,7 +892,11 @@ multidict_popone(MultiDictObject *self, PyObject *const *args,
         return NULL;
     }
 #else
-    static _PyArg_Parser _parser = {NULL, _keywords, "popone", 0};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "popone",
+        .kwtuple = NULL,
+    };
     PyObject *argsbuf[3];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
 
@@ -919,7 +943,11 @@ multidict_pop(MultiDictObject *self, PyObject *const *args,
         return NULL;
     }
 #else
-    static _PyArg_Parser _parser = {NULL, _keywords, "pop", 0};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "pop",
+        .kwtuple = NULL,
+    };
     PyObject *argsbuf[3];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
 
@@ -967,7 +995,11 @@ multidict_popall(MultiDictObject *self, PyObject *const *args,
         return NULL;
     }
 #else
-    static _PyArg_Parser _parser = {NULL, _keywords, "popall", 0};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "popall",
+        .kwtuple = NULL,
+    };
     PyObject *argsbuf[3];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -199,6 +199,7 @@ class BaseMultiDictTest:
             d.getone("key2")
 
         assert d.getone("key2", "default") == "default"
+        assert d.getone(key="key2", default="default") == "default"
 
     def test__iter__(
         self,
@@ -532,6 +533,9 @@ class TestMultiDict(BaseMultiDictTest):
     def test_get(self, cls: Type[MultiDict[int]]) -> None:
         d = cls([("a", 1), ("a", 2)])
         assert d["a"] == 1
+        assert d.get("a") == 1
+        assert d.get("z", 3) == 3
+        assert d.get(key="z", default=3) == 3
 
     def test_items__repr__(self, cls: Type[MultiDict[str]]) -> None:
         d = cls([("key", "value1")], key="value2")

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -535,7 +535,6 @@ class TestMultiDict(BaseMultiDictTest):
         assert d["a"] == 1
         assert d.get("a") == 1
         assert d.get("z", 3) == 3
-        assert d.get(key="z", default=3) == 3
 
     def test_items__repr__(self, cls: Type[MultiDict[str]]) -> None:
         d = cls([("key", "value1")], key="value2")

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -44,6 +44,7 @@ class TestMutableMultiDict:
 
         default = object()
         assert d.getall("some_key", default) is default
+        assert d.getall(key="some_key", default=default) is default
 
     def test_add(self, cls):
         d = cls()
@@ -124,7 +125,7 @@ class TestMutableMultiDict:
     def test_set_default(self, cls):
         d = cls([("key", "one"), ("key", "two")], foo="bar")
         assert "one" == d.setdefault("key", "three")
-        assert "three" == d.setdefault("otherkey", "three")
+        assert "three" == d.setdefault(key="otherkey", default="three")
         assert "otherkey" in d
         assert "three" == d["otherkey"]
 
@@ -163,6 +164,7 @@ class TestMutableMultiDict:
         d = cls(other="val")
 
         assert "default" == d.pop("key", "default")
+        assert "default" == d.pop(key="key", default="default")
         assert "other" in d
 
     def test_pop_raises(self, cls):
@@ -229,6 +231,7 @@ class TestMutableMultiDict:
     def test_popall_default(self, cls):
         d = cls()
         assert "val" == d.popall("key", "val")
+        assert "val" == d.popall(key="key", default="val")
 
     def test_popall_key_error(self, cls):
         d = cls()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -95,6 +95,8 @@ class VersionMixin:
         v = self.getver(m)
         m.popone("key2", "default")
         assert self.getver(m) == v
+        m.popone(key="key2", default="default")
+        assert self.getver(m) == v
 
     def test_popone_key_error(self):
         m = self.cls()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

If you use keyword args with py3.12, parser initialization causes a segfault.
It was noticed in https://github.com/aio-libs/multidict/issues/868 but actually there are more methods affected.

## Are there changes in behavior for the user?

No more segfaults on 3.12

## Related issue number

https://github.com/aio-libs/multidict/issues/868

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
