### PR TITLE
Remove missed compat code for Python older than 3.8 from tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import argparse
 import pickle
 from dataclasses import dataclass
 from importlib import import_module
-from sys import version_info as _version_info
 from types import ModuleType
 from typing import Callable, Type
 
@@ -22,7 +21,6 @@ import pytest
 from multidict import MultiMapping, MutableMultiMapping
 
 C_EXT_MARK = pytest.mark.c_extension
-PY_38_AND_BELOW = _version_info < (3, 9)
 
 
 @dataclass(frozen=True)
@@ -171,19 +169,11 @@ def pytest_addoption(
 
     parser.addoption(
         "--c-extensions",  # disabled with `--no-c-extensions`
-        action="store_true" if PY_38_AND_BELOW else argparse.BooleanOptionalAction,
+        action=argparse.BooleanOptionalAction,
         default=True,
         dest="c_extensions",
         help="Test C-extensions (on by default)",
     )
-
-    if PY_38_AND_BELOW:
-        parser.addoption(
-            "--no-c-extensions",
-            action="store_false",
-            dest="c_extensions",
-            help="Skip testing C-extensions (on by default)",
-        )
 
 
 def pytest_collection_modifyitems(


### PR DESCRIPTION
https://github.com/aio-libs/multidict/pull/1010#discussion_r1788762690