### PR TITLE
Use istr as keys in CIMultiDict

### DIFF
--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -80,8 +80,9 @@ class _Iter(Generic[_T]):
 
 
 class _ViewBase(Generic[_V]):
-    def __init__(self, impl: _Impl[_V]):
+    def __init__(self, impl: _Impl[_V], keyfunc: Callable[[str], str]):
         self._impl = impl
+        self._keyfunc = keyfunc
 
     def __len__(self) -> int:
         return len(self._impl._items)
@@ -139,8 +140,11 @@ class _ValuesView(_ViewBase[_V], ValuesView[_V]):
 
 class _KeysView(_ViewBase[_V], KeysView[str]):
     def __contains__(self, key: object) -> bool:
-        for item in self._impl._items:
-            if item[1] == key:
+        if not isinstance(key, str):
+            return False
+        identity = self._keyfunc(key)
+        for i, k, v in self._impl._items:
+            if i == identity:
                 return True
         return False
 
@@ -148,10 +152,10 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
         return _Iter(len(self), self._iter(self._impl._version))
 
     def _iter(self, version: int) -> Iterator[str]:
-        for item in self._impl._items:
+        for i, k, v in self._impl._items:
             if version != self._impl._version:
                 raise RuntimeError("Dictionary changed during iteration")
-            yield item[1]
+            yield k
 
     def __repr__(self) -> str:
         lst = []
@@ -226,15 +230,15 @@ class _Base(MultiMapping[_V]):
 
     def keys(self) -> KeysView[str]:
         """Return a new view of the dictionary's keys."""
-        return _KeysView(self._impl)
+        return _KeysView(self._impl, self._title)
 
     def items(self) -> ItemsView[str, _V]:
         """Return a new view of the dictionary's items *(key, value) pairs)."""
-        return _ItemsView(self._impl)
+        return _ItemsView(self._impl, self._title)
 
     def values(self) -> _ValuesView[_V]:
         """Return a new view of the dictionary's values."""
-        return _ValuesView(self._impl)
+        return _ValuesView(self._impl, self._title)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Mapping):
@@ -530,6 +534,14 @@ class MultiDict(_Base[_V], MutableMultiMapping[_V]):
 class CIMultiDict(MultiDict[_V]):
     """Dictionary with the support for duplicate case-insensitive keys."""
 
+    def _key(self, key: str) -> str:
+        if isinstance(key, str):
+            if getattr(type(key), '__is_istr__', False):
+                return key
+            else:
+                return istr(key)
+        else:
+            raise TypeError("MultiDict keys should be either str or subclasses of str")
     def _title(self, key: str) -> str:
         return key.title()
 

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -690,3 +690,21 @@ class TestCIMutableMultiDict:
         d["c"] = "000"
         # This causes an error on pypy.
         list(before_mutation_values)
+
+    def test_keys_type(
+        self,
+        case_insensitive_multidict_class: type[CIMultiDict[str]],
+        case_insensitive_str_class: type[istr],
+    ) -> None:
+        d = case_insensitive_multidict_class([("KEY", "one"),])
+        d['k2'] = '2'
+        d.extend(k3='3')
+
+        for k in d:
+            assert type(k) is case_insensitive_str_class
+
+        for k in d.keys():
+            assert type(k) is case_insensitive_str_class
+
+        for k, v in d.items():
+            assert type(k) is case_insensitive_str_class


### PR DESCRIPTION
Currently, keys of CIMultiDict are stored as-is, e.g. `CIMultiDict({'k': 'v'})` has `str` key.

But it is slightly incorrect, CIMultiDict should store `istr` keys.