### PR TITLE
Add codspeed badge to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,10 @@ multidict
    :target: https://multidict.aio-libs.org
    :alt: Read The Docs build status badge
 
+.. image:: https://img.shields.io/endpoint?url=https://codspeed.io/badge.json
+   :target: https://codspeed.io/aio-libs/multidict
+   :alt: CodSpeed
+
 .. image:: https://img.shields.io/pypi/pyversions/multidict.svg
    :target: https://pypi.org/project/multidict
    :alt: Python versions


### PR DESCRIPTION
We have been using codspeed a lot on this repo recently. We should add it to the README as done on other projects to its easy to find, and thank codspeed for offering their tooling for free to OSS.