### PR TITLE
Fix docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -375,7 +375,6 @@ nitpick_ignore: list[str] = []
 towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-version', 'sphinx-release'
 towncrier_draft_include_empty = True
 towncrier_draft_working_directory = PROJECT_ROOT_DIR
-towncrier_draft_config_path = "pyproject.toml"  # relative to cwd
 
 
 def _replace_missing_aiohttp_hdrs_reference(

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,4 +1,5 @@
 -r ci.txt
+-r towncrier.txt
 
 black==24.10.0
 isort==5.13.2


### PR DESCRIPTION
`towncrier_draft_config_path` was set to `pyproject.toml` but the config is in `towncrier.toml`
