### PR TITLE
[DNM] 🧪 Instrument C-extensions to collect coverage

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -409,6 +409,12 @@ jobs:
         && runner.os == 'Linux'
       run: |
         gcovr --verbose
+    - name: See Gcovr leftovers [FIXME]
+      if: >-
+        !cancelled()
+        && runner.os == 'Linux'
+      run: |
+        find ~/ -type f -name '*.gcov.json.gz'
     - name: Produce markdown test summary from JUnit
       if: >-
         !cancelled()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -371,6 +371,13 @@ jobs:
         --cov-report xml
         --junitxml=.test-results/pytest/test.xml
         --${{ matrix.no-extensions == 'Y' && 'no-' || '' }}c-extensions
+    - name: Experimentally run Gcovr [FIXME]
+      if: >-
+        !cancelled()
+        && runner.os == 'Linux'
+      run: |
+        pip install gcovr
+        gcovr
     - name: Produce markdown test summary from JUnit
       if: >-
         !cancelled()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -408,7 +408,7 @@ jobs:
         !cancelled()
         && runner.os == 'Linux'
       run: |
-        gcovr
+        gcovr --verbose
     - name: Produce markdown test summary from JUnit
       if: >-
         !cancelled()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -390,7 +390,7 @@ jobs:
         !cancelled()
         && runner.os == 'Linux'
       run: |
-        gcovr
+        pip install gcovr
     - name: Experimentally run Gcovr [FIXME]
       if: >-
         !cancelled()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -358,8 +358,8 @@ jobs:
     - name: Pre-install ccache for gcov  [FIXME]
       if: steps.build_type.outputs.build_type == 'source'
       run: >-
-        apt update -y
-        && apt install -y ccache
+        sudo apt update -y
+        && sudo apt install -y ccache
       shell: bash
     - name: Self-install (from ${{ steps.build_type.outputs.build_type }})
       env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -371,12 +371,29 @@ jobs:
         --cov-report xml
         --junitxml=.test-results/pytest/test.xml
         --${{ matrix.no-extensions == 'Y' && 'no-' || '' }}c-extensions
+    - name: Experimentally find gcda/gcno [FIXME]
+      if: >-
+        !cancelled()
+        && runner.os == 'Linux'
+      run: |
+        find . -name '*.gc*'
+    - name: Experimentally find gcda/gcno in site-packages [FIXME]
+      if: >-
+        !cancelled()
+        && runner.os == 'Linux'
+      run: |
+        find "$(python -Ic 'import importlib.resources; print(str(importlib.resources.files("multidict")))')" -name '*.gc*'
+    - name: Experimentally install Gcovr [FIXME]
+      if: >-
+        !cancelled()
+        && runner.os == 'Linux'
+      run: |
+        gcovr
     - name: Experimentally run Gcovr [FIXME]
       if: >-
         !cancelled()
         && runner.os == 'Linux'
       run: |
-        pip install gcovr
         gcovr
     - name: Produce markdown test summary from JUnit
       if: >-

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -409,12 +409,18 @@ jobs:
         && runner.os == 'Linux'
       run: |
         gcovr --verbose
-    - name: See Gcovr leftovers [FIXME]
+    - name: See Gcovr leftovers at home [FIXME]
       if: >-
         !cancelled()
         && runner.os == 'Linux'
       run: |
         find ~/ -type f -name '*.gcov.json.gz'
+    - name: See Gcovr leftovers in workdir [FIXME]
+      if: >-
+        !cancelled()
+        && runner.os == 'Linux'
+      run: |
+        find ../.. -type f -name '*.gcov.json.gz'
     - name: Produce markdown test summary from JUnit
       if: >-
         !cancelled()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -355,6 +355,12 @@ jobs:
       run: >-
         make clean
       shell: bash
+    - name: Pre-install ccache for gcov  [FIXME]
+      if: steps.build_type.outputs.build_type == 'source'
+      run: >-
+        apt update -y
+        && apt install -y ccache
+      shell: bash
     - name: Self-install (from ${{ steps.build_type.outputs.build_type }})
       env:
         MULTIDICT_NO_EXTENSIONS: ${{ matrix.no-extensions }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -365,6 +365,8 @@ jobs:
           && '.'
           || steps.wheel-file.outputs.path
         }}'
