### PR TITLE
🧪 Fix uploading coverage from GHA to Codecov

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -367,7 +367,7 @@ jobs:
         coverage xml
       shell: bash
     - name: Send coverage data to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
         flags: >-

--- a/.github/workflows/reusable-linters.yml
+++ b/.github/workflows/reusable-linters.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         make lint
     - name: Send coverage data to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.codecov-token }}
         files: >-

--- a/CHANGES/941.contrib.rst
+++ b/CHANGES/941.contrib.rst
@@ -1,0 +1,7 @@
+`codecov-action <https://github.com/codecov/codecov-action>`_
+has been temporarily downgraded to ``v3``
+in the GitHub Actions CI/CD workflow definitions
+in order to fix uploading coverage to
+`Codecov <https://app.codecov.io/gh/aio-libs/multidict>`_.
+See `this issue <https://github.com/codecov/codecov-action/issues/1252>`_
+for more details.


### PR DESCRIPTION
_Hello @webknjaz,_

## What do these changes do?

The newest version of the [codecov-action](https://github.com/codecov/codecov-action) fails to submit coverage, so it isn't ready for use yet.

These changes downgrade `codecov-action` to `v3`.

## Are there changes in behavior for the user?

No.

## Related issues
  * codecov/codecov-action#1252
  * codecov/codecov-action#1242
  * codecov/codecov-cli#365

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes

##
_Best regards!_