### PR TITLE
Fix missing space in ValueError message

### DIFF
--- a/CHANGES/1295.bugfix.rst
+++ b/CHANGES/1295.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a missing space in the :exc:`ValueError` message
+raised when constructing a multidict from a sequence
+-- by :user:`veeceey`.

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -831,7 +831,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 for pos, item in enumerate(arg):
                     if not len(item) == 2:
                         raise ValueError(
-                            f"multidict update sequence element #{pos}"
+                            f"multidict update sequence element #{pos} "
                             f"has length {len(item)}; 2 is required"
                         )
                     identity = identity_func(item[0])

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -294,7 +294,10 @@ class BaseMultiDictTest:
         self,
         cls: type[MutableMultiMapping[str]],
     ) -> None:
-        with pytest.raises(ValueError, match="multidict update sequence element"):
+        with pytest.raises(
+            ValueError,
+            match=r"^multidict update sequence element #0 has length 3; 2 is required$",
+        ):
             cls([(1, 2, 3)])  # type: ignore[call-arg]
 
     def test_keys_is_set_less(self, cls: type[MultiDict[str]]) -> None:


### PR DESCRIPTION
## Summary

Fix missing space in the `ValueError` message raised by `_parse_args()` -- the implicit string concatenation between the two f-strings was missing a trailing space, producing `"element #0has"` instead of `"element #0 has"`.

## Test plan

- Verified the corrected message output manually