### PR TITLE
Pin cffi for <3.14 in tests to fix CI

### DIFF
--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,3 +1,4 @@
+cffi<2.0.0;python_version<"3.14"
 objgraph==3.6.2
 pytest==8.4.0
 pytest-codspeed==3.2.0


### PR DESCRIPTION
Same fix we had to do to get propcache builds working again
https://github.com/aio-libs/propcache/pull/148