### PR TITLE
Update benchmarks to use Python 3.13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -383,11 +383,11 @@ jobs:
         pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         merge-multiple: true
 
-    - name: Setup Python 3.12
+    - name: Setup Python 3.13
       id: python-install
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.13
         cache: pip
         cache-dependency-path: requirements/*.txt
     - name: Install dependencies


### PR DESCRIPTION
Wait for https://github.com/aio-libs/multidict/pull/1109 to merge

Usually I update these when a Python release reaches .1 but I forgot about this repo
