### PR TITLE
Release 6.3.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,34 @@ Changelog
 
 .. towncrier release notes start
 
+6.3.1
+=====
+
+*(2025-04-01)*
+
+
+Bug fixes
+---------
+
+- Fixed keys not becoming case-insensitive when :class:`multidict.CIMultiDict` is created by passing in a :class:`multidict.MultiDict` -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1112`.
+
+- Fixed the pure Python version mutating the original :class:`multidict.MultiDict` when creating a new :class:`multidict.CIMultiDict` from an existing one when keyword arguments are also passed -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1113`.
+
+- Prevented crashing with a segfault when :func:`repr` is called for recursive multidicts and their proxies and views.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1115`.
+
+
+----
+
+
 6.3.0
 =====
 

--- a/CHANGES/1112.bugfix.rst
+++ b/CHANGES/1112.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed keys not becoming case-insensitive when :class:`multidict.CIMultiDict` is created by passing in a :class:`multidict.MultiDict` -- by :user:`bdraco`. 

--- a/CHANGES/1113.bugfix.rst
+++ b/CHANGES/1113.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed the pure Python version mutating the original :class:`multidict.MultiDict` when creating a new :class:`multidict.CIMultiDict` from an existing one when keyword arguments are also passed -- by :user:`bdraco`.

--- a/CHANGES/1115.bugfix
+++ b/CHANGES/1115.bugfix
@@ -1,1 +1,0 @@
-Prevented crashing with a segfault when :func:`repr` is called for recursive multidicts and their proxies and views.

--- a/multidict/__init__.py
+++ b/multidict/__init__.py
@@ -22,7 +22,7 @@ __all__ = (
     "getversion",
 )
 
-__version__ = "6.3.0"
+__version__ = "6.3.1"
 
 
 if TYPE_CHECKING or not USE_EXTENSIONS:


### PR DESCRIPTION
6.3.1 to fix the regressions that were identified quickly after the 6.3.0 release.

We will likely do a 6.3.2 rather soon once we have a reproducer and fix for https://github.com/aio-libs/multidict/issues/1117

<img width="679" alt="Screenshot 2025-04-01 at 10 02 54 AM" src="https://github.com/user-attachments/assets/e933dbdf-1f81-499c-87dd-04491c02372a" />
