### PR TITLE
Omit coverage report for setup.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -34,5 +34,6 @@ source =
 source_pkgs =
   multidict
 omit =
+  setup.py
   # FIXME: migrate to a snapshotting plugin. See #922, #924 and #938.
   tests/gen_pickles.py


### PR DESCRIPTION
`setup.py` is not a part of the project, it shouldn't be covered