### PR TITLE
Add test coverage for _multidict_base.py

### DIFF
--- a/CHANGES/936.contrib.rst
+++ b/CHANGES/936.contrib.rst
@@ -1,0 +1,2 @@
+Add test coverage for _multidict_base.py 
+`NotImplemented`` and `Iterable-but-not-Set` for `and, or, sub, xor` operators

--- a/CHANGES/936.contrib.rst
+++ b/CHANGES/936.contrib.rst
@@ -1,2 +1,9 @@
-Added test coverage for the :ref:`and <python:and>`, :ref:`or <python:or>`, :py:obj:`sub <python:object.__sub__>`, and :py:obj:`xor <python:object.__xor__>` operators in the :file:`multidict/_multidict_base.py` module. It also covers  
-:py:data:`NotImplemented` and ":py:class:`~typing.Iterable`-but-not-:py:class:`~typing.Set`" cases there.
+Added test coverage for the :ref:`and <python:and>`, :ref:`or
+<python:or>`, :py:obj:`sub <python:object.__sub__>`, and
+:py:obj:`xor <python:object.__xor__>` operators in the
+:file:`multidict/_multidict_base.py` module. It also covers
+:py:data:`NotImplemented` and
+":py:class:`~typing.Iterable`-but-not-:py:class:`~typing.Set`"
+cases there.
+
+-- by :user:`a5r0n`

--- a/CHANGES/936.contrib.rst
+++ b/CHANGES/936.contrib.rst
@@ -1,2 +1,2 @@
-Added test coverage for the :ref:`and <python:and>`, :ref:`or <python:or>`, :py:obj:`sub <python:object.__sub__>`, and :py:obj:`xor <python:object.xor>` operators in the :file:`multidict/_multidict_base.py` module. It also covers  
+Added test coverage for the :ref:`and <python:and>`, :ref:`or <python:or>`, :py:obj:`sub <python:object.__sub__>`, and :py:obj:`xor <python:object.__xor__>` operators in the :file:`multidict/_multidict_base.py` module. It also covers  
 :py:data:`NotImplemented` and ":py:class:`~typing.Iterable`-but-not-:py:class:`~Set`" cases there.

--- a/CHANGES/936.contrib.rst
+++ b/CHANGES/936.contrib.rst
@@ -1,2 +1,2 @@
-Added test coverage for the :ref:`and <python:and>`, :ref:`or <python:or>`, :ref:`sub <python:sub>`, and :ref:`xor <python:xor>` operators in the :file:`multidict/_multidict_base.py` module. It also covers  
+Added test coverage for the :ref:`and <python:and>`, :ref:`or <python:or>`, :py:obj:`sub <python:object.__sub__>`, and :py:obj:`xor <python:object.xor>` operators in the :file:`multidict/_multidict_base.py` module. It also covers  
 :py:data:`NotImplemented` and ":py:class:`~typing.Iterable`-but-not-:py:class:`~Set`" cases there.

--- a/CHANGES/936.contrib.rst
+++ b/CHANGES/936.contrib.rst
@@ -1,2 +1,2 @@
-Add test coverage for _multidict_base.py 
-`NotImplemented`` and `Iterable-but-not-Set` for `and, or, sub, xor` operators
+Added test coverage for the :ref:`and <python:and>`, :ref:`or <python:or>`, :ref:`sub <python:sub>`, and :ref:`xor <python:xor>` operators in the :file:`multidict/_multidict_base.py` module. It also covers  
+:py:data:`NotImplemented` and ":py:class:`~typing.Iterable`-but-not-:py:class:`~Set`" cases there.

--- a/CHANGES/936.contrib.rst
+++ b/CHANGES/936.contrib.rst
@@ -1,2 +1,2 @@
 Added test coverage for the :ref:`and <python:and>`, :ref:`or <python:or>`, :py:obj:`sub <python:object.__sub__>`, and :py:obj:`xor <python:object.__xor__>` operators in the :file:`multidict/_multidict_base.py` module. It also covers  
-:py:data:`NotImplemented` and ":py:class:`~typing.Iterable`-but-not-:py:class:`~Set`" cases there.
+:py:data:`NotImplemented` and ":py:class:`~typing.Iterable`-but-not-:py:class:`~typing.Set`" cases there.

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -388,7 +388,7 @@ class BaseMultiDictTest:
 
         assert {"key"} == {"key", "key2"} & d.keys()
 
-    def test_and_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
+    def test_bitwise_and_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
 
         sentinel_operation_result = object()
@@ -400,7 +400,7 @@ class BaseMultiDictTest:
 
         assert d.keys() & RightOperand() is sentinel_operation_result
 
-    def test_and_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
+    def test_bitwise_and_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
 
         assert {"key"} == d.keys() & ["key", "key2"]

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -387,6 +387,17 @@ class BaseMultiDictTest:
 
         assert {"key"} == {"key", "key2"} & d.keys()
 
+    def test_and_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
+        d = cls([("key", "value1")])
+
+        with pytest.raises(TypeError):
+            operator.and_(d.keys(), 1)
+
+    def test_and_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
+        d = cls([("key", "value1")])
+
+        assert {"key"} == d.keys() & ["key", "key2"]
+
     def test_or(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
 
@@ -396,6 +407,17 @@ class BaseMultiDictTest:
         d = cls([("key", "value1")])
 
         assert {"key", "key2"} == {"key2"} | d.keys()
+
+    def test_or_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
+        d = cls([("key", "value1")])
+
+        with pytest.raises(TypeError):
+            operator.or_(d.keys(), 1)
+
+    def test_or_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
+        d = cls([("key", "value1")])
+
+        assert {"key", "key2"} == d.keys() | ["key2"]
 
     def test_sub(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])
@@ -407,6 +429,17 @@ class BaseMultiDictTest:
 
         assert {"key3"} == {"key", "key2", "key3"} - d.keys()
 
+    def test_sub_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
+        d = cls([("key", "value1"), ("key2", "value2")])
+
+        with pytest.raises(TypeError):
+            operator.sub(d.keys(), 1)
+
+    def test_sub_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
+        d = cls([("key", "value1"), ("key2", "value2")])
+
+        assert {"key"} == d.keys() - ["key2"]
+
     def test_xor(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])
 
@@ -416,6 +449,17 @@ class BaseMultiDictTest:
         d = cls([("key", "value1"), ("key2", "value2")])
 
         assert {"key", "key3"} == {"key2", "key3"} ^ d.keys()
+
+    def test_xor_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
+        d = cls([("key", "value1"), ("key2", "value2")])
+
+        with pytest.raises(TypeError):
+            operator.xor(d.keys(), 1)
+
+    def test_xor_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
+        d = cls([("key", "value1"), ("key2", "value2")])
+
+        assert {"key", "key3"} == d.keys() ^ ["key2", "key3"]
 
     @pytest.mark.parametrize(
         ("key", "value", "expected"),

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -415,7 +415,9 @@ class BaseMultiDictTest:
 
         assert {"key", "key2"} == {"key2"} | d.keys()
 
-    def test_or_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
+    def test_bitwise_or_not_implemented(
+        self, cls: Type[MutableMultiMapping[str]]
+    ) -> None:
         d = cls([("key", "value1")])
 
         sentinel_operation_result = object()
@@ -427,7 +429,9 @@ class BaseMultiDictTest:
 
         assert d.keys() | RightOperand() is sentinel_operation_result
 
-    def test_or_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
+    def test_bitwise_or_iterable_not_set(
+        self, cls: Type[MutableMultiMapping[str]]
+    ) -> None:
         d = cls([("key", "value1")])
 
         assert {"key", "key2"} == d.keys() | ["key2"]

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -390,8 +390,8 @@ class BaseMultiDictTest:
     def test_and_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
 
-        with pytest.raises(TypeError):
-            operator.and_(d.keys(), 1)
+        with pytest.raises(TypeError, match=r"unsupported operand type(\(s\))? for \&"):
+            d.keys() & 1
 
     def test_and_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
@@ -411,8 +411,8 @@ class BaseMultiDictTest:
     def test_or_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
 
-        with pytest.raises(TypeError):
-            operator.or_(d.keys(), 1)
+        with pytest.raises(TypeError, match=r"unsupported operand type(\(s\))? for \|"):
+            d.keys() | 1
 
     def test_or_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
@@ -432,8 +432,8 @@ class BaseMultiDictTest:
     def test_sub_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])
 
-        with pytest.raises(TypeError):
-            operator.sub(d.keys(), 1)
+        with pytest.raises(TypeError, match=r"unsupported operand type(\(s\))? for -"):
+            d.keys() - 1
 
     def test_sub_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])
@@ -453,8 +453,8 @@ class BaseMultiDictTest:
     def test_xor_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])
 
-        with pytest.raises(TypeError):
-            operator.xor(d.keys(), 1)
+        with pytest.raises(TypeError, match=r"unsupported operand type(\(s\))? for \^"):
+            d.keys() ^ 1
 
     def test_xor_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -388,19 +388,23 @@ class BaseMultiDictTest:
 
         assert {"key"} == {"key", "key2"} & d.keys()
 
-    def test_bitwise_and_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
+    def test_bitwise_and_not_implemented(
+        self, cls: Type[MutableMultiMapping[str]]
+    ) -> None:
         d = cls([("key", "value1")])
 
         sentinel_operation_result = object()
 
         class RightOperand:
-            def __rand__(self, other: KeysView) -> object:
+            def __rand__(self, other: KeysView[str]) -> object:
                 assert isinstance(other, KeysView)
                 return sentinel_operation_result
 
         assert d.keys() & RightOperand() is sentinel_operation_result
 