+    - name: Experimental display of multidict files  [FIXME]
+      run: pip show multidict --files
     - name: Run unittests
       run: >-
         python -Im pytest tests -v

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -397,6 +397,12 @@ jobs:
         && runner.os == 'Linux'
       run: |
         pip install gcovr
+    - name: Experimentally make a coverage dir [FIXME]
+      if: >-
+        !cancelled()
+        && runner.os == 'Linux'
+      run: |
+        mkdir -pv coverage
     - name: Experimentally run Gcovr [FIXME]
       if: >-
         !cancelled()

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include .coveragerc
+include gcovr.cfg
 include pyproject.toml
 include pytest.ini
 include LICENSE

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,9 @@
+filter = multidict/
+
+html-details = coverage/index.html
+
+print-summary = yes
+
+search-path = multidict/__tracing-data__/
+
+xml = coverage/coverage.xml

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -4,6 +4,7 @@ html-details = coverage/index.html
 
 print-summary = yes
 
-search-path = multidict/__tracing-data__/
+search-path = multidict/__tracing-data__/multidict/_multidict.gcda
+search-path = multidict/__tracing-data__/multidict/_multidict.gcno
 
 xml = coverage/coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ enable = ["cpython-freethreading"]
 # Re-enable 32-bit builds (disabled by default in cibuildwheel 3.0)
 archs = ["auto", "auto32"]
 before-all = "yum install -y ccache libffi-devel || apk add --upgrade ccache libffi-dev || apt-get install ccache libffi-dev"
+
+[tool.cibuildwheel.linux.environment]
+MULTIDICT_DEBUG_BUILD = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,6 @@ enable = ["cpython-freethreading"]
 # Re-enable 32-bit builds (disabled by default in cibuildwheel 3.0)
 archs = ["auto", "auto32"]
 before-all = "yum install -y ccache libffi-devel || apk add --upgrade ccache libffi-dev || apt-get install ccache libffi-dev"
-test-requires = "gcovr -r requirements/pytest.txt"
-test-command = [
-  'pytest -m "not leaks" --no-cov {project}/tests',
-  'gcovr',
-]
 
 [tool.cibuildwheel.linux.environment]
 MULTIDICT_DEBUG_BUILD = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,4 @@ enable = ["cpython-freethreading"]
 [tool.cibuildwheel.linux]
 # Re-enable 32-bit builds (disabled by default in cibuildwheel 3.0)
 archs = ["auto", "auto32"]
-before-all = "yum install -y libffi-devel || apk add --upgrade libffi-dev || apt-get install libffi-dev"
+before-all = "yum install -y ccache libffi-devel || apk add --upgrade ccache libffi-dev || apt-get install ccache libffi-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ enable = ["cpython-freethreading"]
 # Re-enable 32-bit builds (disabled by default in cibuildwheel 3.0)
 archs = ["auto", "auto32"]
 before-all = "yum install -y ccache libffi-devel || apk add --upgrade ccache libffi-dev || apt-get install ccache libffi-dev"
+test-requires = "gcovr -r requirements/pytest.txt"
+test-command = [
+  'pytest -m "not leaks" --no-cov {project}/tests',
+  'gcovr',
+]
 
 [tool.cibuildwheel.linux.environment]
 MULTIDICT_DEBUG_BUILD = "1"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,9 @@ if platform.system() != "Windows" and False:
         ]
     )
 
