### PR TITLE
Add __reversed__ support to keys, values, and items views

### DIFF
--- a/CHANGES/448.feature.rst
+++ b/CHANGES/448.feature.rst
@@ -1,0 +1,1 @@
+Added support for reversing keys, values, and items views via ``reversed()`` -- implements :issue:`448`.

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -101,6 +101,15 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 raise RuntimeError("Dictionary changed during iteration")
             yield self._md._key(e.key), e.value
 
+    def __reversed__(self) -> Iterator[tuple[str, _V]]:
+        return _Iter(len(self), self._iter_reversed(self._md._version))
+
+    def _iter_reversed(self, version: int) -> Iterator[tuple[str, _V]]:
+        for e in self._md._keys.iter_entries_reverse():
+            if version != self._md._version:
+                raise RuntimeError("Dictionary changed during iteration")
+            yield self._md._key(e.key), e.value
+
     @reprlib.recursive_repr()
     def __repr__(self) -> str:
         lst = []
@@ -272,6 +281,15 @@ class _ValuesView(_ViewBase[_V], ValuesView[_V]):
                 raise RuntimeError("Dictionary changed during iteration")
             yield e.value
 
+    def __reversed__(self) -> Iterator[_V]:
+        return _Iter(len(self), self._iter_reversed(self._md._version))
+
+    def _iter_reversed(self, version: int) -> Iterator[_V]:
+        for e in self._md._keys.iter_entries_reverse():
+            if version != self._md._version:
+                raise RuntimeError("Dictionary changed during iteration")
+            yield e.value
+
     @reprlib.recursive_repr()
     def __repr__(self) -> str:
         lst = []
@@ -297,6 +315,15 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
 
     def _iter(self, version: int) -> Iterator[str]:
         for e in self._md._keys.iter_entries():
+            if version != self._md._version:
+                raise RuntimeError("Dictionary changed during iteration")
+            yield self._md._key(e.key)
+
+    def __reversed__(self) -> Iterator[str]:
+        return _Iter(len(self), self._iter_reversed(self._md._version))
+
+    def _iter_reversed(self, version: int) -> Iterator[str]:
+        for e in self._md._keys.iter_entries_reverse():
             if version != self._md._version:
                 raise RuntimeError("Dictionary changed during iteration")
             yield self._md._key(e.key)
@@ -594,6 +621,9 @@ class _HtKeys(Generic[_V]):  # type: ignore[misc]
 
     def iter_entries(self) -> Iterator[_Entry[_V]]:
         return filter(None, self.entries)
+
+    def iter_entries_reverse(self) -> Iterator[_Entry[_V]]:
+        return filter(None, reversed(self.entries))
 
     def restore_hash(self, hash_: int) -> None:
         mask = self.mask


### PR DESCRIPTION
## Summary

Implements the `__reversed__` method for `_KeysView`, `_ValuesView`, and `_ItemsView`, allowing `reversed()` iteration over multidict views.

Since Python 3.8, built-in `dict` views support `reversed()`. This PR brings multidict views to parity.

Closes #448.

## Changes

- Added `iter_entries_reverse()` to `_HtKeys` for reverse entry traversal
- Added `__reversed__` and `_iter_reversed` to `_KeysView`, `_ValuesView`, and `_ItemsView`
- All view types (including CIMultiDict and proxies) support `reversed()`

## Example

```python
from multidict import MultiDict

md = MultiDict([('a', 1), ('b', 2), ('c', 3)])
list(reversed(md.keys()))   # ['c', 'b', 'a']
list(reversed(md.values())) # [3, 2, 1]
list(reversed(md.items()))  # [('c', 3), ('b', 2), ('a', 1)]
```