### PR TITLE
Fix setuptools deprecation warning about the license

### DIFF
--- a/CHANGES/1216.contrib.rst
+++ b/CHANGES/1216.contrib.rst
@@ -1,0 +1,1 @@
+Fixed ``setuptools`` deprecation warning about the license specification -- by :user:`asvetlov`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,15 +22,13 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Andrew Svetlov
 author_email = andrew.svetlov@gmail.com
-license = Apache 2
+license = Apache License 2.0
 license_files =
   LICENSE
 classifiers =
   Development Status :: 5 - Production/Stable
 
   Intended Audience :: Developers
-
-  License :: OSI Approved :: Apache Software License
 
   Programming Language :: Python
   Programming Language :: Python :: 3


### PR DESCRIPTION
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license