### PR TITLE
Fix memory leak caused by identity when default value is inplace

### DIFF
--- a/CHANGES/1284.bugfix.rst
+++ b/CHANGES/1284.bugfix.rst
@@ -1,2 +1,2 @@
-Fixed slow memory leak caused by identity by adding ``Py_DECREF`` to identity value before leaving ``md_pop_one`` on success.
--- by :user:`Vizonex`
+Fixed slow memory leak caused by identity by adding ``Py_DECREF`` to identity value before leaving ``md_pop_one`` on success
+-- by :user:`Vizonex`.

--- a/CHANGES/1284.bugfix.rst
+++ b/CHANGES/1284.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed slow memory leak caused by identity by adding ``Py_DECREF`` to identity value before leaving ``md_pop_one`` on success.
+-- by :user:`Vizonex`

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -1019,7 +1019,7 @@ md_pop_one(MultiDictObject *md, PyObject *key, PyObject **ret)
             goto fail;
         }
     }
-
+    Py_DECREF(identity);
     ASSERT_CONSISTENT(md, false);
     return 0;
 fail:

--- a/tests/isolated/multidict_pop.py
+++ b/tests/isolated/multidict_pop.py
@@ -65,7 +65,9 @@ def _test_popone() -> None:
 
 # SEE: https://github.com/aio-libs/multidict/issues/1273
 def _test_pop_with_default() -> None:
-    result = MultiDict()
+    # XXX: mypy wants an annotation so the only
+    # thing we can do here is pass the headers along.
+    result = MultiDict(headers)
     for i in range(100_000):
         result.pop(f"missing_key_{i}", None)
     check_for_leak()

--- a/tests/isolated/multidict_pop.py
+++ b/tests/isolated/multidict_pop.py
@@ -61,6 +61,14 @@ def _test_popone() -> None:
                 result.popone(k)
         check_for_leak()
 
+# SEE: https://github.com/aio-libs/multidict/issues/1273
+def _test_pop_with_default() -> None:
+    for _ in range(10):
+        for _ in range(100):
+            result = MultiDict(headers)
+            for k in keys:
+                result.pop(k, None)
+        check_for_leak()
 
 def _test_del() -> None:
     for _ in range(10):
@@ -75,6 +83,7 @@ def _run_isolated_case() -> None:
     _test_pop()
     _test_popall()
     _test_popone()
+    _test_pop_with_default()
     _test_del()
 
 

--- a/tests/isolated/multidict_pop.py
+++ b/tests/isolated/multidict_pop.py
@@ -68,7 +68,7 @@ def _test_pop_with_default() -> None:
     # XXX: mypy wants an annotation so the only
     # thing we can do here is pass the headers along.
     result = MultiDict(headers)
-    for i in range(100_000):
+    for i in range(1_000_000):
         result.pop(f"missing_key_{i}", None)
     check_for_leak()
 

--- a/tests/isolated/multidict_pop.py
+++ b/tests/isolated/multidict_pop.py
@@ -62,6 +62,7 @@ def _test_popone() -> None:
                 result.popone(k)
         check_for_leak()
 
+
 # SEE: https://github.com/aio-libs/multidict/issues/1273
 def _test_pop_with_default() -> None:
     for _ in range(10):
@@ -70,6 +71,7 @@ def _test_pop_with_default() -> None:
             for k in keys:
                 result.pop(k, None)
         check_for_leak()
+
 
 def _test_del() -> None:
     for _ in range(10):

--- a/tests/isolated/multidict_pop.py
+++ b/tests/isolated/multidict_pop.py
@@ -64,12 +64,10 @@ def _test_popone() -> None:
 
 # SEE: https://github.com/aio-libs/multidict/issues/1273
 def _test_pop_with_default() -> None:
-    for _ in range(10):
-        for _ in range(100):
-            result = MultiDict(headers)
-            for k in keys:
-                result.pop(k, None)
-        check_for_leak()
+    result = MultiDict()
+    for i in range(100_000):
+        result.pop(f"missing_key_{i}", None)
+    check_for_leak()
 
 def _test_del() -> None:
     for _ in range(10):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This was reported a while ago without a reproducer to use until @rodrigobnogueira provided me some very detailed information about where the problem was and how to fix it. So I went ahead and added in something to ensure that the identity value is properly handled if or when the user has provided a default value to use.

## Are there changes in behavior for the user?

A Slow memory leak should be patched now.

## Related issue number

fixes #1273

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
