### PR TITLE
Switch to mirrors-clang-format and enable in pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,6 @@
 
 ci:
   autoupdate_schedule: quarterly
-  skip:
-  - clang-format
 
 repos:
 - repo: https://github.com/python-jsonschema/check-jsonschema.git
@@ -113,10 +111,11 @@ repos:
     types:
     - file
     - rst
-- repo: https://github.com/cpp-linter/cpp-linter-hooks
-  rev: v0.8.0
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v16.0.6
   hooks:
   - id: clang-format
+    types_or: [c, c++]
 - repo: https://github.com/pre-commit/mirrors-mypy.git
   rev: v1.15.0
   hooks:

--- a/CHANGES/1318.contrib.rst
+++ b/CHANGES/1318.contrib.rst
@@ -1,0 +1,2 @@
+Switched to ``mirrors-clang-format`` and enabled clang-format in pre-commit.ci
+-- by :user:`bdraco`.

--- a/CHANGES/1318.contrib.rst
+++ b/CHANGES/1318.contrib.rst
@@ -1,2 +1,2 @@
-Switched to ``mirrors-clang-format`` and enabled clang-format in pre-commit.ci
+Switched to ``mirrors-clang-format`` and enabled clang-format in ``pre-commit.ci``
 -- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Replaces the cpp-linter-hooks clang-format hook with mirrors-clang-format, which bundles the clang-format binary directly instead of downloading it at runtime. This fixes the hook failing on some platforms due to missing shared libraries and allows removing clang-format from the pre-commit.ci skip list so it actually runs in CI.

## Are there changes in behavior for the user?

No. clang-format will now run in pre-commit.ci where it was previously skipped.

## Related issue number

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes