### PR TITLE
Fix the Towncrier philosophy link

### DIFF
--- a/CHANGES/911.doc.rst
+++ b/CHANGES/911.doc.rst
@@ -1,0 +1,2 @@
+On the `Contributing docs <https://github.com/aio-libs/multidict/blob/master/CHANGES/README.rst>`_ page,
+a link to the ``Towncrier philosophy`` has been fixed.

--- a/CHANGES/README.rst
+++ b/CHANGES/README.rst
@@ -96,4 +96,4 @@ File :file:`CHANGES/553.feature.rst`:
 
 
 .. _Towncrier philosophy:
-   https://towncrier.readthedocs.io/en/actual-freaking-docs/#philosophy
+   https://towncrier.readthedocs.io/en/stable/#philosophy


### PR DESCRIPTION
_Hello @webknjaz,_
There's one more broken link to fix.

## What do these changes do?

These changes fix a broken link to `towncrier`'s philosophy.

## Are there changes in behavior for the user?

Link from [Contributing docs](https://github.com/aio-libs/multidict/blob/master/CHANGES/README.rst) to `towncrier`'s philosophy will be fixed.

## Related issue number

Similar PR:
  * aio-libs/frozenlist#574

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes

_Best regards!_