### PR TITLE
Run CI against all PRs, not only for PR with master base branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,10 +12,6 @@ on:
     tags:
     - v*
   pull_request:
-    branches:
-    - master
-    - >-
-      [0-9].[0-9]+
   schedule:
   - cron: 0 6 * * *  # Daily 6AM UTC build
 


### PR DESCRIPTION
When @Vizonex created PR against capi working branch, these PRs didn't run CI tests.

If I understand correctly how GitHub works, it is because of the current filters for `pull_request` event.

The proposal drops the filters for `pull_request` event, all PRs will be tested regardless of the base branch name.