### PR TITLE
🧪 Fix pip cache keys interpolation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -219,7 +219,7 @@ jobs:
             runner.os
           }}-${{
             matrix.pyver
-          }}-{{
+          }}-${{
             matrix.no-extensions
           }}-${{
             hashFiles('requirements/*.txt')
@@ -230,7 +230,7 @@ jobs:
             runner.os
           }}-${{
             matrix.pyver
-          }}-{{
+          }}-${{
             matrix.no-extensions
           }}-
     - name: Install dependencies

--- a/CHANGES/943.contrib.rst
+++ b/CHANGES/943.contrib.rst
@@ -1,0 +1,3 @@
+``pip`` cache keys rendering has been
+fixed by adding missing ``$`` signs
+in the GitHub Actions CI/CD workflow definition.

--- a/CHANGES/943.contrib.rst
+++ b/CHANGES/943.contrib.rst
@@ -1,3 +1,3 @@
-``pip`` cache keys rendering has been
-fixed by adding missing ``$`` signs
+Interpolation of the ``pip`` cache keys has been
+fixed by adding missing ``$`` syntax
 in the GitHub Actions CI/CD workflow definition.


### PR DESCRIPTION
## What do these changes do?

Fix [rendering](https://github.com/aio-libs/multidict/actions/runs/7751071979/job/21138438717#step:6:3) of `pip` cache keys.

## Are there changes in behavior for the user?

No.

## Related issue number

`N\A`

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes