### PR TITLE
add atomic global counter system

### DIFF
--- a/CHANGES/1328.bugfix.rst
+++ b/CHANGES/1328.bugfix.rst
@@ -1,2 +1,2 @@
-Fixed global counter system using an atomic variable.
+Fixed global counter system using an atomic variable
 -- by :user:`Vizonex`.

--- a/CHANGES/1328.bugfix.rst
+++ b/CHANGES/1328.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed global counter system using an atomic variable.
+-- by :user:`Vizonex`.

--- a/multidict/_multilib/state.h
+++ b/multidict/_multilib/state.h
@@ -134,7 +134,7 @@ NEXT_VERSION(mod_state *state)
      * itself */
     return atomic_fetch_add_explicit(
                &state->global_version, 1, memory_order_relaxed) +
-           1
+           1;
 }
 
 #ifdef __cplusplus

--- a/multidict/_multilib/state.h
+++ b/multidict/_multilib/state.h
@@ -28,7 +28,7 @@ typedef struct {
     PyObject *str_lower;
     PyObject *str_name;
 
-    uint64_t global_version;
+    _Atomic uint64_t global_version;
 } mod_state;
 
 static inline mod_state *
@@ -131,7 +131,7 @@ static inline uint64_t
 NEXT_VERSION(mod_state *state)
 {
     return atomic_fetch_add_explicit(
-        (_Atomic(uint64_t) *)&state->global_version, 1, memory_order_relaxed);
+        &state->global_version, 1, memory_order_relaxed);
 }
 
 #ifdef __cplusplus

--- a/multidict/_multilib/state.h
+++ b/multidict/_multilib/state.h
@@ -131,7 +131,8 @@ static inline uint64_t
 NEXT_VERSION(mod_state *state)
 {
     return atomic_fetch_add_explicit(
-        &state->global_version, 1, memory_order_relaxed) + 1;
+               &state->global_version, 1, memory_order_relaxed) +
+           1;
 }
 
 #ifdef __cplusplus

--- a/multidict/_multilib/state.h
+++ b/multidict/_multilib/state.h
@@ -131,7 +131,7 @@ static inline uint64_t
 NEXT_VERSION(mod_state *state)
 {
     return atomic_fetch_add_explicit(
-        &state->global_version, 1, memory_order_relaxed);
+        &state->global_version, 1, memory_order_relaxed) + 1;
 }
 
 #ifdef __cplusplus

--- a/multidict/_multilib/state.h
+++ b/multidict/_multilib/state.h
@@ -130,9 +130,10 @@ get_mod_state_by_def(PyObject *self)
 static inline uint64_t
 NEXT_VERSION(mod_state *state)
 {
-    return atomic_fetch_add_explicit(
-               &state->global_version, 1, memory_order_relaxed) +
-           1;
+    /* threads have the ability to screw with the global version,
+     * using an atomic variable ensures the global version is
+     * always accurate. */
+    return atomic_fetch_add(&state->global_version, 1) + 1;
 }
 
 #ifdef __cplusplus

--- a/multidict/_multilib/state.h
+++ b/multidict/_multilib/state.h
@@ -130,7 +130,8 @@ get_mod_state_by_def(PyObject *self)
 static inline uint64_t
 NEXT_VERSION(mod_state *state)
 {
-    return atomic_fetch_add_explicit((_Atomic(uint64_t)*)&state->global_version, 1, memory_order_relaxed);
+    return atomic_fetch_add_explicit(
+        (_Atomic(uint64_t) *)&state->global_version, 1, memory_order_relaxed);
 }
 
 #ifdef __cplusplus

--- a/multidict/_multilib/state.h
+++ b/multidict/_multilib/state.h
@@ -130,10 +130,8 @@ get_mod_state_by_def(PyObject *self)
 static inline uint64_t
 NEXT_VERSION(mod_state *state)
 {
-    /* threads have the ability to screw with the global version,
-     * using an atomic variable ensures the global version is
-     * always accurate. */
-    return atomic_fetch_add(&state->global_version, 1) + 1;
+    /* relaxed is fine here as we only care about the atomicity of the RMW itself */
+    return atomic_fetch_add_explicit(&state->global_version, 1, memory_order_relaxed) + 1
 }
 
 #ifdef __cplusplus

--- a/multidict/_multilib/state.h
+++ b/multidict/_multilib/state.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#include <stdatomic.h>
+
 /* State of the _multidict module */
 typedef struct {
     PyTypeObject *IStrType;
@@ -128,7 +130,7 @@ get_mod_state_by_def(PyObject *self)
 static inline uint64_t
 NEXT_VERSION(mod_state *state)
 {
-    return ++state->global_version;
+    return atomic_fetch_add_explicit((_Atomic(uint64_t)*)&state->global_version, 1, memory_order_relaxed);
 }
 
 #ifdef __cplusplus

--- a/multidict/_multilib/state.h
+++ b/multidict/_multilib/state.h
@@ -130,8 +130,11 @@ get_mod_state_by_def(PyObject *self)
 static inline uint64_t
 NEXT_VERSION(mod_state *state)
 {
-    /* relaxed is fine here as we only care about the atomicity of the RMW itself */
-    return atomic_fetch_add_explicit(&state->global_version, 1, memory_order_relaxed) + 1
+    /* relaxed is fine here as we only care about the atomicity of the RMW
+     * itself */
+    return atomic_fetch_add_explicit(
+               &state->global_version, 1, memory_order_relaxed) +
+           1
 }
 
 #ifdef __cplusplus

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,13 @@ if platform.system() != "Windows":
             "-Werror",
         ]
     )
