### PR TITLE
Add tests to have full code coverage of the function `_viewbaseset_richcmp`

### DIFF
--- a/CHANGES/928.bugfix.rst
+++ b/CHANGES/928.bugfix.rst
@@ -1,0 +1,3 @@
+Covered the unreachable code path in
+``multidict._multidict_base._abc_itemsview_register()``
+with typing -- by :user:`skinnyBat`.

--- a/CHANGES/928.contrib.rst
+++ b/CHANGES/928.contrib.rst
@@ -1,1 +1,3 @@
-Added tests to have full code coverage of the ``_viewbaseset_richcmp`` function -- by :user:`skinnyBat`
+Added tests to have full code coverage of the
+``multidict._multidict_base._viewbaseset_richcmp()`` function
+-- by :user:`skinnyBat`.

--- a/CHANGES/928.contrib.rst
+++ b/CHANGES/928.contrib.rst
@@ -1,0 +1,1 @@
+Added tests to have full code coverage of the ``_viewbaseset_richcmp`` function -- by :user:`skinnyBat`

--- a/multidict/_multidict_base.py
+++ b/multidict/_multidict_base.py
@@ -46,6 +46,8 @@ def _viewbaseset_richcmp(view, other, op):
             if elem not in view:
                 return False
         return True
+    else:  # pragma: no cover
+        return NotImplemented
 
 
 def _viewbaseset_and(view, other):

--- a/multidict/_multidict_base.py
+++ b/multidict/_multidict_base.py
@@ -4,10 +4,7 @@ from collections.abc import ItemsView, Iterable, KeysView, Set, ValuesView
 if sys.version_info >= (3, 11):
     from typing import assert_never
 else:
-    from typing import Any, NoReturn
-
-    def assert_never(value: Any) -> NoReturn:
-        raise AssertionError(f"Expected code to be unreachable, but got: {value!r}")
+    from typing_extensions import assert_never
 
 
 def _abc_itemsview_register(view_cls):

--- a/multidict/_multidict_base.py
+++ b/multidict/_multidict_base.py
@@ -1,4 +1,13 @@
+import sys
 from collections.abc import ItemsView, Iterable, KeysView, Set, ValuesView
+
+if sys.version_info >= (3, 11):
+    from typing import assert_never
+else:
+    from typing import Any, NoReturn
+
+    def assert_never(value: Any) -> NoReturn:
+        raise AssertionError(f"Expected code to be unreachable, but got: {value!r}")
 
 
 def _abc_itemsview_register(view_cls):
@@ -47,7 +56,7 @@ def _viewbaseset_richcmp(view, other, op):
                 return False
         return True
     else:  # pragma: no cover
-        return NotImplemented
+        assert_never(op)
 
 
 def _viewbaseset_and(view, other):

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ classifiers =
 [options]
 python_requires = >= 3.7
 install_requires =
-  typing-extensions >= 4.1.0;python_version<'3.11'
+  typing-extensions >= 4.1.0; python_version < '3.11'
 packages =
   multidict
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,8 @@ classifiers =
 
 [options]
 python_requires = >= 3.7
+install_requires =
+  typing-extensions >= 4.1.0;python_version<'3.11'
 packages =
   multidict
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -303,7 +303,8 @@ class BaseMultiDictTest:
     ) -> None:
         d = cls(contents)
 
-        assert (d.keys() <= {"key", "key2"}) == expected
+        result = d.keys() <= {"key", "key2"}
+        assert result is expected
 
     def test_keys_is_set_equal(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
@@ -329,7 +330,8 @@ class BaseMultiDictTest:
     ) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])
 
-        assert (d.keys() >= set_) == expected
+        result = d.keys() >= set_
+        assert result is expected
 
     @pytest.mark.parametrize("op", (operator.le, operator.lt, operator.ge, operator.gt))
     def test_keys_compare_type_error(
@@ -337,7 +339,12 @@ class BaseMultiDictTest:
     ) -> None:
         d = cls([("key", "value1")])
 
-        with pytest.raises(TypeError):
+        with pytest.raises(
+            TypeError,
+            match=(
+                "^'.+' not supported between instances of '.*_KeysView' and 'NoneType'$"
+            ),
+        ):
             op(d.keys(), None)
 
     def test_keys_is_set_not_equal(self, cls: Type[MutableMultiMapping[str]]) -> None:

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -286,10 +286,24 @@ class BaseMultiDictTest:
 
         assert d.keys() < {"key", "key2"}
 
-    def test_keys_is_set_less_equal(self, cls: Type[MutableMultiMapping[str]]) -> None:
-        d = cls([("key", "value1")])
+    @pytest.mark.parametrize(
+        ("contents", "expected"),
+        (
+            ([("key", "value1")], True),
+            ([("key", "value1"), ("key2", "value2")], True),
+            ([("key", "value1"), ("key2", "value2"), ("key3", "value3")], False),
+            ([("key", "value1"), ("key3", "value3")], False),
+        ),
+    )
+    def test_keys_is_set_less_equal(
+        self,
+        cls: Type[MutableMultiMapping[str]],
+        contents: List[Tuple[str, str]],
+        expected: bool,
+    ) -> None:
+        d = cls(contents)
 
