### PR TITLE
🧪 Skip tests when building `x86_64` wheels

### DIFF
--- a/CHANGES/946.contrib.rst
+++ b/CHANGES/946.contrib.rst
@@ -1,0 +1,2 @@
+Duplicated test runs have been disabled when
+building wheels for the ``x86_64`` architecture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,6 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 test-requires = "-r requirements/pytest.txt"
 test-command = "pytest {project}/tests"
+test-skip = "*x86_64 *amd64"
 # don't build PyPy wheels, install from source instead
 skip = "pp*"


### PR DESCRIPTION
_Hello @webknjaz,_

## What do these changes do?

Testing is redundant when building wheels for `x86_64` since there are dedicated jobs that run tests for this arch.
Disabling it reduces build time noticeably.

Related documentation:
  - https://cibuildwheel.readthedocs.io/en/stable/options/#test-skip

## Are there changes in behavior for the user?

`CI/CD` build time will be reduced.

## Related issue number

`N/A`

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes
##
_Best regards!_