-    def test_bitwise_and_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
+    def test_bitwise_and_iterable_not_set(
+        self, cls: Type[MutableMultiMapping[str]]
+    ) -> None:
         d = cls([("key", "value1")])
 
         assert {"key"} == d.keys() & ["key", "key2"]
@@ -423,7 +427,7 @@ class BaseMultiDictTest:
         sentinel_operation_result = object()
 
         class RightOperand:
-            def __ror__(self, other: KeysView) -> object:
+            def __ror__(self, other: KeysView[str]) -> object:
                 assert isinstance(other, KeysView)
                 return sentinel_operation_result
 
@@ -452,7 +456,7 @@ class BaseMultiDictTest:
         sentinel_operation_result = object()
 
         class RightOperand:
-            def __rsub__(self, other: KeysView) -> object:
+            def __rsub__(self, other: KeysView[str]) -> object:
                 assert isinstance(other, KeysView)
                 return sentinel_operation_result
 
@@ -479,7 +483,7 @@ class BaseMultiDictTest:
         sentinel_operation_result = object()
 
         class RightOperand:
-            def __rxor__(self, other: KeysView) -> object:
+            def __rxor__(self, other: KeysView[str]) -> object:
                 assert isinstance(other, KeysView)
                 return sentinel_operation_result
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -12,6 +12,7 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
+    KeysView,
     List,
     Mapping,
     Set,
@@ -390,8 +391,14 @@ class BaseMultiDictTest:
     def test_and_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
 
-        with pytest.raises(TypeError, match=r"unsupported operand type(\(s\))? for \&"):
-            d.keys() & 1
+        sentinel_operation_result = object()
+
+        class RightOperand:
+            def __rand__(self, other):
+                assert isinstance(other, KeysView)
+                return sentinel_operation_result
+
+        assert d.keys() & RightOperand() is sentinel_operation_result
 
     def test_and_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
@@ -411,8 +418,14 @@ class BaseMultiDictTest:
     def test_or_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
 
-        with pytest.raises(TypeError, match=r"unsupported operand type(\(s\))? for \|"):
-            d.keys() | 1
+        sentinel_operation_result = object()
+
+        class RightOperand:
+            def __ror__(self, other):
+                assert isinstance(other, KeysView)
+                return sentinel_operation_result
+
+        assert d.keys() | RightOperand() is sentinel_operation_result
 
     def test_or_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1")])
@@ -432,8 +445,14 @@ class BaseMultiDictTest:
     def test_sub_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])
 
-        with pytest.raises(TypeError, match=r"unsupported operand type(\(s\))? for -"):
-            d.keys() - 1
+        sentinel_operation_result = object()
+
+        class RightOperand:
+            def __rsub__(self, other):
+                assert isinstance(other, KeysView)
+                return sentinel_operation_result
+
+        assert d.keys() - RightOperand() is sentinel_operation_result
 
     def test_sub_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])
@@ -453,8 +472,14 @@ class BaseMultiDictTest:
     def test_xor_not_implemented(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])
 
-        with pytest.raises(TypeError, match=r"unsupported operand type(\(s\))? for \^"):
-            d.keys() ^ 1
+        sentinel_operation_result = object()
+
+        class RightOperand:
+            def __rxor__(self, other):
+                assert isinstance(other, KeysView)
+                return sentinel_operation_result
+
+        assert d.keys() ^ RightOperand() is sentinel_operation_result
 
     def test_xor_iterable_not_set(self, cls: Type[MutableMultiMapping[str]]) -> None:
         d = cls([("key", "value1"), ("key2", "value2")])

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -394,7 +394,7 @@ class BaseMultiDictTest:
         sentinel_operation_result = object()
 
         class RightOperand:
-            def __rand__(self, other):
+            def __rand__(self, other: KeysView) -> object:
                 assert isinstance(other, KeysView)
                 return sentinel_operation_result
 
@@ -423,7 +423,7 @@ class BaseMultiDictTest:
         sentinel_operation_result = object()
 
         class RightOperand:
-            def __ror__(self, other):
+            def __ror__(self, other: KeysView) -> object:
                 assert isinstance(other, KeysView)
                 return sentinel_operation_result
 
@@ -452,7 +452,7 @@ class BaseMultiDictTest:
         sentinel_operation_result = object()
 
         class RightOperand:
-            def __rsub__(self, other):
+            def __rsub__(self, other: KeysView) -> object:
                 assert isinstance(other, KeysView)
                 return sentinel_operation_result
 
@@ -479,7 +479,7 @@ class BaseMultiDictTest:
         sentinel_operation_result = object()
 
         class RightOperand:
-            def __rxor__(self, other):
+            def __rxor__(self, other: KeysView) -> object:
                 assert isinstance(other, KeysView)
                 return sentinel_operation_result
 


### PR DESCRIPTION
`NotImplemented` and `Iterable` but not `Set` for `_viewbaseset_{and, or, sub, xor}`

Partially addresses https://github.com/aio-libs/multidict/issues/921.