### PR TITLE
🐛 Use compatible `pytest < 8` when running MyPy against Python 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,7 +155,7 @@ repos:
     additional_dependencies:
     - types-docutils
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
-    - pytest
+    - pytest < 8
     - Sphinx >= 5.3.0, < 6
     args:
     - --python-version=3.7

--- a/CHANGES/937.contrib.rst
+++ b/CHANGES/937.contrib.rst
@@ -1,0 +1,3 @@
+The version of pytest is now capped below 8, when running MyPy
+against Python 3.7. This pytest release dropped support for
+said runtime.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -71,6 +71,7 @@ pre
 proxied
 pyenv
 pyinstaller
+pytest
 refactor
 refactored
 regex


### PR DESCRIPTION
_Hello @webknjaz,_

## What do these changes do?

These changes:
  - fix `pytest`/`mypy` compatibility issue for Python 3.7
  - bump [pypa/cibuildwheel](https://github.com/pypa/cibuildwheel) to `2.16.5`

## Are there changes in behavior for the user?

Issues on CI will be resolved.

## Related issue number

  * pypa/cibuildwheel#1748

## Checklist

- [x] I think the code is well written

_Best regards!_