### PR TITLE
🧪💅 Refactor Codecov config metrics

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,7 +7,8 @@ codecov:
 
   require_ci_to_pass: false
 
-  token: 796e466d-bf08-4b98-8d5b-0e9c442aef06  # repo-scoped
+  token: >-  # notsecret  # repo-scoped, upload-only, stability in fork PRs
+    796e466d-bf08-4b98-8d5b-0e9c442aef06
 
 comment:
   require_changes: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,7 +16,7 @@ coverage:
   range: 97.87..100
   status:
     patch:
-      default:
+      runtime:
         target: 100%
         flags:
         - pytest

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -26,7 +26,7 @@ coverage:
         - pytest
         paths:
         - multidict/
-        target: 94.05%
+        target: 100%
       tests:
         flags:
         - pytest

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,8 +21,6 @@ coverage:
         flags:
         - pytest
     project:
-      default:
-        target: 100%
       lib:
         flags:
         - pytest

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,6 +20,9 @@ coverage:
         target: 100%
         flags:
         - pytest
+      typing:
+        flags:
+        - MyPy
     project:
       lib:
         flags:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -38,4 +38,7 @@ coverage:
         - MyPy
         target: 85%
 
+github_checks:
+  annotations: false
+
 ...

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,7 +13,7 @@ comment:
   require_changes: true
 
 coverage:
-  range: 97.87..100
+  range: 100..100
   status:
     patch:
       runtime:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -133,10 +133,12 @@ Contributor-facing changes
 - `codecov-action <https://github.com/codecov/codecov-action>`_
   has been temporarily downgraded to ``v3``
   in the GitHub Actions CI/CD workflow definitions
-  in order to fix uploading coverage to
-  `Codecov <https://app.codecov.io/gh/aio-libs/multidict>`_.
+  in order to fix uploading coverage to Codecov_.
   See `this issue <https://github.com/codecov/codecov-action/issues/1252>`_
   for more details.
+
+
+  .. _Codecov: https://codecov.io/gh/aio-libs/multidict?flags[]=pytest
 
 
   *Related issues and pull requests on GitHub:*

--- a/CHANGES/1093.contrib.rst
+++ b/CHANGES/1093.contrib.rst
@@ -1,0 +1,34 @@
+The the project-wide Codecov_ metric is no longer reported
+via GitHub Checks API. The combined value is not very useful
+because one of the sources (MyPy) cannot reach 100% with the
+current state of the ecosystem. We may want to reconsider in
+the future. Instead, we now have two separate
+“runtime coverage” metrics for library code and tests.
+They are to be kept at 100% at all times.
+And the “type coverage” metric will remain advisory, at a
+lower threshold.
+
+The default patch metric check is renamed to “runtime”
+to better reflect its semantics. This one will also require
+100% coverage.
+Another “typing” patch coverage metric is now reported
+alongside it. It's considered advisory, just like its
+project counterpart.
+
+When looking at Codecov_, one will likely want to look at
+MyPy and pytest flags separately. It is usually best to
+avoid looking at the PR pages that sometimes display
+combined coverage incorrectly.
+
+The change additionally disables the deprecated GitHub
+Annotations integration in Codecov_.
+
+Finally, the badge coloring range now starts at 100%.
+
+
+.. image:: https://codecov.io/gh/aio-libs/multidict/branch/master/graph/badge.svg?flag=pytest
+   :target: https://codecov.io/gh/aio-libs/multidict?flags[]=pytest
+   :alt: Coverage metrics
+
+
+-- by :user:`webknjaz`

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ multidict
    :target: https://github.com/aio-libs/multidict/actions
    :alt: GitHub status for master branch
 
-.. image:: https://codecov.io/gh/aio-libs/multidict/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/aio-libs/multidict
+.. image:: https://codecov.io/gh/aio-libs/multidict/branch/master/graph/badge.svg?flag=pytest
+   :target: https://codecov.io/gh/aio-libs/multidict?flags[]=pytest
    :alt: Coverage metrics
 
 .. image:: https://img.shields.io/pypi/v/multidict.svg


### PR DESCRIPTION
This patch drops the project-wide Codecov metric.
The combined value is not very useful when one of the sources (MyPy)
has no chance at reaching 100%. We may want to reconsider in the
future. Instead, we'll have two separate “runtime coverage” metrics
for library code and tests that will be kept at 100%, while the
“type coverage” metric will remain at a lower threshold.

The “runtime coverage” is what we enforced, while MyPy results are
advisory.

When looking at Codecov, one will likely want to look at MyPy and
pytest flags separately. It is usually best to avoid looking at the
PR pages that sometimes display combined coverage incorrectly.

The change additionally disables the deprecated GitHub Annotations
integration in Codecov.

The default patch metric check is renamed to “runtime” to better
reflect its semantics. And another “typing” patch coverage metric
is now reported alongside it.

The badge coloring range now starts at 100%.
