### PR TITLE
Increase wheel build timeout to 25m

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -141,7 +141,7 @@ jobs:
       check-name: >-
         Build ${{ matrix.tag }} wheels on ${{ matrix.runner-vm-os }}
       runner-vm-os: ${{ matrix.runner-vm-os }}
-      timeout-minutes: 15
+      timeout-minutes: 25
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
       dists-artifact-name: ${{ needs.pre-setup.outputs.dists-artifact-name }}


### PR DESCRIPTION
We build so many versions and the free-threading as well now so the release failed
