### PR TITLE
🧪 Drop the explicit `__init__.py` from `tests/`

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -25,6 +25,5 @@ warn_unreachable = True
 warn_unused_ignores = True
 warn_return_any = True
 
-[mypy-tests.*]
-disallow_any_decorated = False
-disallow_untyped_calls = False
+[mypy-test_multidict]
+disable_error_code = misc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,21 @@ repos:
 
 - repo: local
   hooks:
+  - id: top-level-tests-init-py
+    name: changelog filenames
+    language: fail
+    entry: >-
+      The `tests/__init__.py` module must not exist so `pytest` doesn't add the
+      project root to `sys.path` / `$PYTHONPATH`
+    files: >-
+      (?x)
+      ^
+        tests/__init__\.py
+      $
+    types: []
+    types_or:
+    - file
+    - symlink
   - id: changelogs-rst
     name: changelog filenames
     language: fail


### PR DESCRIPTION
This ensures that `pytest` does not inject the project directory into `sys.path` / `$PYTHONPATH`.