### PR TITLE
Fix md_get_all() return value

### DIFF
--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -868,7 +868,7 @@ md_get_all(MultiDictObject *md, PyObject *key, PyObject **ret)
 
     md_finder_cleanup(&finder);
     Py_DECREF(identity);
-    return ret != NULL;
+    return *ret != NULL;
 fail:
     md_finder_cleanup(&finder);
     Py_XDECREF(identity);


### PR DESCRIPTION
It is a follow-up PR for #1187 that corrects retval of internal `md_get_all()` function.