### PR TITLE
Slightly rewrite internal C API to reflect the modern dict API

### DIFF
--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -621,6 +621,7 @@ multidict_setdefault(MultiDictObject *self, PyObject *const *args,
     PyObject *key = NULL;
     PyObject *_default = NULL;
     bool decref_default = false;
+    PyObject *ret = NULL;
 
     if (parse2("setdefault",
                args,
@@ -641,7 +642,9 @@ multidict_setdefault(MultiDictObject *self, PyObject *const *args,
         decref_default = true;
     }
     ASSERT_CONSISTENT(self, false);
-    PyObject *ret = md_set_default(self, key, _default);
+    if (md_set_default(self, key, _default, &ret) < 0) {
+        return NULL;
+    }
     if (decref_default) {
         Py_CLEAR(_default);
     }


### PR DESCRIPTION
1. `md_get_one()`, `md_get_all()`, `md_pop_one()`, `md_pop_all()` now return `1` if key exists in multidict, `0` otherwise.
2. `md_set_default()` now also returns `1` if key exists in multidict, `0` if key doesn't exist and the default was iserted into the object.
3. All functions return `-1` in case of error.

The PR doesn't affect any public API; it is a preparation step for introducing multidict's public C API.