-os.environ['CC'] = 'ccache gcc'
+if DEBUG_BUILD:
+    # https://gcovr.com/en/stable/cookbook.html#how-to-collect-coverage-for-c-extensions-in-python
+    os.environ['CC'] = 'ccache gcc'  # no distutils/setuptools equivalent
 
 extensions = [
     Extension(

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class TraceableBinaryExtensionCmd(build_ext):
         fullname = self.get_ext_fullname(ext.name)
         return fullname.split('.')
 
-    def _ext_tracing_file_for(self, ext) -> Path:
+    def _ext_tracing_file_for(self, ext) -> pathlib.Path:
         if not DEBUG_BUILD:
             raise LookupError
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
+import functools
 import json
 import os
 import pathlib
 import platform
 import sys
 
+from distutils import log
 from setuptools import Extension, setup
 
 NO_EXTENSIONS = bool(os.environ.get("MULTIDICT_NO_EXTENSIONS"))
@@ -62,56 +64,173 @@ from setuptools.command.build_ext import build_ext
 
 
 class TraceableBinaryExtensionCmd(build_ext):
-    def run(self):
-        super().run()
-        from distutils import log
-        log.info(f'{self.build_lib=}')
-        log.info(f'{self.build_temp=}')
+    def _ext_mod_path_for(self, ext) -> list[str]:
+        if not DEBUG_BUILD:
+            raise LookupError
+
+        fullname = self.get_ext_fullname(ext.name)
+        return fullname.split('.')
+
+    def _ext_tracing_file_for(self, ext) -> Path:
+        if not DEBUG_BUILD:
+            raise LookupError
+
+        modpath = self._ext_mod_path_for(ext)
+
+        # NOTE: `.o` file is unnecessary for gcovr to function
+        return pathlib.Path(*modpath).with_suffix('.gcno')
+
+    def _ext_tracing_data_dir_for(self, ext) -> tuple[str]:
+        if not DEBUG_BUILD:
+            raise LookupError
+
+        modpath = self._ext_mod_path_for(ext)
+        package = '.'.join(modpath[:-1])
+        build_py = self.get_finalized_command('build_py')  # ??
+        package_dir = pathlib.Path(build_py.get_package_dir(package))
+        return package_dir / '__tracing-data__'
+
+    @functools.cached_property
+    def _ext_tracing_data_dir_map(self) -> dict[str, tuple[str]]:
+        extensions_with_tracing_data = self.extensions if DEBUG_BUILD else ()
+
+        return {
+            ext.name: self._ext_tracing_data_dir_for(ext)
+            for ext in extensions_with_tracing_data
+        }
+
+    def _extra_ext_data_files_for(self, ext) -> tuple[str]:
+        if not DEBUG_BUILD:
+            return ()
+
+        tracing_data_in_package_dir = self._ext_tracing_data_dir_map[ext.name]
+        tracing_data_file_in_tmp_dir = self._ext_tracing_file_for(ext)
+        tracing_data_file_in_package_dir = tracing_data_in_package_dir / tracing_data_file_in_tmp_dir
+        build_meta_json_path = tracing_data_in_package_dir / 'build-metadata.json'
+
+        return (build_meta_json_path, tracing_data_file_in_package_dir)
+
+    @functools.cached_property
+    def _extra_ext_data_files_map(self) -> dict[str, tuple[str]]:
+        extensions_with_tracing_data = self.extensions if DEBUG_BUILD else ()
+
+        return {
+            ext.name: self._extra_ext_data_files_for(ext)
+            for ext in extensions_with_tracing_data
+        }
+
+    @functools.cached_property
+    def _extra_wheel_data_files(self) -> tuple[pathlib.Path]:
+        extensions_with_tracing_data = self.extensions if DEBUG_BUILD else ()
+
+        return tuple(
+            relative_path
+            for ext in extensions_with_tracing_data
+            for relative_path in self._extra_ext_data_files_map[ext.name]
+        )
+
+    def get_outputs(self) -> list[str]:
+        """Return absolute file paths to be included in the wheel."""
+        base_outputs = super().get_outputs()
+
+        build_dir_path = pathlib.Path(self.build_lib)
+        tracing_outputs = (
+            build_dir_path / relative_path
+            for relative_path in self._extra_wheel_data_files
+        )
+
+        # NOTE: Files returned here end up in wheels and then `site-packages/`.
+        # NOTE: Editable installs rely on the tracing files to be copied into
+        # NOTE: the source checkout, which is happening in `run()`.
+        return [*base_outputs, *tracing_outputs]
+
+    def build_extension(self, ext):
+        super().build_extension(ext)
 
         if not DEBUG_BUILD:
-            log.info('Not a debug build. Exiting early...')
+            log.info('Not a debug build. Skipping tracing data...')
             return
 
-        for ext in self.extensions:
-            fullname = self.get_ext_fullname(ext.name)
-            modpath = fullname.split('.')
-            package = '.'.join(modpath[:-1])
-            package_dir = pathlib.Path(self.build_lib)
-            tracing_data_file_in_tmp_dir = pathlib.Path(*modpath).with_suffix('.gcno')  # `.o` file is unnecessary for gcovr to function
-            tracing_data_in_package_dir = package_dir / '__tracing-data__'
+        log.info('Copying tracing data into the build directory')
+        tracing_data_file_in_tmp_dir = self._ext_tracing_file_for(ext)
+        tracing_data_in_package_dir = self._ext_tracing_data_dir_map[ext.name]
+        tracing_data_file_in_package_dir = tracing_data_in_package_dir / tracing_data_file_in_tmp_dir
 
-            tracing_data_file_in_tmp_dir_absolute = pathlib.Path(self.build_temp) / tracing_data_file_in_tmp_dir
-            tracing_data_file_in_package_dir = tracing_data_in_package_dir / tracing_data_file_in_tmp_dir
+        tracing_data_in_build_dir = pathlib.Path(self.build_lib) / tracing_data_in_package_dir
 
-            tracing_data_file_in_package_dir.parent.mkdir(exist_ok=True, parents=True)
-            (tracing_data_in_package_dir / '.gitignore').write_text('*\n')
+        tracing_data_file_in_build_dir_absolute = tracing_data_in_build_dir / tracing_data_file_in_tmp_dir
 
-            log.info(f'GCOV_PREFIX={tracing_data_in_package_dir !s}')
-            log.info(f'GCOV_PREFIX_STRIP={len(pathlib.Path(self.build_temp).parents) !s}')
-            build_meta_json_path = (tracing_data_in_package_dir / 'build-metadata.json')
-            build_meta_json_path.write_text(
-                json.dumps(
-                    {
-                        'GCOV_PREFIX': str(tracing_data_in_package_dir),
-                        'GCOV_PREFIX_STRIP': str(len(pathlib.Path(self.build_temp).parents)),
-                    },
-                ),
-                encoding='utf-8',
-            )
-            # TODO: PWD dir hack — https://maskray.me/blog/2023-04-25-compiler-output-files
-            # breakpoint()
+        tracing_data_file_in_build_dir_absolute.parent.mkdir(exist_ok=True, parents=True)
+        # NOTE: `gcc` writes `.gcno` files next to `.o` which is the temporary
+        # NOTE: directory for us (`build_temp`). This copies it over into the
+        # NOTE: regular build directory (`build_lib`) producing the layout we
+        # NOTE: expect in wheels / site-packages / source checkout. It's later
+        # NOTE: copied over to those places along with the shared libraries.
+        self.copy_file(
+            pathlib.Path(self.build_temp) / tracing_data_file_in_tmp_dir,
+            tracing_data_file_in_build_dir_absolute,
+            level=self.verbose,
+        )
+
+        # NOTE: `gcc` writes an absolute path to `.gcno` files into the shared
+        # NOTE: library at build time. It may point to an arbitrary temporary
+        # NOTE: directory that we don't care for. When pytest imports this
+        # NOTE: file, the C-extension attempts writing a `.gcda` file in the
+        # NOTE: same directory. We want it to be written in the source checkout
+        # NOTE: next to the tracing file. For this, we record information about
+        # NOTE: the desired location relative to the project root, bundle it
+        # NOTE: in the wheel and the tests will read from it, and set the
+        # NOTE: respective environment variables so the coverage data ends up
+        # NOTE: where we expect it to. `gcovr` will also work better with
+        # NOTE: predictable data locations.
+        # NOTE:
+        # NOTE: The contributors won't have to set the env vars manually
+        # NOTE: $ GCOV_PREFIX=multidict/__tracing-data__/ \
+        # NOTE:   GCOV_PREFIX_STRIP=2 \
+        # NOTE:     python -Im pytest
+        build_meta_path = tracing_data_in_build_dir / 'build-metadata.json'
+        tmp_path_length = len(pathlib.Path(self.build_temp).resolve().parents)
+        build_meta_path.write_text(
+            json.dumps(
+                {
+                    'GCOV_PREFIX': str(tracing_data_in_package_dir),
+                    'GCOV_PREFIX_STRIP': str(tmp_path_length),
+                },
+            ),
+            encoding='utf-8',
+        )
+
+    def run(self):
+        super().run()
+
+        if not self.inplace:
+            log.info('Not an editable install. Skipping tracing data...')
+
+        if not DEBUG_BUILD:
+            log.info('Not a debug build. Skipping tracing data...')
+            return
+
+        log.info(
+            'Editable install in debug mode. Copying tracing data in-tree...',
+        )
+
+        # NOTE: Editable installs usually expect data in-tree. This handles
+        # NOTE: the cases of `python setup.py build_ext --inplace` and
+        # NOTE: `pip install -e .`
+        # NOTE: Normal wheel builds include files returned by `get_outputs()`.
+
+        build_dir_path = pathlib.Path(self.build_lib)
+        for relative_path in self._extra_wheel_data_files:
+            relative_path.parent.mkdir(exist_ok=True, parents=True)
             self.copy_file(
-                tracing_data_file_in_tmp_dir_absolute,
-                tracing_data_file_in_package_dir,
+                build_dir_path / relative_path,
+                relative_path,
                 level=self.verbose,
             )
-        # GCOV_PREFIX=multidict/ GCOV_PREFIX_STRIP=4 some-venv/bin/python -Im pytest tests/test_istr.py
-        # GCOV_PREFIX_STRIP=2 some-venv/bin/python -Im pytest tests/test_istr.py
-        # GCOV_PREFIX=ext/ GCOV_PREFIX_STRIP=3 some-venv/bin/python -Im pytest tests/test_istr.py
-        # GCOV_PREFIX=__tracing-data__/ GCOV_PREFIX_STRIP=2 some-venv/bin/python -Im pytest tests/test_istr.py
-        # GCOV_PREFIX=multidict/__tracing-data__/ GCOV_PREFIX_STRIP=3 some-venv/bin/python -Im pytest
-        # GCOV_PREFIX=multidict/__tracing-data__/multidict/ GCOV_PREFIX_STRIP=3 some-venv/bin/python -Im pytest
-        # *FINAL*: GCOV_PREFIX=multidict/__tracing-data__/ GCOV_PREFIX_STRIP=2 some-venv/bin/python -Im pytest
+
+        for ext in self.extensions:
+            tracing_data_in_pkg_dir = self._ext_tracing_data_dir_map[ext.name]
+            (tracing_data_in_pkg_dir / '.gitignore').write_text('*\n')
 
 
 if not NO_EXTENSIONS:

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,7 @@ if DEBUG_BUILD:
         '-fprofile-abs-path',
     ])
 
-# LDFLAGS = ['-coverage'] if DEBUG_BUILD else []
 LDFLAGS = ['--coverage'] if DEBUG_BUILD else []
-
-# CFLAGS = ["-O2"]
-# CFLAGS.extend(['--coverage', '-g', '-O0'])
 
 if platform.system() != "Windows" and False:
     CFLAGS.extend(

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,25 @@ if sys.implementation.name != "cpython":
     NO_EXTENSIONS = True
 
 CFLAGS = ["-O0", "-g3", "-UNDEBUG"] if DEBUG_BUILD else ["-O3", "-DNDEBUG"]
+# https://gcc.gnu.org/onlinedocs/gcc/Gcov-Data-Files.html
+# `-ftest-coverage` -> `.gcno` is in the same place as `.o` -> `{self.build_temp}/multidict`
+# `-fprofile-dir` -> change the location of the `.gcda` file
+#
+# https://gcc.gnu.org/onlinedocs/gcc/Invoking-Gcov.html
+# `-fkeep-inline-functions`
+# `-fkeep-static-functions`
+# NOTE: Moving `_multidict.gcno` and `_multidict.o` under `multidict/` before running `pytest`, and `_multidict.gcda` after, worked. Prior to running gcovr.
+if DEBUG_BUILD:
+    CFLAGS.extend(['--coverage', '-coverage', '-fprofile-arcs', '-ftest-coverage', '-fPIC'])
+    # CFLAGS.extend(['-fprofile-dir=./multidict/'])
 
-if platform.system() != "Windows":
+LDFLAGS = ['--coverage', '-coverage', '-lgcov'] if DEBUG_BUILD else []
+
+# CFLAGS = ["-O2"]
+# CFLAGS.extend(['--coverage', '-g', '-O0'])
+# CFLAGS = ['-g']
+
+if platform.system() != "Windows" and False:
     CFLAGS.extend(
         [
             "-std=c11",
@@ -25,20 +42,81 @@ if platform.system() != "Windows":
         ]
     )
 
+os.environ['CC'] = 'ccache gcc'
+os.environ['CFLAGS'] = ' '.join(CFLAGS)
+# os.environ['LDFLAGS'] = ' '.join(LDFLAGS)
+
 extensions = [
     Extension(
         "multidict._multidict",
         ["multidict/_multidict.c"],
         extra_compile_args=CFLAGS,
+        # extra_link_args=LDFLAGS,
     ),
 ]
+
+
+from setuptools.command.build_ext import build_ext
+
+
+class TraceableBinaryExtensionCmd(build_ext):
+    # def initialize_options(self):  # ??
+    # def finalize_options(self):  # ??
+    #     super().finalize_options()
+    #     # self._pkg_dir = self.get_finalized_command('build_py').get_package_dir('multidict')
+    #     # self.build_temp = f'{self.build_lib}/{self._pkg_dir}/__debug-symbols__'
+    #     # self.build_temp = self.build_lib
+    #     # breakpoint()
+
+    def run(self):
+        super().run()
+        from distutils import log
+        log.info(f'{self.build_lib=}')
+        log.info(f'{self.build_temp=}')
+        # self.copy_file(f'{self.build_temp}/multidict/_multidict.o', f'multidict/_multidict.o', level=self.verbose)  # `.o` file seems unnecessary for gcovr to function
+
+        for ext in self.extensions:
+            fullname = self.get_ext_fullname(ext.name)
+            # breakpoint()
+            filename = self.get_ext_filename(fullname)
+            modpath = fullname.split('.')
+            package = '.'.join(modpath[:-1])
+            build_py = self.get_finalized_command('build_py')  # ??
+            package_dir = build_py.get_package_dir(package)
+            inplace_file = os.path.join(package_dir, os.path.basename(filename))
+            regular_file = os.path.join(self.build_lib, filename)
+            tracing_data_file_in_tmp_dir = os.path.join(*modpath) + '.gcno'
+            # f'{self.build_temp}/{package_dir}/'
+            tracing_data_in_tmp_dir = f'{self.build_temp}/{package_dir}/'
+            tracing_data_in_package_dir = f'{package_dir}/__tracing-data__/'
+            # breakpoint()
+
+            os.makedirs(os.path.join(tracing_data_in_package_dir, os.path.dirname(tracing_data_file_in_tmp_dir)), exist_ok=True)
+            with open(os.path.join(tracing_data_in_package_dir, '.gitignore'), 'w') as gitignore_fd:
+                gitignore_fd.writelines(('*', ))
+
+            self.copy_file(
+                # os.path.join(tracing_data_in_tmp_dir, '_multidict.gcno'),  # `.o` file is unnecessary for gcovr to function
+                os.path.join(self.build_temp, tracing_data_file_in_tmp_dir),  # `.o` file is unnecessary for gcovr to function
+                os.path.join(tracing_data_in_package_dir, tracing_data_file_in_tmp_dir),
+                level=self.verbose,
+            )
+        # GCOV_PREFIX=multidict/ GCOV_PREFIX_STRIP=4 some-venv/bin/python -Im pytest tests/test_istr.py
+        # GCOV_PREFIX_STRIP=2 some-venv/bin/python -Im pytest tests/test_istr.py
+        # GCOV_PREFIX=ext/ GCOV_PREFIX_STRIP=3 some-venv/bin/python -Im pytest tests/test_istr.py
+        # GCOV_PREFIX=__tracing-data__/ GCOV_PREFIX_STRIP=2 some-venv/bin/python -Im pytest tests/test_istr.py
+        # GCOV_PREFIX=multidict/__tracing-data__/ GCOV_PREFIX_STRIP=3 some-venv/bin/python -Im pytest
+        # *FINAL*: GCOV_PREFIX=multidict/__tracing-data__/multidict/ GCOV_PREFIX_STRIP=3 some-venv/bin/python -Im pytest
 
 
 if not NO_EXTENSIONS:
     print("*********************")
     print("* Accelerated build *")
     print("*********************")
-    setup(ext_modules=extensions)
+    setup(
+        cmdclass={'build_ext': TraceableBinaryExtensionCmd},
+        ext_modules=extensions,
+    )
 else:
     print("*********************")
     print("* Pure Python build *")

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,8 @@ CFLAGS = ["-O0", "-g3", "-UNDEBUG"] if DEBUG_BUILD else ["-O3", "-DNDEBUG"]
 # https://gcc.gnu.org/onlinedocs/gcc/Invoking-Gcov.html
 # `-fkeep-inline-functions`
 # `-fkeep-static-functions`
-# NOTE: Moving `_multidict.gcno` and `_multidict.o` under `multidict/` before running `pytest`, and `_multidict.gcda` after, worked. Prior to running gcovr.
 if DEBUG_BUILD:
     CFLAGS.extend(['--coverage', '-coverage', '-fprofile-arcs', '-ftest-coverage', '-fPIC'])
-    # CFLAGS.extend(['-fprofile-dir=./multidict/'])
 
 # CFLAGS = ["-O2"]
 # CFLAGS.extend(['--coverage', '-g', '-O0'])

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,22 @@ CFLAGS = ["-O0", "-g3", "-UNDEBUG"] if DEBUG_BUILD else ["-O3", "-DNDEBUG"]
 # https://gcc.gnu.org/onlinedocs/gcc/Invoking-Gcov.html
 # `-fkeep-inline-functions`
 # `-fkeep-static-functions`
+# `-fprofile-prefix-map=old=new`
+# `--coverage` is an alias for `-fprofile-arcs -ftest-coverage` when compiling and `-lgcov` when linking; `-coverage` seems to be its synonym.
+# `-fprofile-abs-path` makes `gcovr` more robust — https://gcovr.com/en/stable/guide/compiling.html#compiler-options
 if DEBUG_BUILD:
-    CFLAGS.extend(['--coverage', '-coverage', '-fprofile-arcs', '-ftest-coverage', '-fPIC'])
+    CFLAGS.extend([
+        '--coverage',
+        '-fkeep-inline-functions',
+        '-fkeep-static-functions',
+        '-fprofile-abs-path',
+    ])
 
-LDFLAGS = ['--coverage', '-coverage', '-lgcov'] if DEBUG_BUILD else []
+# LDFLAGS = ['-coverage'] if DEBUG_BUILD else []
+LDFLAGS = ['--coverage'] if DEBUG_BUILD else []
 
 # CFLAGS = ["-O2"]
 # CFLAGS.extend(['--coverage', '-g', '-O0'])
-# CFLAGS = ['-g']
 
 if platform.system() != "Windows" and False:
     CFLAGS.extend(

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ import sys
 from distutils import log
 from setuptools import Extension, setup
 
-DEBUG_BUILD = bool(os.environ.get("MULTIDICT_DEBUG_BUILD"))
 NO_EXTENSIONS = bool(os.environ.get("MULTIDICT_NO_EXTENSIONS"))
+DEBUG_BUILD = bool(os.environ.get("MULTIDICT_DEBUG_BUILD"))
 
 if sys.implementation.name != "cpython":
     NO_EXTENSIONS = True

--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,7 @@ class TraceableBinaryExtensionCmd(build_ext):
             fullname = self.get_ext_fullname(ext.name)
             modpath = fullname.split('.')
             package = '.'.join(modpath[:-1])
-            build_py = self.get_finalized_command('build_py')  # ??
-            package_dir = pathlib.Path(build_py.get_package_dir(package))
+            package_dir = pathlib.Path(self.build_lib)
             tracing_data_file_in_tmp_dir = pathlib.Path(*modpath).with_suffix('.gcno')  # `.o` file is unnecessary for gcovr to function
             tracing_data_in_package_dir = package_dir / '__tracing-data__'
 

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ if DEBUG_BUILD:
     CFLAGS.extend(['--coverage', '-coverage', '-fprofile-arcs', '-ftest-coverage', '-fPIC'])
     # CFLAGS.extend(['-fprofile-dir=./multidict/'])
 
-# LDFLAGS = ['--coverage', '-coverage', '-lgcov'] if DEBUG_BUILD else []
-
 # CFLAGS = ["-O2"]
 # CFLAGS.extend(['--coverage', '-g', '-O0'])
 # CFLAGS = ['-g']
@@ -48,14 +46,12 @@ if platform.system() != "Windows" and False:
 
 os.environ['CC'] = 'ccache gcc'
 os.environ['CFLAGS'] = ' '.join(CFLAGS)
-# os.environ['LDFLAGS'] = ' '.join(LDFLAGS)
 
 extensions = [
     Extension(
         "multidict._multidict",
         ["multidict/_multidict.c"],
         extra_compile_args=CFLAGS,
-        # extra_link_args=LDFLAGS,
     ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ CFLAGS = ["-O0", "-g3", "-UNDEBUG"] if DEBUG_BUILD else ["-O3", "-DNDEBUG"]
 if DEBUG_BUILD:
     CFLAGS.extend(['--coverage', '-coverage', '-fprofile-arcs', '-ftest-coverage', '-fPIC'])
 
+LDFLAGS = ['--coverage', '-coverage', '-lgcov'] if DEBUG_BUILD else []
+
 # CFLAGS = ["-O2"]
 # CFLAGS.extend(['--coverage', '-g', '-O0'])
 # CFLAGS = ['-g']
@@ -43,13 +45,13 @@ if platform.system() != "Windows" and False:
     )
 
 os.environ['CC'] = 'ccache gcc'
-os.environ['CFLAGS'] = ' '.join(CFLAGS)
 
 extensions = [
     Extension(
         "multidict._multidict",
         ["multidict/_multidict.c"],
         extra_compile_args=CFLAGS,
+        extra_link_args=LDFLAGS,
     ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ import sys
 from distutils import log
 from setuptools import Extension, setup
 
-NO_EXTENSIONS = bool(os.environ.get("MULTIDICT_NO_EXTENSIONS"))
 DEBUG_BUILD = bool(os.environ.get("MULTIDICT_DEBUG_BUILD"))
+NO_EXTENSIONS = bool(os.environ.get("MULTIDICT_NO_EXTENSIONS"))
 
 if sys.implementation.name != "cpython":
     NO_EXTENSIONS = True

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ class TraceableBinaryExtensionCmd(build_ext):
                 ),
                 encoding='utf-8',
             )
-            breakpoint()
+            # TODO: PWD dir hack — https://maskray.me/blog/2023-04-25-compiler-output-files
+            # breakpoint()
             self.copy_file(
                 tracing_data_file_in_tmp_dir_absolute,
                 tracing_data_file_in_package_dir,

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,10 @@ class TraceableBinaryExtensionCmd(build_ext):
         log.info(f'{self.build_lib=}')
         log.info(f'{self.build_temp=}')
 
+        if not DEBUG_BUILD:
+            log.info('Not a debug build. Exiting early...')
+            return
+
         for ext in self.extensions:
             fullname = self.get_ext_fullname(ext.name)
             modpath = fullname.split('.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,11 +81,17 @@ def _gcov_configuration() -> None:
     # NOTE: improve this if we start, to avoid data races. Also, should we
     # NOTE: integrate `tmp_path` instead of writing to `site-packages/`?
 
-    build_meta_json_path = (
-        importlib.resources.files('multidict')  # FIXME: read from `pyproject.toml`?
+    tracing_data_dir_path = (
+        # FIXME: read from `pyproject.toml`?
+        importlib.resources.files('multidict')
         / '__tracing-data__'
-        / 'build-metadata.json'
     )
+    if not tracing_data_dir_path.is_dir():
+        # NOTE: The C-extention was probably compiled without tracing or
+        # NOTE: packaging is borked.
+        return
+
+    build_meta_json_path = tracing_data_dir_path / 'build-metadata.json'
     gcov_env = json.loads(build_meta_json_path.read_text(encoding='utf-8'))
     os.environ.update(gcov_env)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import pickle
 from dataclasses import dataclass
 from functools import cached_property
 from importlib import import_module
+from pathlib import Path
+from shutil import copytree
 from types import ModuleType
 from typing import Callable, Type, Union
 
@@ -91,8 +93,16 @@ def _gcov_configuration() -> None:
         # NOTE: packaging is borked.
         return
 
+    project_root = Path(__file__).parent.parent.resolve()
+
     build_meta_json_path = tracing_data_dir_path / 'build-metadata.json'
     gcov_env = json.loads(build_meta_json_path.read_text(encoding='utf-8'))
+
+    in_project_tracing_data_dir_path = project_root / gcov_env['GCOV_PREFIX']
+    gcov_env['GCOV_PREFIX'] = str(in_project_tracing_data_dir_path)
+
+    copytree(tracing_data_dir_path, in_project_tracing_data_dir_path, dirs_exist_ok=True)
+
     os.environ.update(gcov_env)
 
 


### PR DESCRIPTION
## What do these changes do?

This patch sets up the infrastructure for collecting and reporting coverage for C-extensions. It includes updates to packaging, test runner and CI/CD.

> [!warning]
> **THE PATCH IS INCOMPLETE. THIS IS @webknjaz's PLAYGROUND FOR NOW. DO NOT MERGE!**
>
> *I've been able to generate coverage reports locally, with a series of manual commands. They still need to be integrated and cleaned up to fit well together.*

## Are there changes in behavior for the user?

This is a contributor-facing change, allowing them to expose gaps in coverage of C-extensions.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
