### PR TITLE
Fix `MultiDict.items().isdisjoint()` for C Extensions

### DIFF
--- a/CHANGES/927.bugfix.rst
+++ b/CHANGES/927.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a ``SystemError: null argument to internal routine`` error on
+a ``MultiDict.items().isdisjoint()`` call when using C Extensions.

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -409,7 +409,7 @@ multidict_views_init(void)
     GET_MOD_ATTR(abc_keysview_register_func, "_abc_keysview_register");
     GET_MOD_ATTR(abc_valuesview_register_func, "_abc_valuesview_register");
 
-    GET_MOD_ATTR(itemsview_repr_func, "_itemsview_isdisjoint");
+    GET_MOD_ATTR(itemsview_isdisjoint_func, "_itemsview_isdisjoint");
     GET_MOD_ATTR(itemsview_repr_func, "_itemsview_repr");
 
     GET_MOD_ATTR(keysview_repr_func, "_keysview_repr");

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -417,13 +417,16 @@ class BaseMultiDictTest:
 
         assert {"key", "key3"} == {"key2", "key3"} ^ d.keys()
 
-    @pytest.mark.parametrize(("set_", "expected"), (({"key2"}, True), ({"key"}, False)))
+    @pytest.mark.parametrize(
+        ("key", "value", "expected"),
+        (("key2", "v", True), ("key", "value1", False)),
+    )
     def test_isdisjoint(
-        self, cls: Type[MutableMultiMapping[str]], set_: Set[str], expected: bool
+        self, cls: Type[MutableMultiMapping[str]], key: str, value: str, expected: bool
     ) -> None:
         d = cls([("key", "value1")])
-
-        assert d.keys().isdisjoint(set_) == expected
+        assert d.items().isdisjoint({(key, value)}) is expected
+        assert d.keys().isdisjoint({key}) is expected
 
     def test_repr_aiohttp_issue_410(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls()


### PR DESCRIPTION
_Hello @webknjaz,_

## What do these changes do?

These changes fix a mismatch at `views.h` that causes `SystemError: null argument to internal routine` when calling `MultiDict.items().isdisjoint()`.

## Are there changes in behavior for the user?

`MultiDict.items().isdisjoint()` will not cause a `SystemError` when using C Extensions.

## Related issue number

Semi-related issue:
  * #921

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes

_Best regards!_