### PR TITLE
Fix SEGFAULTs under Python 3.12 by using public C-API

### DIFF
--- a/CHANGES/909.bugfix.rst
+++ b/CHANGES/909.bugfix.rst
@@ -1,3 +1,10 @@
-Revert to using the public argument parsing API
-:c:func:`PyArg_ParseTupleAndKeywords` under Python 3.13
--- :user:`webknjaz`.
+Reverted to using the public argument parsing API
+:c:func:`PyArg_ParseTupleAndKeywords` under Python 3.12
+-- by :user:`charles-dyfis-net` and :user:`webknjaz`.
+
+The effect is that this change prevents build failures with
+clang 16.9.6 and gcc-14 reported in :issue:`926`. It also
+fixes a segmentation fault crash caused by passing keyword
+arguments to :py:meth:`MultiDict.getall()
+<multidict.MultiDict.getall>` discovered by :user:`jonaslb`
+and :user:`hroncok` while examining the problem.

--- a/CHANGES/926.bugfix.rst
+++ b/CHANGES/926.bugfix.rst
@@ -1,0 +1,1 @@
+909.bugfix.rst

--- a/CHANGES/929.bugfix.rst
+++ b/CHANGES/929.bugfix.rst
@@ -1,0 +1,1 @@
+909.bugfix.rst

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -33,6 +33,7 @@ eof
 fallback
 fastpath
 filename
+gcc
 getitem
 github
 google

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -9,7 +9,7 @@
 #include "_multilib/iter.h"
 #include "_multilib/views.h"
 
-#if PY_MAJOR_VERSION < 3 || PY_MINOR_VERSION < 13
+#if PY_MAJOR_VERSION < 3 || PY_MINOR_VERSION < 12
 #ifndef _PyArg_UnpackKeywords
 #define FASTCALL_OLD
 #endif
@@ -444,7 +444,7 @@ fail:
 static inline PyObject *
 multidict_getall(
     MultiDictObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -458,7 +458,7 @@ multidict_getall(
              *key      = NULL,
              *_default = NULL;
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     static char *getall_keywords[] = {"key", "default", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:getall",
@@ -509,7 +509,7 @@ skip_optional_pos:
 static inline PyObject *
 multidict_getone(
     MultiDictObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -522,7 +522,7 @@ multidict_getone(
     PyObject *key      = NULL,
              *_default = NULL;
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     static char *getone_keywords[] = {"key", "default", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:getone",
@@ -563,7 +563,7 @@ skip_optional_pos:
 static inline PyObject *
 multidict_get(
     MultiDictObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -577,7 +577,7 @@ multidict_get(
              *_default = Py_None,
              *ret;
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     static char *getone_keywords[] = {"key", "default", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:getone",
@@ -833,7 +833,7 @@ multidict_tp_init(MultiDictObject *self, PyObject *args, PyObject *kwds)
 static inline PyObject *
 multidict_add(
     MultiDictObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -846,7 +846,7 @@ multidict_add(
     PyObject *key = NULL,
              *val = NULL;
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     static char *kwlist[] = {"key", "value", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO:add",
                                      kwlist, &key, &val))
@@ -913,7 +913,7 @@ multidict_clear(MultiDictObject *self)
 static inline PyObject *
 multidict_setdefault(
     MultiDictObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -926,7 +926,7 @@ multidict_setdefault(
     PyObject *key      = NULL,
              *_default = NULL;
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     static char *setdefault_keywords[] = {"key", "default", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:setdefault",
@@ -967,7 +967,7 @@ skip_optional_pos:
 static inline PyObject *
 multidict_popone(
     MultiDictObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -981,7 +981,7 @@ multidict_popone(
              *_default = NULL,
              *ret_val  = NULL;
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     static char *popone_keywords[] = {"key", "default", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:popone",
@@ -1046,7 +1046,7 @@ skip_optional_pos:
 static inline PyObject *
 multidict_pop(
     MultiDictObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -1060,7 +1060,7 @@ multidict_pop(
              *_default = NULL,
              *ret_val  = NULL;
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     static char *pop_keywords[] = {"key", "default", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:popone",
@@ -1113,7 +1113,7 @@ skip_optional_pos:
 static inline PyObject *
 multidict_popall(
     MultiDictObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -1128,7 +1128,7 @@ multidict_popall(
              *ret_val  = NULL;
 
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     static char *popall_keywords[] = {"key", "default", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:popall",
@@ -1270,7 +1270,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "getall",
         (PyCFunction)multidict_getall,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1281,7 +1281,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "getone",
         (PyCFunction)multidict_getone,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1292,7 +1292,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "get",
         (PyCFunction)multidict_get,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1321,7 +1321,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "add",
         (PyCFunction)multidict_add,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1350,7 +1350,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "setdefault",
         (PyCFunction)multidict_setdefault,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1361,7 +1361,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "popone",
         (PyCFunction)multidict_popone,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1372,7 +1372,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "pop",
         (PyCFunction)multidict_pop,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1383,7 +1383,7 @@ static PyMethodDef multidict_methods[] = {
     {
         "popall",
         (PyCFunction)multidict_popall,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1559,7 +1559,7 @@ multidict_proxy_tp_init(MultiDictProxyObject *self, PyObject *args,
 static inline PyObject *
 multidict_proxy_getall(
     MultiDictProxyObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -1572,7 +1572,7 @@ multidict_proxy_getall(
     return multidict_getall(
         self->md,
         args,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         kwds
 #else
         nargs,
@@ -1584,7 +1584,7 @@ multidict_proxy_getall(
 static inline PyObject *
 multidict_proxy_getone(
     MultiDictProxyObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -1596,7 +1596,7 @@ multidict_proxy_getone(
 {
     return multidict_getone(
         self->md, args,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         kwds
 #else
         nargs, kwnames
@@ -1607,7 +1607,7 @@ multidict_proxy_getone(
 static inline PyObject *
 multidict_proxy_get(
     MultiDictProxyObject *self,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
     PyObject *args,
     PyObject *kwds
 #else
@@ -1620,7 +1620,7 @@ multidict_proxy_get(
     return multidict_get(
         self->md,
         args,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         kwds
 #else
         nargs,
@@ -1734,7 +1734,7 @@ static PyMethodDef multidict_proxy_methods[] = {
     {
         "getall",
         (PyCFunction)multidict_proxy_getall,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1745,7 +1745,7 @@ static PyMethodDef multidict_proxy_methods[] = {
     {
         "getone",
         (PyCFunction)multidict_proxy_getone,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL
@@ -1756,7 +1756,7 @@ static PyMethodDef multidict_proxy_methods[] = {
     {
         "get",
         (PyCFunction)multidict_proxy_get,
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 12
         METH_VARARGS
 #else
         METH_FASTCALL

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -209,6 +209,10 @@ class BaseMultiDictTest:
 
         assert d.getone("key2", "default") == "default"
 
+    def test_call_with_kwargs(self, cls: Type[MultiDict[str]]) -> None:
+        d = cls([("present", "value")])
+        assert d.getall(default="missing", key="notfound") == "missing"
+
     def test__iter__(
         self,
         cls: Union[


### PR DESCRIPTION
## What do these changes do?

Fix build issues (observed personally with clang 16.0.6 as wrapped by nixpkgs when building multidict via [poetry2nix](https://github.com/nix-community/poetry2nix), and reported by @psss to also happen on gcc-14) related to changes to the `_PyArg_Parser` structure by moving away from this internal interface to use a slower, fully-supported interface instead.

## Are there changes in behavior for the user?

This change has a performance penalty.

## Related issue number

Trivial modification to the work done in #909.
Fixes #926.

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
