### PR TITLE
🧪💅 Deduplicate MyPy config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,12 +67,3 @@ norecursedirs = dist build .tox docs requirements tools
 addopts = --doctest-modules --cov=multidict --cov-report term-missing:skip-covered --cov-report xml --junitxml=junit-test-results.xml -v
 doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 junit_family = xunit2
-
-[mypy]
-
-[mypy-pytest]
-ignore_missing_imports = true
-
-
-[mypy-multidict._multidict]
-ignore_missing_imports = true


### PR DESCRIPTION
Previously, there were MyPy sections in `setup.cfg` and `.mypy.ini`. It seems like the ones in `setup.cfg` were never used because MyPy was loading the other file, which created confusion. Now, there is only one MyPy config in a dedicated file.