### PR TITLE
Fix pointer increment issue in _md_shrink causing memory corruption

### DIFF
--- a/CHANGES/1221.bugfix.rst
+++ b/CHANGES/1221.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed a memory corruption issue in the C implementation of ``_md_shrink()`` that could lead to segmentation faults and data loss when items were deleted from a ``MultiDict``. The issue was an edge case in the pointer arithmetic during the compaction phase -- by :user:`bdraco`.
+Fixed a memory corruption issue in the C implementation of ``_md_shrink()`` that could lead to segmentation faults and data loss when items were deleted from a :class:`~multidict.MultiDict`. The issue was an edge case in the pointer arithmetic during the compaction phase -- by :user:`bdraco`.

--- a/CHANGES/1221.bugfix.rst
+++ b/CHANGES/1221.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a memory corruption issue in the C implementation of ``_md_shrink()`` that could lead to segmentation faults and data loss when items were deleted from a ``MultiDict``. The issue was an edge case in the pointer arithmetic during the compaction phase -- by :user:`bdraco`.

--- a/CHANGES/1222.bugfix.rst
+++ b/CHANGES/1222.bugfix.rst
@@ -1,0 +1,1 @@
+1221.bugfix.rst

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -251,8 +251,9 @@ _md_shrink(MultiDictObject *md, bool update)
     for (Py_ssize_t i = 0; i < nentries; ++i, ++old_ep) {
         if (old_ep->identity != NULL) {
             if (new_ep != old_ep) {
-                *new_ep++ = *old_ep;
+                *new_ep = *old_ep;
             }
+            new_ep++;
         } else {
             newnentries -= 1;
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR addresses a subtle pointer arithmetic issue in the `_md_shrink` function that was part of the memory optimization improvements in PR #1200 (version 6.6.0). 

The `_md_shrink` function optimizes memory usage by compacting the internal hash table in-place when there are deleted entries. However, there was an edge case where the pointer increment logic didn't account for when `new_ep == old_ep` (which occurs for the first non-deleted entry after deletions).

This PR adjusts the pointer increment to happen for all non-deleted entries, ensuring the compaction process maintains data integrity throughout the operation.

## Are there changes in behavior for the user?

No API or functionality changes. This fix ensures the memory optimization continues to work as intended while maintaining data integrity. Users who experienced stability issues with 6.6.0 should see those resolved.

## Related issue number

Fixes #1221

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes