### PR TITLE
Sync `reusable-cibuildwheel.yml` with upstream

### DIFF
--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -1,6 +1,9 @@
 ---
 
-name: Build wheel
+name: >-
+  ❌
+  [DO NOT CLICK]
+  Reusable cibuildwheel
 
 on:  # yamllint disable-line rule:truthy
   workflow_call:

--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -8,12 +8,15 @@ name: >-
 on:  # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
-      dists-artifact-name:
-        description: Workflow artifact name containing dists
-        required: true
-        type: string
       check-name:
         description: A custom name for the Checks API-reported status
+        required: false
+        type: string
+      dists-artifact-name:
+        description: >-
+          Workflow artifact name containing dists.
+          Defaults to "python-package-distributions".
+        default: python-package-distributions
         required: false
         type: string
       environment-variables:
@@ -35,8 +38,10 @@ on:  # yamllint disable-line rule:truthy
         required: false
         type: string
       source-tarball-name:
-        description: Sdist filename wildcard
-        required: true
+        default: >-
+          *.tar.gz
+        description: Sdist filename wildcard. Defaults to "*.tar.gz".
+        required: false
         type: string
       timeout-minutes:
         description: Deadline for the job to complete

--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -95,11 +95,11 @@ jobs:
             print(f'hash={hash}', file=outputs_file)
       shell: python
 
-    - name: Retrieve the project source from an sdist inside the GHA artifact
-      uses: re-actors/checkout-python-sdist@release/v2
+    - name: Download the source distribution
+      uses: actions/download-artifact@v4
       with:
-        source-tarball-name: ${{ inputs.source-tarball-name }}
-        workflow-artifact-name: ${{ inputs.dists-artifact-name }}
+        name: ${{ inputs.dists-artifact-name }}
+        path: dist/
 
     - name: Set up QEMU
       if: inputs.qemu
@@ -109,6 +109,9 @@ jobs:
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.0.0
+      with:
+        package-dir: >-  # not necessarily a dir, we pass an acceptable sdist
+          dist/${{ inputs.source-tarball-name }}
 
     - name: Upload built artifacts for testing and publishing
       uses: actions/upload-artifact@v4

--- a/CHANGES/1199.contrib.rst
+++ b/CHANGES/1199.contrib.rst
@@ -1,0 +1,2 @@
+When building wheels, the source distribution is now passed directly
+to the ``cibuildwheel`` invocation -- by :user:`webknjaz`.


### PR DESCRIPTION
## What do these changes do?

This patch includes setting input defaults for sdist-related fields and passing the sdist directly into `cibuildwheel`. It also normalizes the workflow name.

## Are there changes in behavior for the user?

Nope.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes