### PR TITLE
Increase deploy timeout to 15 minutes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -557,7 +557,7 @@ jobs:
     - build-wheels-for-tested-arches
     - pre-setup  # transitive, for accessing settings
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases


### PR DESCRIPTION
The last release failed sigstore due to it taking longer than 5 minutes.  Probably needed 7 minutes.  Increase timeout to 15 minutes so we don't have this problem again even if something is a bit slower in the future.
