### PR TITLE
🧪 Update syntax for setting step outputs in GitHub Actions CI/CD workflow definition

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -210,7 +210,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
+        echo "dir=$(pip cache dir)" >> "${GITHUB_OUTPUT}"
     - name: Cache PyPI
       uses: actions/cache@v4
       with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -210,7 +210,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"    # - name: Cache
+        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
     - name: Cache PyPI
       uses: actions/cache@v4
       with:

--- a/CHANGES/940.contrib.rst
+++ b/CHANGES/940.contrib.rst
@@ -1,0 +1,4 @@
+`The deprecated <https://hynek.me/til/set-output-deprecation-github-actions/>`_
+``::set-output`` workflow command has been replaced
+by the ``$GITHUB_OUTPUT`` environment variable
+in the GitHub Actions CI/CD workflow definition.


### PR DESCRIPTION
## What do these changes do?

The `set-output` command is deprecated and will be disabled soon.
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Are there changes in behavior for the user?

No.

## Related issue number

`N\A`

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes
