### PR TITLE
Fix format strings on 32bit platforms

### DIFF
--- a/CHANGELOG/1225.bugfix.rst
+++ b/CHANGELOG/1225.bugfix.rst
@@ -1,0 +1,1 @@
+1226.bugfix.rst

--- a/CHANGELOG/1226.bugfix.rst
+++ b/CHANGELOG/1226.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed format string compilation errors in debug builds on 32-bit platforms by using portable `%zd` format specifiers for `Py_ssize_t` values instead of `%ld`.
+Fixed format string compilation errors in debug builds on 32-bit platforms by using portable `%zd` format specifiers for `Py_ssize_t` values instead of `%ld` -- by :user:`bdraco`.

--- a/CHANGELOG/1226.bugfix.rst
+++ b/CHANGELOG/1226.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed format string compilation errors in debug builds on 32-bit platforms by using portable `%zd` format specifiers for `Py_ssize_t` values instead of `%ld`.

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -1963,7 +1963,7 @@ static inline int
 _md_dump(MultiDictObject *md)
 {
     htkeys_t *keys = md->keys;
-    printf("Dump %p [%ld from %ld usable %ld nentries %ld]\n",
+    printf("Dump %p [%zd from %zd usable %zd nentries %zd]\n",
            (void *)md,
            md->used,
            htkeys_nslots(keys),
@@ -1971,7 +1971,7 @@ _md_dump(MultiDictObject *md)
            keys->nentries);
     for (Py_ssize_t i = 0; i < htkeys_nslots(keys); i++) {
         Py_ssize_t ix = htkeys_get_index(keys, i);
-        printf("  %ld -> %ld\n", i, ix);
+        printf("  %zd -> %zd\n", i, ix);
     }
     printf("  --------\n");
     entry_t *entries = htkeys_entries(keys);
@@ -1980,9 +1980,9 @@ _md_dump(MultiDictObject *md)
         PyObject *identity = entry->identity;
 
         if (identity == NULL) {
-            printf("  %ld [deleted]\n", i);
+            printf("  %zd [deleted]\n", i);
         } else {
-            printf("  %ld h=%20ld, i=\'", i, entry->hash);
+            printf("  %zd h=%20zd, i=\'", i, entry->hash);
             PyObject_Print(entry->identity, stdout, Py_PRINT_RAW);
             printf("\', k=\'");
             PyObject_Print(entry->key, stdout, Py_PRINT_RAW);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR fixes format string specifiers in the `_md_dump` debug function that were causing compilation failures on 32-bit platforms. The issue was that `%ld` format specifiers were being used for `Py_ssize_t` values, which are `int` on 32-bit platforms but `long int` on 64-bit platforms. All `%ld` specifiers for `Py_ssize_t` values have been changed to `%zd`, which is the correct portable format specifier that automatically adjusts to the platform's size.

## Are there changes in behavior for the user?

No functional changes for end users. This fix only affects debug builds (when `MULTIDICT_DEBUG_BUILD` environment variable is set) and allows them to compile successfully on 32-bit platforms. The `_md_dump` function is only compiled in debug builds and is used for internal debugging purposes.

## Related issue number

Fixes #1225

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes

Note: No unit tests or documentation changes are needed for this fix as it only corrects format specifiers in a debug-only function that doesn't affect the public API or runtime behavior.