### PR TITLE
🧪 Fix the `Get pip cache dir` CI step for Windows runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -211,6 +211,7 @@ jobs:
       id: pip-cache
       run: |
         echo "dir=$(pip cache dir)" >> "${GITHUB_OUTPUT}"
+      shell: bash
     - name: Cache PyPI
       uses: actions/cache@v4
       with:

--- a/CHANGES/942.contrib.rst
+++ b/CHANGES/942.contrib.rst
@@ -1,0 +1,5 @@
+In the GitHub Actions CI/CD workflow definition,
+the ``Get pip cache dir`` step has been fixed for
+Windows runners by adding ``shell: bash``.
+See `actions/runner#2224 <https://github.com/actions/runner/issues/2224>`_
+for more details.


### PR DESCRIPTION
## What do these changes do?

Fix the `Get pip cache dir` CI step for [Windows runners](https://github.com/aio-libs/multidict/actions/runs/7751071979/job/21138438840#step:6:32).
Please see annotations [here](https://github.com/aio-libs/multidict/actions/runs/7751071979).

## Are there changes in behavior for the user?

No.

## Related issue number
  * actions/runner#2224

This bug was introduced in this PR:
  * #940

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes
