### PR TITLE
Upgrade actions/[upload|download]-artifact and other GHA dependencies

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -187,7 +187,7 @@ jobs:
         workflow-artifact-name: >-
           ${{ needs.pre-setup.outputs.dists-artifact-name }}
     - name: Download distributions
-      if: ${{ !endsWith(matrix.pyver, '-dev') }}
+      if: ${{ !endsWith(matrix.pyver, '-dev') && true || false }}
       uses: actions/download-artifact@v4
       with:
         pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,7 +95,7 @@ jobs:
         }
         >> "${GITHUB_OUTPUT}"
     - name: Upload built artifacts for testing
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
         name: ${{ needs.pre-setup.outputs.dists-artifact-name  }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -180,7 +180,7 @@ jobs:
 
     steps:
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v1
+      uses: re-actors/checkout-python-sdist@187f55296b0f54d88259aaaf99af32ad3647d3bc  # Current main that uses download-artifact@v4
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
@@ -336,7 +336,7 @@ jobs:
       with:
         jobs: ${{ toJSON(needs) }}
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v1
+      uses: re-actors/checkout-python-sdist@187f55296b0f54d88259aaaf99af32ad3647d3bc  # Current main that uses download-artifact@v4
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
@@ -420,7 +420,7 @@ jobs:
 
     steps:
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v1
+      uses: re-actors/checkout-python-sdist@187f55296b0f54d88259aaaf99af32ad3647d3bc  # Current main that uses download-artifact@v4
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -188,7 +188,7 @@ jobs:
           ${{ needs.pre-setup.outputs.dists-artifact-name }}
     - name: Download distributions
       if: ${{ !endsWith(matrix.pyver, '-dev') && true || false }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
         path: dist
@@ -343,7 +343,7 @@ jobs:
         workflow-artifact-name: >-
           ${{ needs.pre-setup.outputs.dists-artifact-name }}
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: coverage
         path: ${{ runner.temp }}/coverage
@@ -428,7 +428,7 @@ jobs:
           ${{ needs.pre-setup.outputs.dists-artifact-name }}
 
     - name: Download distributions
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
         path: dist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -180,17 +180,18 @@ jobs:
 
     steps:
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@187f55296b0f54d88259aaaf99af32ad3647d3bc  # Current main that uses download-artifact@v4
+      uses: re-actors/checkout-python-sdist@release/v2
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
         workflow-artifact-name: >-
           ${{ needs.pre-setup.outputs.dists-artifact-name }}
     - name: Download distributions
-      if: ${{ !endsWith(matrix.pyver, '-dev') && true || false }}
+      if: ${{ !endsWith(matrix.pyver, '-dev') }}
       uses: actions/download-artifact@v4
       with:
-        name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
+        merge-multiple: true
         path: dist
 
     - name: Setup Python ${{ matrix.pyver }}
@@ -336,7 +337,7 @@ jobs:
       with:
         jobs: ${{ toJSON(needs) }}
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@187f55296b0f54d88259aaaf99af32ad3647d3bc  # Current main that uses download-artifact@v4
+      uses: re-actors/checkout-python-sdist@release/v2
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
@@ -420,7 +421,7 @@ jobs:
 
     steps:
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@187f55296b0f54d88259aaaf99af32ad3647d3bc  # Current main that uses download-artifact@v4
+      uses: re-actors/checkout-python-sdist@release/v2
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
@@ -430,7 +431,8 @@ jobs:
     - name: Download distributions
       uses: actions/download-artifact@v4
       with:
-        name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
+        merge-multiple: true
         path: dist
     - run: |
         tree

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -319,7 +319,7 @@ jobs:
       # combining Linux and Windows paths is tricky, left this exercise for
       # others multidict has no Windows or macOS specific code paths anyway
       if: ${{ matrix.os == 'ubuntu' }}
-      uses: aio-libs/prepare-coverage@v22.1.2
+      uses: aio-libs/prepare-coverage@v24.9.2
 
   test-summary:
     name: Tests status
@@ -346,7 +346,8 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: coverage
+        pattern: coverage*
+        merge-multiple: true
         path: ${{ runner.temp }}/coverage
     - name: Install coverage
       run: |

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: ${{ inputs.qemu && 47 || 14 }}
     steps:
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@187f55296b0f54d88259aaaf99af32ad3647d3bc  # Current main that uses download-artifact@v4
+      uses: re-actors/checkout-python-sdist@release/v2
       with:
         source-tarball-name: ${{ inputs.source-tarball-name }}
         workflow-artifact-name: ${{ inputs.dists-artifact-name }}
@@ -75,7 +75,8 @@ jobs:
     - name: Upload built artifacts for testing and publishing
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.dists-artifact-name }}
+        name: >-
+          ${{ inputs.dists-artifact-name }}-${{ inputs.os }}-${{ inputs.qemu }}
         path: ./wheelhouse/*.whl
 
 ...

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: ${{ inputs.qemu && 47 || 14 }}
     steps:
     - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v1
+      uses: re-actors/checkout-python-sdist@187f55296b0f54d88259aaaf99af32ad3647d3bc  # Current main that uses download-artifact@v4
       with:
         source-tarball-name: ${{ inputs.source-tarball-name }}
         workflow-artifact-name: ${{ inputs.dists-artifact-name }}

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -73,7 +73,7 @@ jobs:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
 
     - name: Upload built artifacts for testing and publishing
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.dists-artifact-name }}
         path: ./wheelhouse/*.whl


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

- Upgrade `actions/upload-artifact` to v4 since v2 is deprecated and v3 is scheduled to be deprecated in November.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.
<!-- Outline any notable behaviour for the end users. -->

