### PR TITLE
Fix __contains__ with unexpected types

### DIFF
--- a/CHANGES/1045.bugfix.rst
+++ b/CHANGES/1045.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed `__contains__` throwing an exception for non strings.
+Fixed ``__contains__`` throwing an exception for non strings.

--- a/CHANGES/1045.bugfix.rst
+++ b/CHANGES/1045.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``in`` checks throwing an exception instead of returning ``False`` when testing non-strings.
+Fixed ``in`` checks throwing an exception instead of returning :data:`False` when testing non-strings.

--- a/CHANGES/1045.bugfix.rst
+++ b/CHANGES/1045.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``__contains__`` throwing an exception for non strings.
+Fixed ``in`` checks throwing an exception instead of returning ``False`` when testing non-strings.

--- a/CHANGES/1045.bugfix.rst
+++ b/CHANGES/1045.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `__contains__` throwing an exception for non strings.

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -123,6 +123,8 @@ class _Base:
         return True
 
     def __contains__(self, key):
+        if not isinstance(key, str):
+            return False
         identity = self._title(key)
         for i, k, v in self._impl._items:
             if i == identity:
@@ -447,8 +449,8 @@ class _ViewBase:
 
 class _ItemsView(_ViewBase, abc.ItemsView):
     def __contains__(self, item):
-        assert isinstance(item, tuple) or isinstance(item, list)
-        assert len(item) == 2
+        if not isinstance(item, (tuple, list)) or len(item) != 2:
+            return False
         for i, k, v in self._impl._items:
             if item[0] == k and item[1] == v:
                 return True

--- a/multidict/_multilib/pair_list.h
+++ b/multidict/_multilib/pair_list.h
@@ -497,6 +497,10 @@ pair_list_contains(pair_list_t *list, PyObject *key)
     PyObject *identity = NULL;
     int tmp;
 
+    if (!PyUnicode_Check(key)) {
+        Py_RETURN_NOTIMPLEMENTED;
+    }
+
     ident = pair_list_calc_identity(list, key);
     if (ident == NULL) {
         goto fail;

--- a/multidict/_multilib/pair_list.h
+++ b/multidict/_multilib/pair_list.h
@@ -498,7 +498,7 @@ pair_list_contains(pair_list_t *list, PyObject *key)
     int tmp;
 
     if (!PyUnicode_Check(key)) {
-        Py_RETURN_NOTIMPLEMENTED;
+        return 0;
     }
 
     ident = pair_list_calc_identity(list, key);

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -224,6 +224,23 @@ class BaseMultiDictTest:
         d = cls([("key", "one"), ("key2", "two"), ("key", 3)])
         assert list(d) == ["key", "key2", "key"]
 
+    def test__contains(
+        self,
+        cls: Union[
+            Type[MultiDict[Union[str, int]]],
+            Type[CIMultiDict[Union[str, int]]],
+        ],
+    ) -> None:
+        d = cls([("key", "one"), ("key2", "two"), ("key", 3)])
+
+        assert list(d) == ["key", "key2", "key"]
+
+        assert "key" in d
+        assert "key2" in d
+
+        assert "foo" not in d
+        assert 42 not in d
+
     def test_keys__contains(
         self,
         cls: Union[
@@ -239,6 +256,7 @@ class BaseMultiDictTest:
         assert "key2" in d.keys()
 
         assert "foo" not in d.keys()
+        assert 42 not in d.keys()
 
     def test_values__contains(
         self,
@@ -273,6 +291,8 @@ class BaseMultiDictTest:
         assert ("key", 3) in d.items()
 
         assert ("foo", "bar") not in d.items()
+        assert (42, 3) not in d.items()
+        assert 42 not in d.items()
 
     def test_cannot_create_from_unaccepted(
         self,


### PR DESCRIPTION
Found this while adding inline type annotations for mypy.