### PR TITLE
Relax test_leak to run reliable against free-threaded python

### DIFF
--- a/tests/test_istr.py
+++ b/tests/test_istr.py
@@ -71,4 +71,4 @@ def test_leak(create_istrs: Callable[[], None]) -> None:
 
     gc.collect()
     cnt2 = len(gc.get_objects())
-    assert abs(cnt - cnt2) < 10  # on PyPy these numbers are not equal
+    assert abs(cnt - cnt2) < 50  # on PyPy these numbers are not equal


### PR DESCRIPTION
Free-threaded Python has a little different GC implementation, the number in the test should be raised.