### PR TITLE
Bump Python to 3.12 for linters

### DIFF
--- a/.github/workflows/reusable-linters.yml
+++ b/.github/workflows/reusable-linters.yml
@@ -21,7 +21,7 @@ env:
   PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: 1
-  PYTHON_LATEST: 3.9
+  PYTHON_LATEST: 3.12
 
 jobs:
 


### PR DESCRIPTION
Needed for sphinx 8+, and the spell checker will fail with sphinx 8+ on python < 3.10

unblocks https://github.com/aio-libs/multidict/pull/999
