### PR TITLE
Add benchmarks for iterating multidict

### DIFF
--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -577,6 +577,17 @@ def test_iterate_multidict_keys(
             pass
 
 
+def test_iterate_multidict_values(
+    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+) -> None:
+    items = [(str(i), str(i)) for i in range(100)]
+    md = any_multidict_class(items)
+
+    @benchmark
+    def _run() -> None:
+        for _ in md.values():
+            pass
+
 def test_iterate_multidict_items(
     benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
 ) -> None:

--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -552,3 +552,38 @@ def test_copy_from_existing_cimultidict(
     @benchmark
     def _run() -> None:
         existing.copy()
+
+
+def test_iterate_multidict(
+    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+) -> None:
+    items = [(str(i), str(i)) for i in range(100)]
+    md = any_multidict_class(items)
+
+    @benchmark
+    def _run() -> None:
+        for _ in md:
+            pass
+
+def test_iterate_multidict_keys(
+    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+) -> None:
+    items = [(str(i), str(i)) for i in range(100)]
+    md = any_multidict_class(items)
+
+    @benchmark
+    def _run() -> None:
+        for _ in md.keys():
+            pass
+
+
+def test_iterate_multidict_items(
+    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+) -> None:
+    items = [(str(i), str(i)) for i in range(100)]
+    md = any_multidict_class(items)
+
+    @benchmark
+    def _run() -> None:
+        for _, _ in md.items():
+            pass


### PR DESCRIPTION
Iterating the multidict is a common enough operation in aiohttp that we should benchmark it
https://github.com/aio-libs/aiohttp/blob/e66b5fedc3f24d1d8c76d118b0a28df02e75e81b/aiohttp/client.py#L1082
https://github.com/aio-libs/aiohttp/blob/e66b5fedc3f24d1d8c76d118b0a28df02e75e81b/aiohttp/client_reqrep.py#L406