### PR TITLE
Release 6.4.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,18 @@ Changelog
 
 .. towncrier release notes start
 
+6.4.1
+=====
+
+*(2025-04-09)*
+
+
+No significant changes.
+
+
+----
+
+
 6.4.0
 =====
 

--- a/multidict/__init__.py
+++ b/multidict/__init__.py
@@ -22,7 +22,7 @@ __all__ = (
     "getversion",
 )
 
-__version__ = "6.4.0"
+__version__ = "6.4.1"
 
 
 if TYPE_CHECKING or not USE_EXTENSIONS:


### PR DESCRIPTION
The sigstore action failed for 6.4.0 because of the timeout.  This is a no change release to ensure the binaries are signed with sigstore


<img width="389" alt="Screenshot 2025-04-09 at 8 58 11 AM" src="https://github.com/user-attachments/assets/f965333e-9473-4c8b-9c3d-17282ef89fea" />
