### PR TITLE
Remove the last element by popitem()

### DIFF
--- a/CHANGES/1105.feature
+++ b/CHANGES/1105.feature
@@ -1,5 +1,5 @@
 :meth:`multidict.MultiDict.popitem` is changed to remove
-the latest entry instead of the fisrt.
+the latest entry instead of the first.
 
 It gives O(1) amortized complexity.
 

--- a/CHANGES/1105.feature
+++ b/CHANGES/1105.feature
@@ -1,5 +1,5 @@
-:meth:`multidict.MultiDict.popitem` and :meth:`multidict.CIMultiDict.popitem`
-are changed to remove the latest entry instead of the fisrt.
+:meth:`multidict.MultiDict.popitem` is changed to remove
+the latest entry instead of the fisrt.
 
 It gives O(1) amortized complexity.
 

--- a/CHANGES/1105.feature
+++ b/CHANGES/1105.feature
@@ -1,0 +1,6 @@
+:meth:`multidict.MultiDict.popitem` and :meth:`multidict.CIMultiDict.popitem`
+are changed to remove the latest entry instead of the fisrt.
+
+It gives O(1) amortized complexity.
+
+The standard :meth:`dict.popitem` removes the last entry also.

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -456,7 +456,7 @@ class MultiDict(_Base[_V], MutableMultiMapping[_V]):
     def popitem(self) -> tuple[str, _V]:
         """Remove and return an arbitrary (key, value) pair."""
         if self._impl._items:
-            i = self._impl._items.pop(0)
+            i = self._impl._items.pop()
             self._impl.incr_version()
             return i[1], i[2]
         else:

--- a/multidict/_multilib/pair_list.h
+++ b/multidict/_multilib/pair_list.h
@@ -772,13 +772,14 @@ pair_list_pop_item(pair_list_t *list)
         return NULL;
     }
 
-    pair_t *pair = list->pairs;
+    Py_ssize_t pos = list->size - 1;
+    pair_t *pair = list->pairs + pos;
     PyObject *ret = PyTuple_Pack(2, pair->key, pair->value);
     if (ret == NULL) {
         return NULL;
     }
 
-    if (pair_list_del_at(list, 0) < 0) {
+    if (pair_list_del_at(list, pos) < 0) {
         Py_DECREF(ret);
         return NULL;
     }

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -158,8 +158,8 @@ class TestMutableMultiDict:
         d.add("key", "val1")
         d.add("key", "val2")
 
-        assert ("key", "val1") == d.popitem()
-        assert [("key", "val2")] == list(d.items())
+        assert ("key", "val2") == d.popitem()
+        assert [("key", "val1")] == list(d.items())
 
     def test_popitem_empty_multidict(
         self,
@@ -546,9 +546,9 @@ class TestCIMutableMultiDict:
         d.add("key", "val2")
 
         pair = d.popitem()
-        assert ("KEY", "val1") == pair
+        assert ("key", "val2") == pair
         assert isinstance(pair[0], str)
-        assert [("key", "val2")] == list(d.items())
+        assert [("KEY", "val1")] == list(d.items())
 
     def test_popitem_empty_multidict(
         self,


### PR DESCRIPTION
It gives O(1) amortized complexity.

The standard `dict.popitem()` removes the last entry also.