### PR TITLE
Start building armv7l wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -124,9 +124,24 @@ jobs:
         - ubuntu
         - windows
         - macos
+        tag:
+        - ''
+        - 'musllinux'
+        exclude:
+        - os: windows
+          tag: 'musllinux'
+        - os: macos
+          tag: 'musllinux'
+        - os: ubuntu
+          tag: >-
+           ${{
+           (github.event_name != 'push' || !contains(github.ref, 'refs/tags/'))
+           && 'musllinux' || 'none'
+           }}
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       os: ${{ matrix.os }}
+      tag: ${{ matrix.tag }}
       wheel-tags-to-skip: >-
         ${{
         (github.event_name != 'push' || !contains(github.ref, 'refs/tags/'))
@@ -135,7 +150,8 @@ jobs:
         *-musllinux_*
         *-win32
         pp*'
-        || ''
+        || (matrix.tag == 'musllinux') && '*-manylinux_* pp*'
+        || '*-musllinux_* pp*'
         }}
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
@@ -504,7 +520,7 @@ jobs:
         echo "Predeploy step"
 
   build-wheels-for-odd-archs:
-    name: Build wheels on ${{ matrix.os }} ${{ matrix.qemu }}
+    name: Build wheels on ${{ matrix.tag }} ${{ matrix.qemu }}
     needs:
     - build-pure-python-dists
     - pre-deploy
@@ -515,9 +531,20 @@ jobs:
         - aarch64
         - ppc64le
         - s390x
+        - armv7l
+        tag:
+        - ''
+        - musllinux
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       qemu: ${{ matrix.qemu }}
+      tag: ${{ matrix.tag }}
+      wheel-tags-to-skip: >-
+        ${{
+        (matrix.tag == 'musllinux')
+        && '*-manylinux_* pp*'
+        || '*-musllinux_* pp*'
+        }}
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
       dists-artifact-name: ${{ needs.pre-setup.outputs.dists-artifact-name }}

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -47,6 +47,21 @@ jobs:
     runs-on: ${{ inputs.os }}-latest
     timeout-minutes: ${{ inputs.qemu && 120 || 15 }}
     steps:
+    - name: Compute GHA artifact name ending
+      id: gha-artifact-name
+      run: |
+        from hashlib import sha512
+        from os import environ
+        from pathlib import Path
+        FILE_APPEND_MODE = 'a'
+        inputs_json_str = """${{ toJSON(inputs) }}"""
+        hash = sha512(inputs_json_str.encode()).hexdigest()
+        with Path(environ['GITHUB_OUTPUT']).open(
+                mode=FILE_APPEND_MODE,
+        ) as outputs_file:
+            print(f'hash={hash}', file=outputs_file)
+      shell: python
+
     - name: Retrieve the project source from an sdist inside the GHA artifact
       uses: re-actors/checkout-python-sdist@release/v2
       with:
@@ -84,7 +99,8 @@ jobs:
         name: ${{ inputs.dists-artifact-name }}-
            ${{ inputs.os }}-
            ${{ inputs.qemu }}-
-           ${{ inputs.tag }}
+           ${{ inputs.tag }}-
+           ${{ steps.gha-artifact-name.outputs.hash }}
         path: ./wheelhouse/*.whl
 
 ...

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -19,6 +19,11 @@ on:
         default: ''
         required: false
         type: string
+      tag:
+        description: Build platform tag wheels
+        default: ''
+        required: false
+        type: string
       source-tarball-name:
         description: Sdist filename wildcard
         required: true
@@ -37,7 +42,8 @@ env:
 jobs:
 
   build-wheel:
-    name: Build wheels on ${{ inputs.os }} ${{ inputs.qemu }}
+    name: >-
+      Build ${{ inputs.tag }} wheels on ${{ inputs.os }} ${{ inputs.qemu }}
     runs-on: ${{ inputs.os }}-latest
     timeout-minutes: ${{ inputs.qemu && 120 || 15 }}
     steps:
@@ -75,8 +81,10 @@ jobs:
     - name: Upload built artifacts for testing and publishing
       uses: actions/upload-artifact@v4
       with:
-        name: >-
-          ${{ inputs.dists-artifact-name }}-${{ inputs.os }}-${{ inputs.qemu }}
+        name: ${{ inputs.dists-artifact-name }}-
+           ${{ inputs.os }}-
+           ${{ inputs.qemu }}-
+           ${{ inputs.tag }}
         path: ./wheelhouse/*.whl
 
 ...

--- a/CHANGES/1127.feature.rst
+++ b/CHANGES/1127.feature.rst
@@ -1,0 +1,1 @@
+Started building armv7l wheels -- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,3 +1,4 @@
+armv
 aarch64
 i686
 ppc64le


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Copy the wheel build changes from `yarl` to use `armv7l` which also splits the `manylinux` and `musllinux` jobs which means the release process will be a bit faster

~~Note that the `manylinux` `armv7l` wheels might still not build and we will than have to add the exclude like we do for `yarl` since the previous `manylinux` image for `armv7l` did not have a working `cffi` package. In theory this has been fixed in https://github.com/pypa/cibuildwheel/releases/tag/v2.23.0~~ yarl released fine with manylinux now

## Are there changes in behavior for the user?

`armv7l` wheels
