### PR TITLE
Register ABCs for C Extension classes in Python

### DIFF
--- a/multidict/__init__.py
+++ b/multidict/__init__.py
@@ -36,6 +36,9 @@ if TYPE_CHECKING or not USE_EXTENSIONS:
     )
 else:
     from ._multidict import (
+        _KeysView,
+        _ItemsView,
+        _ValuesView,
         CIMultiDict,
         CIMultiDictProxy,
         MultiDict,
@@ -43,6 +46,13 @@ else:
         getversion,
         istr,
     )
+    from collections.abc import KeysView, ItemsView, ValuesView
+
+    MultiMapping.register(MultiDictProxy)
+    MutableMultiMapping.register(MultiDict)
+    KeysView.register(_KeysView)
+    ItemsView.register(_ItemsView)
+    ValuesView.register(_ValuesView)
 
 
 upstr = istr

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -13,9 +13,6 @@
 #include "_multilib/views.h"
 
 
-static PyObject *collections_abc_mapping;
-static PyObject *collections_abc_mut_mapping;
-static PyObject *collections_abc_mut_multi_mapping;
 static PyObject *repr_func;
 
 static PyTypeObject multidict_type;
@@ -616,9 +613,7 @@ multidict_tp_iter(MultiDictObject *self)
 static inline PyObject *
 multidict_tp_richcompare(PyObject *self, PyObject *other, int op)
 {
-    // TODO: refactoring me with love
-
-    int cmp = 0;
+    int cmp;
 
     if (op != Py_EQ && op != Py_NE) {
         Py_RETURN_NOTIMPLEMENTED;
@@ -629,46 +624,37 @@ multidict_tp_richcompare(PyObject *self, PyObject *other, int op)
             (MultiDictObject*)self,
             (MultiDictObject*)other
         );
-        if (cmp < 0) {
-            return NULL;
-        }
-        if (op == Py_NE) {
-            cmp = !cmp;
-        }
-        return PyBool_FromLong(cmp);
-    }
-
-    if (MultiDictProxy_CheckExact(other) || CIMultiDictProxy_CheckExact(other)) {
+    } else if (MultiDictProxy_CheckExact(other) || CIMultiDictProxy_CheckExact(other)) {
         cmp = _multidict_eq(
             (MultiDictObject*)self,
             ((MultiDictProxyObject*)other)->md
         );
-        if (cmp < 0) {
-            return NULL;
+    } else {
+        bool fits = false;
+        fits = PyDict_Check(other);
+        if (!fits) {
+            PyObject *keys = PyMapping_Keys(other);
+            if (keys != NULL) {
+                fits = true;
+            } else {
+                // reset AttributeError exception
+                PyErr_Clear();
+            }
+            Py_CLEAR(keys);
         }
-        if (op == Py_NE) {
-            cmp = !cmp;
+        if (fits) {
+            cmp = pair_list_eq_to_mapping(&((MultiDictObject*)self)->pairs, other);
+        } else {
+            cmp = 0; // e.g., multidict is not equal to a list
         }
-        return PyBool_FromLong(cmp);
     }
-
-    cmp = PyObject_IsInstance(other, (PyObject*)collections_abc_mapping);
     if (cmp < 0) {
         return NULL;
     }
-
-    if (cmp) {
-        cmp = pair_list_eq_to_mapping(&((MultiDictObject*)self)->pairs, other);
-        if (cmp < 0) {
-            return NULL;
-        }
-        if (op == Py_NE) {
-            cmp = !cmp;
-        }
-        return PyBool_FromLong(cmp);
+    if (op == Py_NE) {
+        cmp = !cmp;
     }
-
-    Py_RETURN_NOTIMPLEMENTED;
+    return PyBool_FromLong(cmp);
 }
 
 static inline void
@@ -1563,9 +1549,6 @@ static inline void
 module_free(void *m)
 {
     Py_CLEAR(multidict_str_lower);
-    Py_CLEAR(collections_abc_mapping);
-    Py_CLEAR(collections_abc_mut_mapping);
-    Py_CLEAR(collections_abc_mut_multi_mapping);
 }
 
 static PyMethodDef multidict_module_methods[] = {
@@ -1596,8 +1579,7 @@ PyInit__multidict(void)
         goto fail;
     }
 
-    PyObject *module = NULL,
-             *reg_func_call_result = NULL;
+    PyObject *module = NULL;
 
     if (multidict_views_init() < 0) {
         goto fail;
@@ -1632,58 +1614,10 @@ PyInit__multidict(void)
         goto fail;                              \
     }
 
-    WITH_MOD("collections.abc");
-    GET_MOD_ATTR(collections_abc_mapping, "Mapping");
-
-    WITH_MOD("multidict._abc");
-    GET_MOD_ATTR(collections_abc_mut_mapping, "MultiMapping");
-    GET_MOD_ATTR(collections_abc_mut_multi_mapping, "MutableMultiMapping");
-
     WITH_MOD("multidict._multidict_base");
     GET_MOD_ATTR(repr_func, "_mdrepr");
 
     Py_CLEAR(module);                       \
-
-    /* Register in _abc mappings (CI)MultiDict and (CI)MultiDictProxy */
-    reg_func_call_result = PyObject_CallMethod(
-        collections_abc_mut_mapping,
-        "register", "O",
-        (PyObject*)&multidict_proxy_type
-    );
-    if (reg_func_call_result == NULL) {
-        goto fail;
-    }
-    Py_DECREF(reg_func_call_result);
-
-    reg_func_call_result = PyObject_CallMethod(
-        collections_abc_mut_mapping,
-        "register", "O",
-        (PyObject*)&cimultidict_proxy_type
-    );
-    if (reg_func_call_result == NULL) {
-        goto fail;
-    }
-    Py_DECREF(reg_func_call_result);
-
-    reg_func_call_result = PyObject_CallMethod(
-        collections_abc_mut_multi_mapping,
-        "register", "O",
-        (PyObject*)&multidict_type
-    );
-    if (reg_func_call_result == NULL) {
-        goto fail;
-    }
-    Py_DECREF(reg_func_call_result);
-
-    reg_func_call_result = PyObject_CallMethod(
-        collections_abc_mut_multi_mapping,
-        "register", "O",
-        (PyObject*)&cimultidict_type
-    );
-    if (reg_func_call_result == NULL) {
-        goto fail;
-    }
-    Py_DECREF(reg_func_call_result);
 
     /* Instantiate this module */
     module = PyModule_Create(&multidict_module);
@@ -1730,13 +1664,31 @@ PyInit__multidict(void)
         goto fail;
     }
 
+    Py_INCREF(&multidict_keysview_type);
+    if (PyModule_AddObject(
+            module, "_KeysView", (PyObject*)&multidict_keysview_type) < 0)
+    {
+        goto fail;
+    }
+
+    Py_INCREF(&multidict_itemsview_type);
+    if (PyModule_AddObject(
+            module, "_ItemsView", (PyObject*)&multidict_itemsview_type) < 0)
+    {
+        goto fail;
+    }
+
+    Py_INCREF(&multidict_valuesview_type);
+    if (PyModule_AddObject(
+            module, "_ValuesView", (PyObject*)&multidict_valuesview_type) < 0)
+    {
+        goto fail;
+    }
+
     return module;
 
 fail:
     Py_XDECREF(multidict_str_lower);
-    Py_XDECREF(collections_abc_mapping);
-    Py_XDECREF(collections_abc_mut_mapping);
-    Py_XDECREF(collections_abc_mut_multi_mapping);
 
     return NULL;
 

--- a/multidict/_multidict_base.py
+++ b/multidict/_multidict_base.py
@@ -21,18 +21,6 @@ else:
     from typing_extensions import assert_never
 
 
-def _abc_itemsview_register(view_cls: type[object]) -> None:
-    ItemsView.register(view_cls)
-
-
-def _abc_keysview_register(view_cls: type[object]) -> None:
-    KeysView.register(view_cls)
-
-
-def _abc_valuesview_register(view_cls: type[object]) -> None:
-    ValuesView.register(view_cls)
-
-
 def _viewbaseset_richcmp(
     view: set[object], other: object, op: Literal[0, 1, 2, 3, 4, 5]
 ) -> Union[bool, NotImplementedType]:

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -15,10 +15,6 @@ static PyObject *viewbaseset_or_func;
 static PyObject *viewbaseset_sub_func;
 static PyObject *viewbaseset_xor_func;
 
-static PyObject *abc_itemsview_register_func;
-static PyObject *abc_keysview_register_func;
-static PyObject *abc_valuesview_register_func;
-
 static PyObject *itemsview_isdisjoint_func;
 static PyObject *itemsview_repr_func;
 
@@ -387,7 +383,6 @@ static PyTypeObject multidict_valuesview_type = {
 static inline int
 multidict_views_init(void)
 {
-    PyObject *reg_func_call_result = NULL;
     PyObject *module = PyImport_ImportModule("multidict._multidict_base");
     if (module == NULL) {
         goto fail;
@@ -405,10 +400,6 @@ multidict_views_init(void)
     GET_MOD_ATTR(viewbaseset_sub_func, "_viewbaseset_sub");
     GET_MOD_ATTR(viewbaseset_xor_func, "_viewbaseset_xor");
 
-    GET_MOD_ATTR(abc_itemsview_register_func, "_abc_itemsview_register");
-    GET_MOD_ATTR(abc_keysview_register_func, "_abc_keysview_register");
-    GET_MOD_ATTR(abc_valuesview_register_func, "_abc_valuesview_register");
-
     GET_MOD_ATTR(itemsview_isdisjoint_func, "_itemsview_isdisjoint");
     GET_MOD_ATTR(itemsview_repr_func, "_itemsview_repr");
 
@@ -424,29 +415,6 @@ multidict_views_init(void)
         goto fail;
     }
 
-    // abc.ItemsView.register(_ItemsView)
-    reg_func_call_result = PyObject_CallFunctionObjArgs(
-        abc_itemsview_register_func, (PyObject*)&multidict_itemsview_type, NULL);
-    if (reg_func_call_result == NULL) {
-        goto fail;
-    }
-    Py_DECREF(reg_func_call_result);
-
-    // abc.KeysView.register(_KeysView)
-    reg_func_call_result = PyObject_CallFunctionObjArgs(
-        abc_keysview_register_func, (PyObject*)&multidict_keysview_type, NULL);
-    if (reg_func_call_result == NULL) {
-        goto fail;
-    }
-    Py_DECREF(reg_func_call_result);
-
-    // abc.ValuesView.register(_KeysView)
-    reg_func_call_result = PyObject_CallFunctionObjArgs(
-        abc_valuesview_register_func, (PyObject*)&multidict_valuesview_type, NULL);
-    if (reg_func_call_result == NULL) {
-        goto fail;
-    }
-    Py_DECREF(reg_func_call_result);
 
     Py_DECREF(module);
     return 0;


### PR DESCRIPTION
As a side effect, drop slow `isinstance(obj, collections.abc.Mapping)` call but check for `obj.keys()`.
Python does it for dict equals check itself, multidict just reuses this approach.