### PR TITLE
Remove compat code for Python older than 3.8 from tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import argparse
 import pickle
 from dataclasses import dataclass
+from functools import cached_property
 from importlib import import_module
 from sys import version_info as _version_info
 from types import ModuleType
 from typing import Callable, Type
-from functools import cached_property
+
 import pytest
 
 from multidict import MultiMapping, MutableMultiMapping

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,16 +7,7 @@ from importlib import import_module
 from sys import version_info as _version_info
 from types import ModuleType
 from typing import Callable, Type
-
-try:
-    from functools import cached_property  # Python 3.8+
-except ImportError:
-    from functools import lru_cache as _lru_cache
-
-    def cached_property(func):
-        return property(_lru_cache()(func))
-
-
+from functools import cached_property
 import pytest
 
 from multidict import MultiMapping, MutableMultiMapping


### PR DESCRIPTION
https://github.com/aio-libs/multidict/pull/1005#issuecomment-2339416121
Remove pre Python 3.8+ compat code from tests