+else:
+    CFLAGS.extend(
+        [
+            "/std:c11",
+            "/experimental:c11atomics",
+        ]
+    )
 
 extensions = [
     Extension(

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ extensions = [
     Extension(
         "multidict._multidict",
         ["multidict/_multidict.c"],
+        extra_compile_args=[],
     ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import os
-import platform
 import sys
 
 from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 
 NO_EXTENSIONS = bool(os.environ.get("MULTIDICT_NO_EXTENSIONS"))
 DEBUG_BUILD = bool(os.environ.get("MULTIDICT_DEBUG_BUILD"))
@@ -10,33 +10,41 @@ DEBUG_BUILD = bool(os.environ.get("MULTIDICT_DEBUG_BUILD"))
 if sys.implementation.name != "cpython":
     NO_EXTENSIONS = True
 
-CFLAGS = ["-O0", "-g3", "-UNDEBUG"] if DEBUG_BUILD else ["-O3", "-DNDEBUG"]
+BASE_CFLAGS = ["O0", "g3", "UNDEBUG"] if DEBUG_BUILD else ["O3", "DNDEBUG"]
 
-if platform.system() != "Windows":
-    CFLAGS.extend(
-        [
-            "-std=c11",
-            "-Wall",
-            "-Wsign-compare",
-            "-Wconversion",
-            "-fno-strict-aliasing",
-            "-Wno-conversion",
-            "-Werror",
-        ]
-    )
-else:
-    CFLAGS.extend(
-        [
-            "/std:c11",
-            "/experimental:c11atomics",
-        ]
-    )
+UNIX_CFLAGS = [
+    "-std=c11",
+    "-Wall",
+    "-Wsign-compare",
+    "-Wconversion",
+    "-fno-strict-aliasing",
+    "-Wno-conversion",
+    "-Werror",
+]
+
+MSVC_CFLAGS = ["/std:c11", "/experimental:c11atomics"]
+
+
+class BuildExt(build_ext):
+    def build_extensions(self):
+        if self.compiler.compiler_type == "msvc":
+            for ext in self.extensions:
+                ext.extra_compile_args.extend(MSVC_CFLAGS)
+                for flag in BASE_CFLAGS:
+                    # XXX: MSVC Doesn't have a /O3 flag only O2 is possible...
+                    ext.extra_compile_args.append("/O2" if flag == "O3" else f"/{flag}")
+        else:
+            for ext in self.extensions:
+                ext.extra_compile_args.extend(UNIX_CFLAGS)
+                for flag in BASE_CFLAGS:
+                    ext.extra_compile_args.append(f"-{flag}")
+        super().build_extensions()
+
 
 extensions = [
     Extension(
         "multidict._multidict",
         ["multidict/_multidict.c"],
-        extra_compile_args=CFLAGS,
     ),
 ]
 
@@ -45,7 +53,7 @@ if not NO_EXTENSIONS:
     print("*********************")
     print("* Accelerated build *")
     print("*********************")
-    setup(ext_modules=extensions)
+    setup(ext_modules=extensions, cmdclass={"build_ext": BuildExt})
 else:
     print("*********************")
     print("* Pure Python build *")

--- a/tests/isolated/multidict_global_counter.py
+++ b/tests/isolated/multidict_global_counter.py
@@ -4,8 +4,7 @@ from multidict import MultiDict
 import sysconfig
 
 FREETHREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
-if not FREETHREADED:
-    raise SystemExit(0)
+
 
 md: MultiDict[int] = MultiDict()
 N, M = 3, 100
@@ -17,7 +16,7 @@ def worker(tid: int) -> None:
         md[f"k{tid}_{i}"] = i
 
 
-if __name__ == "__main__":
+if (__name__ == "__main__") and FREETHREADED:
     threads = [threading.Thread(target=worker, args=(tid,)) for tid in range(N)]
     for t in threads:
         t.start()

--- a/tests/isolated/multidict_global_counter.py
+++ b/tests/isolated/multidict_global_counter.py
@@ -1,7 +1,8 @@
+import sysconfig
 import threading
+
 import multidict
 from multidict import MultiDict
-import sysconfig
 
 FREETHREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 

--- a/tests/isolated/multidict_global_counter.py
+++ b/tests/isolated/multidict_global_counter.py
@@ -7,12 +7,12 @@ FREETHREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 if not FREETHREADED:
     raise SystemExit(0)
 
-md = MultiDict()
+md: MultiDict[int] = MultiDict()
 N, M = 3, 100
-baseline = multidict.getversion(md)
+baseline = multidict.getversion(md)  # type: ignore[arg-type]
 
 
-def worker(tid):
+def worker(tid: int) -> None:
     for i in range(M):
         md[f"k{tid}_{i}"] = i
 
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     for t in threads:
         t.join()
 
-    observed = multidict.getversion(md) - baseline
+    observed = multidict.getversion(md) - baseline  # type: ignore[arg-type]
     expected = N * M
     assert expected == observed, (
         f"expected delta: {expected}"

--- a/tests/isolated/multidict_global_counter.py
+++ b/tests/isolated/multidict_global_counter.py
@@ -1,0 +1,33 @@
+import threading
+import multidict
+from multidict import MultiDict
+import sysconfig
+
+FREETHREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+if not FREETHREADED:
+    raise SystemExit(0)
+
+md = MultiDict()
+N, M = 3, 100
+baseline = multidict.getversion(md)
+
+
+def worker(tid):
+    for i in range(M):
+        md[f"k{tid}_{i}"] = i
+
+
+if __name__ == "__main__":
+    threads = [threading.Thread(target=worker, args=(tid,)) for tid in range(N)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    observed = multidict.getversion(md) - baseline
+    expected = N * M
+    assert expected == observed, (
+        f"expected delta: {expected}"
+        f"   observed: {observed}   "
+        f"lost: {expected - observed}"
+    )

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -18,6 +18,7 @@ IS_PYPY = platform.python_implementation() == "PyPy"
         "multidict_type_leak.py",
         "multidict_type_leak_items_values.py",
         "multidict_pop.py",
+        "multidict_global_counter.py",
     ),
 )
 @pytest.mark.leaks


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes are based off @devdanzin's second fuzzer for freethreading mode which noted using a global atomic counter system instead of a normal `uint64_t` value I did however make one small nitpick/change from that original design to just recast `(_Atomic(uint64_t)*)&state->global_version` which was not in the original suggestion mainly due to my code editor misbehaving on me when I would go to set it into the actual structure. 

## Are there changes in behavior for the user?
Just bug fixes.

## Related issue number
#1321 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
