### PR TITLE
Use SPDX license id

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Andrew Svetlov
 author_email = andrew.svetlov@gmail.com
-license = Apache License 2.0
+license = Apache-2.0
 license_files =
   LICENSE
 classifiers =


### PR DESCRIPTION
Use SPDX license id so that tools can easily generate valid SPDX SBOMs.
