### PR TITLE
Allow `.packaging` suffix in CHANGES

### DIFF
--- a/CHANGES/907.misc.rst
+++ b/CHANGES/907.misc.rst
@@ -1,0 +1,1 @@
+Allow ``.packaging`` suffix in CHANGES -- :user:`edgarrmondragon`.

--- a/tools/check_changes.py
+++ b/tools/check_changes.py
@@ -4,7 +4,14 @@ import sys
 from pathlib import Path
 
 
-ALLOWED_SUFFIXES = [".feature", ".bugfix", ".doc", ".removal", ".misc"]
+ALLOWED_SUFFIXES = [
+    ".feature",
+    ".bugfix",
+    ".doc",
+    ".removal",
+    ".misc",
+    ".packaging",
+]
 
 
 def get_root(script_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Addresses the failing pipeline in https://github.com/aio-libs/multidict/pull/877.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

None

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
