### PR TITLE
Fix memory leak creating new istr objects

### DIFF
--- a/CHANGES/1133.bugfix.rst
+++ b/CHANGES/1133.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a memory leak creating new :class:`~multidict.istr` objects -- by :user:`bdraco`.
+
+The leak was introduced in 6.3.0

--- a/multidict/_multilib/istr.h
+++ b/multidict/_multilib/istr.h
@@ -146,7 +146,7 @@ static PyType_Spec istr_spec = {
 static inline PyObject *
 IStr_New(mod_state *state, PyObject *str, PyObject *canonical)
 {
-    PyObject *res = PyUnicode_FromObject(str);
+    PyObject *res = PyObject_Str(str);
     if (res) {
         ((istrobject*)res)->canonical = canonical;
         ((istrobject*)res)->state = state;

--- a/multidict/_multilib/istr.h
+++ b/multidict/_multilib/istr.h
@@ -146,11 +146,21 @@ static PyType_Spec istr_spec = {
 static inline PyObject *
 IStr_New(mod_state *state, PyObject *str, PyObject *canonical)
 {
-    PyObject *res = PyObject_Str(str);
-    if (res) {
-        ((istrobject*)res)->canonical = canonical;
-        ((istrobject*)res)->state = state;
+    PyObject *args = NULL;
+    PyObject *res = NULL;
+    args = PyTuple_Pack(1, str);
+    if (args == NULL) {
+        goto ret;
     }
+    res = PyUnicode_Type.tp_new(state->IStrType, args, NULL);
+    if (!res) {
+        goto ret;
+    }
+    Py_INCREF(canonical);
+    ((istrobject*)res)->canonical = canonical;
+    ((istrobject*)res)->state = state;
+ret:
+    Py_CLEAR(args);
     return res;
 }
 

--- a/multidict/_multilib/istr.h
+++ b/multidict/_multilib/istr.h
@@ -146,34 +146,11 @@ static PyType_Spec istr_spec = {
 static inline PyObject *
 IStr_New(mod_state *state, PyObject *str, PyObject *canonical)
 {
-    PyObject *args = NULL;
-    PyObject *kwds = NULL;
-    PyObject *res = NULL;
-
-    args = PyTuple_Pack(1, str);
-    if (args == NULL) {
-        goto ret;
+    PyObject *res = PyUnicode_FromObject(str);
+    if (res) {
+        ((istrobject*)res)->canonical = canonical;
+        ((istrobject*)res)->state = state;
     }
-
-    if (canonical != NULL) {
-        kwds = PyDict_New();
-        if (kwds == NULL) {
-            goto ret;
-        }
-        if (!PyUnicode_CheckExact(canonical)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "'canonical' argument should be exactly str");
-            goto ret;
-        }
-        if (PyDict_SetItem(kwds, state->str_canonical, canonical) < 0) {
-            goto ret;
-        }
-    }
-
-    res = istr_new_with_state(state->IStrType, args, kwds, state);
-ret:
-    Py_CLEAR(args);
-    Py_CLEAR(kwds);
     return res;
 }
 

--- a/multidict/_multilib/istr.h
+++ b/multidict/_multilib/istr.h
@@ -27,7 +27,7 @@ istr_dealloc(istrobject *self)
 }
 
 static inline PyObject *
-istr_new_with_state(PyTypeObject *type, PyObject *args, PyObject *kwds)
+istr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *mod = PyType_GetModuleByDef(type, &multidict_module);
     if (mod == NULL) {
@@ -64,12 +64,6 @@ istr_new_with_state(PyTypeObject *type, PyObject *args, PyObject *kwds)
 fail:
     Py_XDECREF(ret);
     return NULL;
-}
-
-static inline PyObject *
-istr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
-{
-    return istr_new_with_state(type, args, kwds);
 }
 
 static inline PyObject *


### PR DESCRIPTION
Fixes leak 1 from https://github.com/aio-libs/multidict/issues/1131#issuecomment-2787514071 (`IStr_New` path)

see https://github.com/aio-libs/multidict/issues/1131#issuecomment-2787878877 https://github.com/aio-libs/multidict/issues/1131#issuecomment-2787879594 https://github.com/aio-libs/multidict/issues/1131#issuecomment-2787891048

This also seems to fix the perf regression in popitem from https://github.com/aio-libs/multidict/pull/1097#issuecomment-2746161895
https://codspeed.io/aio-libs/multidict/branches/istr-keys

introduced #1097
fixes #1131
