### PR TITLE
🧪 Use Pytest 8.2.1 on PyPy

### DIFF
--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,3 +1,4 @@
-pytest==8.3.5
+pytest==8.3.5; platform_python_implementation != 'PyPy'
+pytest < 8.2.2; platform_python_implementation == 'PyPy'  # FIXME: Drop conditionals once the regression is gone. See https://github.com/pytest-dev/pytest/issues/13312.
 pytest-codspeed==3.2.0
 pytest-cov==6.0.0


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

This patch temporarily restricts pytest version below 8.2.2 under PyPy due to a discovered regression that it introduced [[1]].

The regression has been observed on at least `pypy3.9-7.3.16`, `pypy3.10-7.3.19` and `pypy3.11-7.3.19`.

It can be triggered by running the following in affected runtimes:

  pytest --collect-only --no-cov tests/test_abc.py tests/test_copy.py tests/test_incorrect_args.py tests/test_multidict.py tests/test_mypy.py tests/test_pickle.py tests/test_types.py tests/test_update.py tests/test_version.py

[1]: https://github.com/pytest-dev/pytest/issues/13312
[2]: https://github.com/pytest-dev/pytest/pull/12414
[3]: https://github.com/pytest-dev/pytest/pull/12409

<!-- Thank you for your contribution! -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
This is a contributor-only change.

## Related issue number

https://github.com/pytest-dev/pytest/issues/13312, #1072, https://github.com/pytest-dev/pytest/pull/12414, https://github.com/pytest-dev/pytest/pull/12409.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
