### PR TITLE
🐛 Fix type annotation for _replace_missing_aiohttp_hdrs_reference

### DIFF
--- a/CHANGES/939.contrib.rst
+++ b/CHANGES/939.contrib.rst
@@ -1,0 +1,3 @@
+Type annotation for the
+``_replace_missing_aiohttp_hdrs_reference``
+function has been fixed.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ import os
 import re
 from contextlib import suppress
 from pathlib import Path
+from typing import Optional
 
 import alabaster
 from sphinx.addnodes import pending_xref
@@ -384,7 +385,7 @@ def _replace_missing_aiohttp_hdrs_reference(
     env: BuildEnvironment,
     node: pending_xref,
     contnode: literal,
-) -> reference:
+) -> Optional[reference]:
     if (node.get('refdomain'), node.get('reftype')) != ("py", "mod"):
         return None
 


### PR DESCRIPTION
## What do these changes do?

Fix return value type annotation for the `_replace_missing_aiohttp_hdrs_reference` function.

## Are there changes in behavior for the user?

Lint on CI will work once again.

## Related issue number

`N\A`

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes
