### PR TITLE
Add codspeed benchmarks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -356,7 +356,7 @@ jobs:
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v4
       with:
-        path: requirements/test.txt
+        path: requirements/pytest.txt
     - name: Determine pre-compiled compatible wheel
       env:
         # NOTE: When `pip` is forced to colorize output piped into `jq`,

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -321,6 +321,89 @@ jobs:
       if: ${{ matrix.os == 'ubuntu' }}
       uses: aio-libs/prepare-coverage@v24.9.2
 
+  benchmark:
+    name: Benchmark
+    needs:
+    - build-pure-python-dists  # transitive, for accessing settings
+    - build-wheels-for-tested-arches
+    - pre-setup  # transitive, for accessing settings
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v4
+    - name: Retrieve the project source from an sdist inside the GHA artifact
+      uses: re-actors/checkout-python-sdist@release/v2
+      with:
+        source-tarball-name: >-
+          ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
+        workflow-artifact-name: >-
+          ${{ needs.pre-setup.outputs.dists-artifact-name }}
+    - name: Download distributions
+      uses: actions/download-artifact@v4
+      with:
+        path: dist
+        pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
+        merge-multiple: true
+
+    - name: Setup Python 3.12
+      id: python-install
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+        cache: pip
+        cache-dependency-path: requirements/*.txt
+    - name: Install dependencies
+      uses: py-actions/py-dependency-install@v4
+      with:
+        path: requirements/test.txt
+    - name: Determine pre-compiled compatible wheel
+      env:
+        # NOTE: When `pip` is forced to colorize output piped into `jq`,
+        # NOTE: the latter can't parse it. So we're overriding the color
+        # NOTE: preference here via https://no-color.org.
+        # NOTE: Setting `FORCE_COLOR` to any value (including 0, an empty
+        # NOTE: string, or a "YAML null" `~`) doesn't have any effect and
+        # NOTE: `pip` (through its verndored copy of `rich`) treats the
+        # NOTE: presence of the variable as "force-color" regardless.
+        #
+        # NOTE: This doesn't actually work either, so we'll resort to unsetting
+        # NOTE: in the Bash script.
+        # NOTE: Ref: https://github.com/Textualize/rich/issues/2622
+        NO_COLOR: 1
+      id: wheel-file
+      run: >
+        echo -n path= | tee -a "${GITHUB_OUTPUT}"
+
+
+        unset FORCE_COLOR
+
+
+        python
+        -X utf8
+        -u -I
+        -m pip install
+        --find-links=./dist
+        --no-index
+        '${{ env.PROJECT_NAME }}'
+        --force-reinstall
+        --no-color
+        --no-deps
+        --only-binary=:all:
+        --dry-run
+        --report=-
+        --quiet
+        | jq --raw-output .install[].download_info.url
+        | tee -a "${GITHUB_OUTPUT}"
+      shell: bash
+    - name: Self-install
+      run: python -Im pip install '${{ steps.wheel-file.outputs.path }}'
+    - name: Run benchmarks
+      uses: CodSpeedHQ/action@v3
+      with:
+        token: ${{ secrets.CODSPEED_TOKEN }}
+        run: python -Im pytest --no-cov -vvvvv --codspeed
+
   test-summary:
     name: Tests status
     if: always()

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -82,6 +82,11 @@ disable_error_code =
 [mypy-test_multidict]
 disable_error_code = call-arg
 
+[mypy-test_multidict_benchmarks]
+disable_error_code = 
+  no-any-unimported,
+  misc,
+
 [mypy-test_mutable_multidict]
 disable_error_code =
   arg-type,

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -83,7 +83,7 @@ disable_error_code =
 disable_error_code = call-arg
 
 [mypy-test_multidict_benchmarks]
-disable_error_code = 
+disable_error_code =
   no-any-unimported,
   misc,
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,6 +114,7 @@ repos:
     - types-docutils
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
+    - pytest_codspeed
     - Sphinx >= 5.3.0
     args:
     - --python-version=3.13
@@ -128,6 +129,7 @@ repos:
     - types-docutils
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
+    - pytest_codspeed
     - Sphinx >= 5.3.0
     args:
     - --python-version=3.11
@@ -142,6 +144,7 @@ repos:
     - types-docutils
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
+    - pytest_codspeed
     - Sphinx >= 5.3.0
     args:
     - --python-version=3.9
@@ -156,6 +159,7 @@ repos:
     - types-docutils
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
+    - pytest_codspeed
     - Sphinx >= 5.3.0
     args:
     - --python-version=3.8

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -16,7 +16,6 @@ else:
 
 
 class istr(str):
-
     """Case insensitive str."""
 
     __is_istr__ = True

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,2 +1,3 @@
 pytest==8.3.3
+pytest-codspeed==2.2.1
 pytest-cov==5.0.0

--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -12,7 +12,7 @@ from multidict import CIMultiDict, MultiDict, istr
 _SENTINEL = object()
 
 
-def test_multidict_insert_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_insert_str(benchmark: BenchmarkFixture) -> None:
     md: MultiDict[str] = MultiDict()
     items = [str(i) for i in range(100)]
 
@@ -22,7 +22,7 @@ def test_multidict_insert_str_performance(benchmark: BenchmarkFixture) -> None:
             md[i] = i
 
 
-def test_cimultidict_insert_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_insert_str(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict()
     items = [str(i) for i in range(100)]
 
@@ -32,7 +32,7 @@ def test_cimultidict_insert_str_performance(benchmark: BenchmarkFixture) -> None
             md[i] = i
 
 
-def test_cimultidict_insert_istr_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_insert_istr(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[istr] = CIMultiDict()
     items = [istr(i) for i in range(100)]
 
@@ -42,7 +42,7 @@ def test_cimultidict_insert_istr_performance(benchmark: BenchmarkFixture) -> Non
             md[i] = i
 
 
-def test_multidict_add_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_add_str(benchmark: BenchmarkFixture) -> None:
     md: MultiDict[str] = MultiDict()
     items = [str(i) for i in range(100)]
 
@@ -52,7 +52,7 @@ def test_multidict_add_str_performance(benchmark: BenchmarkFixture) -> None:
             md.add(i, i)
 
 
-def test_cimultidict_add_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_add_str(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict()
     items = [str(i) for i in range(100)]
 
@@ -62,7 +62,7 @@ def test_cimultidict_add_str_performance(benchmark: BenchmarkFixture) -> None:
             md.add(i, i)
 
 
-def test_cimultidict_add_istr_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_add_istr(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[istr] = CIMultiDict()
     items = [istr(i) for i in range(100)]
 
@@ -72,7 +72,7 @@ def test_cimultidict_add_istr_performance(benchmark: BenchmarkFixture) -> None:
             md.add(i, i)
 
 
-def test_multidict_pop_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_pop_str(benchmark: BenchmarkFixture) -> None:
     md_base: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
@@ -83,7 +83,7 @@ def test_multidict_pop_str_performance(benchmark: BenchmarkFixture) -> None:
             md.pop(i)
 
 
-def test_cimultidict_pop_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_pop_str(benchmark: BenchmarkFixture) -> None:
     md_base: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
@@ -94,7 +94,7 @@ def test_cimultidict_pop_str_performance(benchmark: BenchmarkFixture) -> None:
             md.pop(i)
 
 
-def test_cimultidict_pop_istr_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_pop_istr(benchmark: BenchmarkFixture) -> None:
     md_base: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
     items = [istr(i) for i in range(100)]
 
@@ -105,7 +105,7 @@ def test_cimultidict_pop_istr_performance(benchmark: BenchmarkFixture) -> None:
             md.pop(i)
 
 
-def test_multidict_popitem_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_popitem_str(benchmark: BenchmarkFixture) -> None:
     md_base: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
 
     @benchmark
@@ -115,7 +115,7 @@ def test_multidict_popitem_str_performance(benchmark: BenchmarkFixture) -> None:
             md.popitem()
 
 
-def test_cimultidict_popitem_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_popitem_str(benchmark: BenchmarkFixture) -> None:
     md_base: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
 
     @benchmark
@@ -125,7 +125,7 @@ def test_cimultidict_popitem_str_performance(benchmark: BenchmarkFixture) -> Non
             md.popitem()
 
 
-def test_multidict_clear_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_clear_str(benchmark: BenchmarkFixture) -> None:
     md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
 
     @benchmark
@@ -133,7 +133,7 @@ def test_multidict_clear_str_performance(benchmark: BenchmarkFixture) -> None:
         md.clear()
 
 
-def test_cimultidict_clear_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_clear_str(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
 
     @benchmark
@@ -141,7 +141,7 @@ def test_cimultidict_clear_str_performance(benchmark: BenchmarkFixture) -> None:
         md.clear()
 
 
-def test_multidict_update_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_update_str(benchmark: BenchmarkFixture) -> None:
     md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
     items = {str(i): str(i) for i in range(100, 200)}
 
@@ -150,7 +150,7 @@ def test_multidict_update_str_performance(benchmark: BenchmarkFixture) -> None:
         md.update(items)
 
 
-def test_cimultidict_update_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_update_str(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = {str(i): str(i) for i in range(100, 200)}
 
@@ -159,7 +159,7 @@ def test_cimultidict_update_str_performance(benchmark: BenchmarkFixture) -> None
         md.update(items)
 
 
-def test_cimultidict_update_istr_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_update_istr(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
     items: Dict[Union[str, istr], istr] = {istr(i): istr(i) for i in range(100, 200)}
 
@@ -168,7 +168,7 @@ def test_cimultidict_update_istr_performance(benchmark: BenchmarkFixture) -> Non
         md.update(items)
 
 
-def test_multidict_extend_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_extend_str(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = {str(i): str(i) for i in range(200)}
 
@@ -177,7 +177,7 @@ def test_multidict_extend_str_performance(benchmark: BenchmarkFixture) -> None:
         md.extend(items)
 
 
-def test_cimultidict_extend_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_extend_str(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = {str(i): str(i) for i in range(200)}
 
@@ -186,7 +186,7 @@ def test_cimultidict_extend_str_performance(benchmark: BenchmarkFixture) -> None
         md.extend(items)
 
 
-def test_cimultidict_extend_istr_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_extend_istr(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
     items = {istr(i): istr(i) for i in range(200)}
 
@@ -195,7 +195,7 @@ def test_cimultidict_extend_istr_performance(benchmark: BenchmarkFixture) -> Non
         md.extend(items)
 
 
-def test_multidict_delitem_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_delitem_str(benchmark: BenchmarkFixture) -> None:
     md_base: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
@@ -206,7 +206,7 @@ def test_multidict_delitem_str_performance(benchmark: BenchmarkFixture) -> None:
             del md[i]
 
 
-def test_cimultidict_delitem_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_delitem_str(benchmark: BenchmarkFixture) -> None:
     md_base: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
@@ -217,7 +217,7 @@ def test_cimultidict_delitem_str_performance(benchmark: BenchmarkFixture) -> Non
             del md[i]
 
 
-def test_cimultidict_delitem_istr_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_delitem_istr(benchmark: BenchmarkFixture) -> None:
     md_base: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
     items = [istr(i) for i in range(100)]
 
@@ -228,7 +228,7 @@ def test_cimultidict_delitem_istr_performance(benchmark: BenchmarkFixture) -> No
             del md[i]
 
 
-def test_multidict_getall_str_hit_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_getall_str_hit(benchmark: BenchmarkFixture) -> None:
     md: MultiDict[str] = MultiDict(("all", str(i)) for i in range(100))
 
     @benchmark
@@ -236,7 +236,7 @@ def test_multidict_getall_str_hit_performance(benchmark: BenchmarkFixture) -> No
         md.getall("all")
 
 
-def test_cimultidict_getall_str_hit_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_getall_str_hit(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict(("all", str(i)) for i in range(100))
 
     @benchmark
@@ -244,7 +244,7 @@ def test_cimultidict_getall_str_hit_performance(benchmark: BenchmarkFixture) -> 
         md.getall("all")
 
 
-def test_cimultidict_getall_istr_hit_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_getall_istr_hit(benchmark: BenchmarkFixture) -> None:
     all_istr = istr("all")
     md: CIMultiDict[istr] = CIMultiDict((all_istr, istr(i)) for i in range(100))
 
@@ -253,7 +253,7 @@ def test_cimultidict_getall_istr_hit_performance(benchmark: BenchmarkFixture) ->
         md.getall(all_istr)
 
 
-def test_multidict_fetch_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_fetch(benchmark: BenchmarkFixture) -> None:
     md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
@@ -263,7 +263,7 @@ def test_multidict_fetch_performance(benchmark: BenchmarkFixture) -> None:
             md[i]
 
 
-def test_cimultidict_fetch_str_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_fetch_str(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
@@ -273,7 +273,7 @@ def test_cimultidict_fetch_str_performance(benchmark: BenchmarkFixture) -> None:
             md[i]
 
 
-def test_cimultidict_fetch_istr_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_fetch_istr(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
     items = [istr(i) for i in range(100)]
 
@@ -283,7 +283,7 @@ def test_cimultidict_fetch_istr_performance(benchmark: BenchmarkFixture) -> None
             md[i]
 
 
-def test_multidict_get_hit_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_get_hit(benchmark: BenchmarkFixture) -> None:
     md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
@@ -293,7 +293,7 @@ def test_multidict_get_hit_performance(benchmark: BenchmarkFixture) -> None:
             md.get(i)
 
 
-def test_multidict_get_miss_performance(benchmark: BenchmarkFixture) -> None:
+def test_multidict_get_miss(benchmark: BenchmarkFixture) -> None:
     md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100, 200)]
 
@@ -303,7 +303,7 @@ def test_multidict_get_miss_performance(benchmark: BenchmarkFixture) -> None:
             md.get(i)
 
 
-def test_cimultidict_get_hit_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_get_hit(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
@@ -313,7 +313,7 @@ def test_cimultidict_get_hit_performance(benchmark: BenchmarkFixture) -> None:
             md.get(i)
 
 
-def test_cimultidict_get_miss_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_get_miss(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100, 200)]
 
@@ -323,7 +323,7 @@ def test_cimultidict_get_miss_performance(benchmark: BenchmarkFixture) -> None:
             md.get(i)
 
 
-def test_cimultidict_get_istr_hit_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_get_istr_hit(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
     items = [istr(i) for i in range(100)]
 
@@ -333,7 +333,7 @@ def test_cimultidict_get_istr_hit_performance(benchmark: BenchmarkFixture) -> No
             md.get(i)
 
 
-def test_cimultidict_get_istr_miss_performance(benchmark: BenchmarkFixture) -> None:
+def test_cimultidict_get_istr_miss(benchmark: BenchmarkFixture) -> None:
     md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
     items = [istr(i) for i in range(100, 200)]
 
@@ -343,7 +343,7 @@ def test_cimultidict_get_istr_miss_performance(benchmark: BenchmarkFixture) -> N
             md.get(i)
 
 
-def test_cimultidict_get_hit_with_default_performance(
+def test_cimultidict_get_hit_with_default(
     benchmark: BenchmarkFixture,
 ) -> None:
     md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
@@ -355,7 +355,7 @@ def test_cimultidict_get_hit_with_default_performance(
             md.get(i, _SENTINEL)
 
 
-def test_cimultidict_get_miss_with_default_performance(
+def test_cimultidict_get_miss_with_default(
     benchmark: BenchmarkFixture,
 ) -> None:
     md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
@@ -367,7 +367,7 @@ def test_cimultidict_get_miss_with_default_performance(
             md.get(i, _SENTINEL)
 
 
-def test_cimultidict_get_istr_hit_with_default_performance(
+def test_cimultidict_get_istr_hit_with_default(
     benchmark: BenchmarkFixture,
 ) -> None:
     md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
@@ -379,7 +379,7 @@ def test_cimultidict_get_istr_hit_with_default_performance(
             md.get(i, _SENTINEL)
 
 
-def test_cimultidict_get_istr_with_default_miss_performance(
+def test_cimultidict_get_istr_with_default_miss(
     benchmark: BenchmarkFixture,
 ) -> None:
     md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))

--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -9,6 +9,8 @@ from multidict import CIMultiDict, MultiDict, istr
 # Note that this benchmark should not be refactored to use pytest.mark.parametrize
 # since each benchmark name should be unique.
 
+_SENTINEL = object()
+
 
 def test_multidict_insert_str_performance(benchmark: BenchmarkFixture) -> None:
     md: MultiDict[str] = MultiDict()
@@ -339,3 +341,51 @@ def test_cimultidict_get_istr_miss_performance(benchmark: BenchmarkFixture) -> N
     def _run() -> None:
         for i in items:
             md.get(i)
+
+
+def test_cimultidict_get_hit_with_default_performance(
+    benchmark: BenchmarkFixture,
+) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i, _SENTINEL)
+
+
+def test_cimultidict_get_miss_with_default_performance(
+    benchmark: BenchmarkFixture,
+) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100, 200)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i, _SENTINEL)
+
+
+def test_cimultidict_get_istr_hit_with_default_performance(
+    benchmark: BenchmarkFixture,
+) -> None:
+    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    items = [istr(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i, _SENTINEL)
+
+
+def test_cimultidict_get_istr_with_default_miss_performance(
+    benchmark: BenchmarkFixture,
+) -> None:
+    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    items = [istr(i) for i in range(100, 200)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i, _SENTINEL)

--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -1,0 +1,331 @@
+"""codspeed benchmarks for multidict."""
+
+from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
+from typing import Union, Dict
+from multidict import CIMultiDict, MultiDict, istr
+
+# Note that this benchmark should not be refactored to use pytest.mark.parametrize
+# since each benchmark name should be unique.
+
+
+def test_multidict_insert_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict()
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md[i] = i
+
+
+def test_cimultidict_insert_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict()
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md[i] = i
+
+
+def test_cimultidict_insert_istr_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[istr] = CIMultiDict()
+    items = [istr(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md[i] = i
+
+
+def test_multidict_add_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict()
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.add(i, i)
+
+
+def test_cimultidict_add_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict()
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.add(i, i)
+
+
+def test_cimultidict_add_istr_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[istr] = CIMultiDict()
+    items = [istr(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.add(i, i)
+
+
+def test_multidict_pop_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.pop(i)
+
+
+def test_cimultidict_pop_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.pop(i)
+
+
+def test_cimultidict_pop_istr_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    items = [istr(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.pop(i)
+
+
+def test_multidict_popitem_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+
+    @benchmark
+    def _run() -> None:
+        for _ in range(100):
+            md.popitem()
+
+
+def test_cimultidict_popitem_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+
+    @benchmark
+    def _run() -> None:
+        for _ in range(100):
+            md.popitem()
+
+
+def test_multidict_clear_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+
+    @benchmark
+    def _run() -> None:
+        md.clear()
+
+
+def test_cimultidict_clear_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+
+    @benchmark
+    def _run() -> None:
+        md.clear()
+
+
+def test_multidict_update_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    items = {str(i): str(i) for i in range(100, 200)}
+
+    @benchmark
+    def _run() -> None:
+        md.update(items)
+
+
+def test_cimultidict_update_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = {str(i): str(i) for i in range(100, 200)}
+
+    @benchmark
+    def _run() -> None:
+        md.update(items)
+
+
+def test_cimultidict_update_istr_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    items: Dict[Union[str, istr], istr] = {istr(i): istr(i) for i in range(100, 200)}
+
+    @benchmark
+    def _run() -> None:
+        md.update(items)
+
+
+def test_multidict_extend_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = {str(i): str(i) for i in range(200)}
+
+    @benchmark
+    def _run() -> None:
+        md.extend(items)
+
+
+def test_cimultidict_extend_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = {str(i): str(i) for i in range(200)}
+
+    @benchmark
+    def _run() -> None:
+        md.extend(items)
+
+
+def test_cimultidict_extend_istr_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    items = {istr(i): istr(i) for i in range(200)}
+
+    @benchmark
+    def _run() -> None:
+        md.extend(items)
+
+
+def test_multidict_delitem_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            del md[i]
+
+
+def test_cimultidict_delitem_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            del md[i]
+
+
+def test_cimultidict_delitem_istr_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    items = [istr(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            del md[i]
+
+
+def test_multidict_getall_str_hit_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict(("all", str(i)) for i in range(100))
+
+    @benchmark
+    def _run() -> None:
+        md.getall("all")
+
+
+def test_cimultidict_getall_str_hit_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict(("all", str(i)) for i in range(100))
+
+    @benchmark
+    def _run() -> None:
+        md.getall("all")
+
+
+def test_cimultidict_getall_istr_hit_performance(benchmark: BenchmarkFixture) -> None:
+    all_istr = istr("all")
+    md: CIMultiDict[istr] = CIMultiDict((all_istr, istr(i)) for i in range(100))
+
+    @benchmark
+    def _run() -> None:
+        md.getall(all_istr)
+
+
+def test_multidict_fetch_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md[i]
+
+
+def test_cimultidict_fetch_str_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md[i]
+
+
+def test_cimultidict_fetch_istr_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    items = [istr(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md[i]
+
+
+def test_multidict_get_hit_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i)
+
+
+def test_multidict_get_miss_performance(benchmark: BenchmarkFixture) -> None:
+    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100, 200)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i)
+
+
+def test_cimultidict_get_hit_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i)
+
+
+def test_cimultidict_get_miss_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    items = [str(i) for i in range(100, 200)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i)
+
+
+def test_cimultidict_get_istr_hit_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    items = [istr(i) for i in range(100)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i)
+
+
+def test_cimultidict_get_istr_miss_performance(benchmark: BenchmarkFixture) -> None:
+    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    items = [istr(i) for i in range(100, 200)]
+
+    @benchmark
+    def _run() -> None:
+        for i in items:
+            md.get(i)

--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -1,7 +1,9 @@
 """codspeed benchmarks for multidict."""
 
+from typing import Dict, Union
+
 from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
-from typing import Union, Dict
+
 from multidict import CIMultiDict, MultiDict, istr
 
 # Note that this benchmark should not be refactored to use pytest.mark.parametrize

--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -71,49 +71,54 @@ def test_cimultidict_add_istr_performance(benchmark: BenchmarkFixture) -> None:
 
 
 def test_multidict_pop_str_performance(benchmark: BenchmarkFixture) -> None:
-    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    md_base: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
     @benchmark
     def _run() -> None:
+        md = md_base.copy()
         for i in items:
             md.pop(i)
 
 
 def test_cimultidict_pop_str_performance(benchmark: BenchmarkFixture) -> None:
-    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    md_base: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
     @benchmark
     def _run() -> None:
+        md = md_base.copy()
         for i in items:
             md.pop(i)
 
 
 def test_cimultidict_pop_istr_performance(benchmark: BenchmarkFixture) -> None:
-    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    md_base: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
     items = [istr(i) for i in range(100)]
 
     @benchmark
     def _run() -> None:
+        md = md_base.copy()
         for i in items:
             md.pop(i)
 
 
 def test_multidict_popitem_str_performance(benchmark: BenchmarkFixture) -> None:
-    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    md_base: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
 
     @benchmark
     def _run() -> None:
+        md = md_base.copy()
         for _ in range(100):
             md.popitem()
 
 
 def test_cimultidict_popitem_str_performance(benchmark: BenchmarkFixture) -> None:
-    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    md_base: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
 
     @benchmark
     def _run() -> None:
+        md = md_base.copy()
         for _ in range(100):
             md.popitem()
 
@@ -189,31 +194,34 @@ def test_cimultidict_extend_istr_performance(benchmark: BenchmarkFixture) -> Non
 
 
 def test_multidict_delitem_str_performance(benchmark: BenchmarkFixture) -> None:
-    md: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
+    md_base: MultiDict[str] = MultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
     @benchmark
     def _run() -> None:
+        md = md_base.copy()
         for i in items:
             del md[i]
 
 
 def test_cimultidict_delitem_str_performance(benchmark: BenchmarkFixture) -> None:
-    md: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
+    md_base: CIMultiDict[str] = CIMultiDict((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
 
     @benchmark
     def _run() -> None:
+        md = md_base.copy()
         for i in items:
             del md[i]
 
 
 def test_cimultidict_delitem_istr_performance(benchmark: BenchmarkFixture) -> None:
-    md: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
+    md_base: CIMultiDict[istr] = CIMultiDict((istr(i), istr(i)) for i in range(100))
     items = [istr(i) for i in range(100)]
 
     @benchmark
     def _run() -> None:
+        md = md_base.copy()
         for i in items:
             del md[i]
 


### PR DESCRIPTION
We are planning on merging free-threading support in https://github.com/aio-libs/multidict/pull/1015 but have no good way to test this does not regress performance. Add benchmarks ahead of merge so we can get a test in the CI