### PR TITLE
Improve benchmarks for getall()

### DIFF
--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -255,17 +255,19 @@ def test_cimultidict_delitem_istr(
 def test_multidict_getall_str_hit(
     benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
 ) -> None:
-    md = any_multidict_class(("all", str(i)) for i in range(100))
+    md = any_multidict_class((f"key{j}", str(f"{i}-{j}"))
+                             for i in range(20) for j in range(5))
 
     @benchmark
     def _run() -> None:
-        md.getall("all")
+        md.getall("key0")
 
 
 def test_multidict_getall_str_miss(
     benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
 ) -> None:
-    md = any_multidict_class(("all", str(i)) for i in range(100))
+    md = any_multidict_class((f"key{j}", str(f"{i}-{j}"))
+                             for i in range(20) for j in range(5))
 
     @benchmark
     def _run() -> None:
@@ -276,8 +278,9 @@ def test_cimultidict_getall_istr_hit(
     benchmark: BenchmarkFixture,
     case_insensitive_multidict_class: Type[CIMultiDict[istr]],
 ) -> None:
-    all_istr = istr("all")
-    md = case_insensitive_multidict_class((all_istr, istr(i)) for i in range(100))
+    all_istr = istr("key0")
+    md = case_insensitive_multidict_class((f"key{j}", istr(f"{i}-{j}"))
+                                          for i in range(20) for j in range(5))
 
     @benchmark
     def _run() -> None:
@@ -288,9 +291,9 @@ def test_cimultidict_getall_istr_miss(
     benchmark: BenchmarkFixture,
     case_insensitive_multidict_class: Type[CIMultiDict[istr]],
 ) -> None:
-    all_istr = istr("all")
     miss_istr = istr("miss")
-    md = case_insensitive_multidict_class((all_istr, istr(i)) for i in range(100))
+    md = case_insensitive_multidict_class((istr(f"key{j}"), istr(f"{i}-{j}"))
+                                          for i in range(20) for j in range(5))
 
     @benchmark
     def _run() -> None:


### PR DESCRIPTION
Instead of filing a multidict with 100 equal keys and getting all of them by `md.getall()`, the PR creates a multidict with 20% of the requested keys uniformly scattered over the multidict.