### PR TITLE
Bump RTD to use Python 3.12 and ubuntu-24.04

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       matrix:
         pyver:
-        - 3.13
+        - 3.13-dev
         - 3.12
         - 3.11
         - "3.10"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       matrix:
         pyver:
-        - 3.13-dev
+        - 3.13
         - 3.12
         - 3.11
         - "3.10"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,10 +3,10 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: >-
-      3.9
+      3.12
 
 python:
   install:


### PR DESCRIPTION
[Bumping sphinx](https://github.com/aio-libs/multidict/pull/999) is currently blocked because 8.x required Python 3.10+