-        assert d.keys() <= {"key"}
+        assert (d.keys() <= {"key", "key2"}) == expected
 
     def test_keys_is_set_equal(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
@@ -297,22 +311,46 @@ class BaseMultiDictTest:
         assert d.keys() == {"key"}
 
     def test_keys_is_set_greater(self, cls: Type[MutableMultiMapping[str]]) -> None:
-        d = cls([("key", "value1")])
+        d = cls([("key", "value1"), ("key2", "value2")])
 
-        assert {"key", "key2"} > d.keys()
+        assert d.keys() > {"key"}
 
+    @pytest.mark.parametrize(
+        ("set_", "expected"),
+        (
+            ({"key"}, True),
+            ({"key", "key2"}, True),
+            ({"key", "key2", "key3"}, False),
+            ({"key3"}, False),
+        ),
+    )
     def test_keys_is_set_greater_equal(
-        self,
-        cls: Type[MutableMultiMapping[str]],
+        self, cls: Type[MutableMultiMapping[str]], set_: Set[str], expected: bool
+    ) -> None:
+        d = cls([("key", "value1"), ("key2", "value2")])
+
+        assert (d.keys() >= set_) == expected
+
+    @pytest.mark.parametrize("op", (operator.le, operator.lt, operator.ge, operator.gt))
+    def test_keys_compare_type_error(
+        self, cls: Type[MutableMultiMapping[str]], op: Callable[[object, object], bool]
     ) -> None:
         d = cls([("key", "value1")])
 
-        assert {"key"} >= d.keys()
+        with pytest.raises(TypeError):
+            op(d.keys(), None)
 
     def test_keys_is_set_not_equal(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
 
         assert d.keys() != {"key2"}
+
+    def test_keys_not_equal_unrelated_type(
+        self, cls: Type[MutableMultiMapping[str]]
+    ) -> None:
+        d = cls([("key", "value1")])
+
+        assert d.keys() != "other"
 
     def test_eq(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -333,19 +333,61 @@ class BaseMultiDictTest:
         result = d.keys() >= set_
         assert result is expected
 
-    @pytest.mark.parametrize("op", (operator.le, operator.lt, operator.ge, operator.gt))
-    def test_keys_compare_type_error(
-        self, cls: Type[MutableMultiMapping[str]], op: Callable[[object, object], bool]
+    def test_keys_less_than_not_implemented(
+        self, cls: Type[MutableMultiMapping[str]]
     ) -> None:
         d = cls([("key", "value1")])
 
-        with pytest.raises(
-            TypeError,
-            match=(
-                "^'.+' not supported between instances of '.*_KeysView' and 'NoneType'$"
-            ),
-        ):
-            op(d.keys(), None)
+        sentinel_operation_result = object()
+
+        class RightOperand:
+            def __gt__(self, other: KeysView[str]) -> object:
+                assert isinstance(other, KeysView)
+                return sentinel_operation_result
+
+        assert (d.keys() < RightOperand()) is sentinel_operation_result
+
+    def test_keys_less_than_or_equal_not_implemented(
+        self, cls: Type[MutableMultiMapping[str]]
+    ) -> None:
+        d = cls([("key", "value1")])
+
+        sentinel_operation_result = object()
+
+        class RightOperand:
+            def __ge__(self, other: KeysView[str]) -> object:
+                assert isinstance(other, KeysView)
+                return sentinel_operation_result
+
+        assert (d.keys() <= RightOperand()) is sentinel_operation_result
+
+    def test_keys_greater_than_not_implemented(
+        self, cls: Type[MutableMultiMapping[str]]
+    ) -> None:
+        d = cls([("key", "value1")])
+
+        sentinel_operation_result = object()
+
+        class RightOperand:
+            def __lt__(self, other: KeysView[str]) -> object:
+                assert isinstance(other, KeysView)
+                return sentinel_operation_result
+
+        assert (d.keys() > RightOperand()) is sentinel_operation_result
+
+    def test_keys_greater_than_or_equal_not_implemented(
+        self, cls: Type[MutableMultiMapping[str]]
+    ) -> None:
+        d = cls([("key", "value1")])
+
+        sentinel_operation_result = object()
+
+        class RightOperand:
+            def __le__(self, other: KeysView[str]) -> object:
+                assert isinstance(other, KeysView)
+                return sentinel_operation_result
+
+        assert (d.keys() >= RightOperand()) is sentinel_operation_result
 
     def test_keys_is_set_not_equal(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])


### PR DESCRIPTION
## What do these changes do?

Add tests to improve the code coverage of `_multidict_base_py`, by fully covering the `_viewbaseset_richcmp` function.

## Are there changes in behavior for the user?

None

## Related issue number

Partially addresses https://github.com/aio-libs/multidict/issues/921.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
