### PR TITLE
Enable ruff to perform syntax upgrades

### DIFF
--- a/CHANGES/1325.feature.rst
+++ b/CHANGES/1325.feature.rst
@@ -1,0 +1,2 @@
+Enable automatic upgrades from ruff after each python version that is dropped
+-- by :user:`Vizonex`.

--- a/benchmarks/becnhmark.py
+++ b/benchmarks/becnhmark.py
@@ -99,10 +99,7 @@ add = dct.add
 
 
 def benchmark_name(name, ctx, prefix=None, use_prefix=False):
-    if use_prefix:
-        return "%s%s" % (prefix % ctx, name)
-
-    return name
+    return f"{prefix % ctx}{name}" if use_prefix else name
 
 
 def add_impl_option(cmd, args):

--- a/benchmarks/istr.py
+++ b/benchmarks/istr.py
@@ -33,10 +33,7 @@ istr(val)
 
 
 def benchmark_name(name, ctx, prefix=None, use_prefix=False):
-    if use_prefix:
-        return "%s%s" % (prefix % ctx, name)
-
-    return name
+    return f"{prefix % ctx}{name}" if use_prefix else name
 
 
 def add_impl_option(cmd, args):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # multidict documentation build configuration file, created by
 # sphinx-quickstart on Wed Mar  5 12:35:35 2014.
@@ -382,7 +381,7 @@ def _replace_missing_aiohttp_hdrs_reference(
     env: BuildEnvironment,
     node: pending_xref,
     contnode: literal,
-) -> "reference | None":
+) -> reference | None:
     if (node.get("refdomain"), node.get("reftype")) != ("py", "mod"):
         return None
 

--- a/multidict/_abc.py
+++ b/multidict/_abc.py
@@ -22,7 +22,7 @@ class SupportsIKeys(Protocol[_V_co]):
     def __getitem__(self, key: istr, /) -> _V_co: ...
 
 
-MDArg = Union[SupportsKeys[_V], SupportsIKeys[_V], Iterable[tuple[str, _V]], None]
+MDArg = SupportsKeys[_V] | SupportsIKeys[_V] | Iterable[tuple[str, _V]] | None
 
 
 class MultiMapping(Mapping[str, _V_co]):

--- a/multidict/_abc.py
+++ b/multidict/_abc.py
@@ -29,17 +29,17 @@ class MultiMapping(Mapping[str, _V_co]):
     @overload
     def getall(self, key: str) -> list[_V_co]: ...
     @overload
-    def getall(self, key: str, default: _T) -> Union[list[_V_co], _T]: ...
+    def getall(self, key: str, default: _T) -> list[_V_co] | _T: ...
     @abc.abstractmethod
-    def getall(self, key: str, default: _T = ...) -> Union[list[_V_co], _T]:
+    def getall(self, key: str, default: _T = ...) -> list[_V_co] | _T:
         """Return all values for key."""
 
     @overload
     def getone(self, key: str) -> _V_co: ...
     @overload
-    def getone(self, key: str, default: _T) -> Union[_V_co, _T]: ...
+    def getone(self, key: str, default: _T) -> _V_co | _T: ...
     @abc.abstractmethod
-    def getone(self, key: str, default: _T = ...) -> Union[_V_co, _T]:
+    def getone(self, key: str, default: _T = ...) -> _V_co | _T:
         """Return first value for key."""
 
 
@@ -59,15 +59,15 @@ class MutableMultiMapping(MultiMapping[_V], MutableMapping[str, _V]):
     @overload
     def popone(self, key: str) -> _V: ...
     @overload
-    def popone(self, key: str, default: _T) -> Union[_V, _T]: ...
+    def popone(self, key: str, default: _T) -> _V | _T: ...
     @abc.abstractmethod
-    def popone(self, key: str, default: _T = ...) -> Union[_V, _T]:
+    def popone(self, key: str, default: _T = ...) -> _V | _T:
         """Remove specified key and return the corresponding value."""
 
     @overload
     def popall(self, key: str) -> list[_V]: ...
     @overload
-    def popall(self, key: str, default: _T) -> Union[list[_V], _T]: ...
+    def popall(self, key: str, default: _T) -> list[_V] | _T: ...
     @abc.abstractmethod
-    def popall(self, key: str, default: _T = ...) -> Union[list[_V], _T]:
+    def popall(self, key: str, default: _T = ...) -> list[_V] | _T:
         """Remove all occurrences of key and return the list of corresponding values."""

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -18,9 +18,7 @@ from typing import (
     ClassVar,
     Generic,
     NoReturn,
-    Optional,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -1129,7 +1127,7 @@ class MultiDictProxy(_CSMixin, MultiMapping[_V]):
 
     _md: MultiDict[_V]
 
-    def __init__(self, arg: Union[MultiDict[_V], "MultiDictProxy[_V]"]):
+    def __init__(self, arg: MultiDict[_V] | "MultiDictProxy[_V]"):
         if not isinstance(arg, (MultiDict, MultiDictProxy)):
             raise TypeError(
                 f"ctor requires MultiDict or MultiDictProxy instance, not {type(arg)}"

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -1127,7 +1127,7 @@ class MultiDictProxy(_CSMixin, MultiMapping[_V]):
 
     _md: MultiDict[_V]
 
-    def __init__(self, arg: MultiDict[_V] | "MultiDictProxy[_V]"):
+    def __init__(self, arg: "MultiDict[_V] | MultiDictProxy[_V]"):
         if not isinstance(arg, (MultiDict, MultiDictProxy)):
             raise TypeError(
                 f"ctor requires MultiDict or MultiDictProxy instance, not {type(arg)}"

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -37,7 +37,7 @@ class istr(str):
     """Case insensitive str."""
 
     __is_istr__ = True
-    __istr_identity__: Optional[str] = None
+    __istr_identity__: str | None = None
 
 
 _V = TypeVar("_V")
@@ -109,9 +109,7 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
         body = ", ".join(lst)
         return f"<{self.__class__.__name__}({body})>"
 
-    def _parse_item(
-        self, arg: Union[tuple[str, _V], _T]
-    ) -> Optional[tuple[int, str, str, _V]]:
+    def _parse_item(self, arg: tuple[str, _V] | _T) -> tuple[int, str, str, _V] | None:
         if not isinstance(arg, tuple):
             return None
         if len(arg) != 2:
@@ -167,14 +165,14 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                     break
         return ret
 
-    def __or__(self, other: Iterable[_T]) -> set[Union[tuple[str, _V], _T]]:
-        ret: set[Union[tuple[str, _V], _T]] = set(self)
+    def __or__(self, other: Iterable[_T]) -> set[tuple[str, _V] | _T]:
+        ret: set[tuple[str, _V] | _T] = set(self)
         try:
             it = iter(other)
         except TypeError:
             return NotImplemented
         for arg in it:
-            item: Optional[tuple[int, str, str, _V]] = self._parse_item(arg)
+            item: tuple[int, str, str, _V] | None = self._parse_item(arg)
             if item is None:
                 ret.add(arg)
                 continue
@@ -186,9 +184,9 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 ret.add(arg)
         return ret
 
-    def __ror__(self, other: Iterable[_T]) -> set[Union[tuple[str, _V], _T]]:
+    def __ror__(self, other: Iterable[_T]) -> set[tuple[str, _V] | _T]:
         try:
-            ret: set[Union[tuple[str, _V], _T]] = set(other)
+            ret: set[tuple[str, _V] | _T] = set(other)
         except TypeError:
             return NotImplemented
         tmp = self._tmp_set(ret)
@@ -198,8 +196,8 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 ret.add((e.key, e.value))
         return ret
 
-    def __sub__(self, other: Iterable[_T]) -> set[Union[tuple[str, _V], _T]]:
-        ret: set[Union[tuple[str, _V], _T]] = set()
+    def __sub__(self, other: Iterable[_T]) -> set[tuple[str, _V] | _T]:
+        ret: set[tuple[str, _V] | _T] = set()
         try:
             it = iter(other)
         except TypeError:
@@ -232,12 +230,12 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 ret.add(arg)
         return ret
 
-    def __xor__(self, other: Iterable[_T]) -> set[Union[tuple[str, _V], _T]]:
+    def __xor__(self, other: Iterable[_T]) -> set[tuple[str, _V] | _T]:
         try:
             rgt = set(other)
         except TypeError:
             return NotImplemented
-        ret: set[Union[tuple[str, _V], _T]] = self - rgt
+        ret: set[tuple[str, _V] | _T] = self - rgt
         ret |= rgt - self
         return ret
 
@@ -338,8 +336,8 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
                 ret.add(key)
         return cast(set[_T], ret)
 
-    def __or__(self, other: Iterable[_T]) -> set[Union[str, _T]]:
-        ret: set[Union[str, _T]] = set(self)
+    def __or__(self, other: Iterable[_T]) -> set[str | _T]:
+        ret: set[str | _T] = set(self)
         try:
             it = iter(other)
         except TypeError:
@@ -352,9 +350,9 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
                 ret.add(key)
         return ret
 
-    def __ror__(self, other: Iterable[_T]) -> set[Union[str, _T]]:
+    def __ror__(self, other: Iterable[_T]) -> set[str | _T]:
         try:
-            ret: set[Union[str, _T]] = set(other)
+            ret: set[str | _T] = set(other)
         except TypeError:
             return NotImplemented
 
@@ -399,12 +397,12 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
                 ret.discard(key)  # type: ignore[arg-type]
         return ret
 
-    def __xor__(self, other: Iterable[_T]) -> set[Union[str, _T]]:
+    def __xor__(self, other: Iterable[_T]) -> set[str | _T]:
         try:
             rgt = set(other)
         except TypeError:
             return NotImplemented
-        ret: set[Union[str, _T]] = self - rgt  # type: ignore[assignment]
+        ret: set[str | _T] = self - rgt  # type: ignore[assignment]
         ret |= rgt - self
         return ret
 
@@ -482,7 +480,7 @@ class _HtKeys(Generic[_V]):  # type: ignore[misc]
     usable: int
 
     indices: array  # type: ignore[type-arg] # TODO(PY312): array[int]
-    entries: list[Optional[_Entry[_V]]]
+    entries: list[_Entry[_V] | None]
 
     @functools.cached_property
     def nslots(self) -> int:
@@ -502,7 +500,7 @@ class _HtKeys(Generic[_V]):  # type: ignore[misc]
             )
 
     @classmethod
-    def new(cls, log2_size: int, entries: list[Optional[_Entry[_V]]]) -> Self:
+    def new(cls, log2_size: int, entries: list[_Entry[_V] | None]) -> Self:
         size = 1 << log2_size
         usable = (size << 1) // 3
         if log2_size < 10:
@@ -649,10 +647,8 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     @overload
     def getall(self, key: str) -> list[_V]: ...
     @overload
-    def getall(self, key: str, default: _T) -> Union[list[_V], _T]: ...
-    def getall(
-        self, key: str, default: Union[_T, _SENTINEL] = sentinel
-    ) -> Union[list[_V], _T]:
+    def getall(self, key: str, default: _T) -> list[_V] | _T: ...
+    def getall(self, key: str, default: _T | _SENTINEL = sentinel) -> list[_V] | _T:
         """Return a list of all values matching the key."""
         identity = self._identity(key)
         hash_ = hash(identity)
@@ -676,10 +672,8 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     @overload
     def getone(self, key: str) -> _V: ...
     @overload
-    def getone(self, key: str, default: _T) -> Union[_V, _T]: ...
-    def getone(
-        self, key: str, default: Union[_T, _SENTINEL] = sentinel
-    ) -> Union[_V, _T]:
+    def getone(self, key: str, default: _T) -> _V | _T: ...
+    def getone(self, key: str, default: _T | _SENTINEL = sentinel) -> _V | _T:
         """Get first value matching the key.
 
         Raises KeyError if the key is not found and no default is provided.
@@ -699,10 +693,10 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         return self.getone(key)
 
     @overload
-    def get(self, key: str, /) -> Union[_V, None]: ...
+    def get(self, key: str, /) -> _V | None: ...
     @overload
-    def get(self, key: str, /, default: _T) -> Union[_V, _T]: ...
-    def get(self, key: str, default: Union[_T, None] = None) -> Union[_V, _T, None]:
+    def get(self, key: str, /, default: _T) -> _V | _T: ...
+    def get(self, key: str, default: _T | None = None) -> _V | _T | None:
         """Get first value matching the key.
 
         If the key is not found, returns the default (or None if no default is provided)
@@ -799,7 +793,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         self,
         arg: MDArg[_V],
         kwargs: Mapping[str, _V],
-    ) -> Iterator[Union[int, _Entry[_V]]]:
+    ) -> Iterator[int | _Entry[_V]]:
         identity_func = self._identity
         if arg:
             if isinstance(arg, MultiDictProxy):
@@ -905,11 +899,11 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
 
     @overload
     def setdefault(
-        self: "MultiDict[Union[_T, None]]", key: str, default: None = None
-    ) -> Union[_T, None]: ...
+        self: "MultiDict[_T | None]", key: str, default: None = None
+    ) -> _T | None: ...
     @overload
     def setdefault(self, key: str, default: _V) -> _V: ...
-    def setdefault(self, key: str, default: Union[_V, None] = None) -> Union[_V, None]:  # type: ignore[misc]
+    def setdefault(self, key: str, default: _V | None = None) -> _V | None:  # type: ignore[misc]
         """Return value for key, set value to default if key is not present."""
         identity = self._identity(key)
         hash_ = hash(identity)
@@ -922,10 +916,8 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     @overload
     def popone(self, key: str) -> _V: ...
     @overload
-    def popone(self, key: str, default: _T) -> Union[_V, _T]: ...
-    def popone(
-        self, key: str, default: Union[_T, _SENTINEL] = sentinel
-    ) -> Union[_V, _T]:
+    def popone(self, key: str, default: _T) -> _V | _T: ...
+    def popone(self, key: str, default: _T | _SENTINEL = sentinel) -> _V | _T:
         """Remove specified key and return the corresponding value.
 
         If key is not found, d is returned if given, otherwise
@@ -952,10 +944,8 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     @overload
     def popall(self, key: str) -> list[_V]: ...
     @overload
-    def popall(self, key: str, default: _T) -> Union[list[_V], _T]: ...
-    def popall(
-        self, key: str, default: Union[_T, _SENTINEL] = sentinel
-    ) -> Union[list[_V], _T]:
+    def popall(self, key: str, default: _T) -> list[_V] | _T: ...
+    def popall(self, key: str, default: _T | _SENTINEL = sentinel) -> list[_V] | _T:
         """Remove all occurrences of key and return the list of corresponding
         values.
 
@@ -1155,10 +1145,8 @@ class MultiDictProxy(_CSMixin, MultiMapping[_V]):
     @overload
     def getall(self, key: str) -> list[_V]: ...
     @overload
-    def getall(self, key: str, default: _T) -> Union[list[_V], _T]: ...
-    def getall(
-        self, key: str, default: Union[_T, _SENTINEL] = sentinel
-    ) -> Union[list[_V], _T]:
+    def getall(self, key: str, default: _T) -> list[_V] | _T: ...
+    def getall(self, key: str, default: _T | _SENTINEL = sentinel) -> list[_V] | _T:
         """Return a list of all values matching the key."""
         if default is not sentinel:
             return self._md.getall(key, default)
@@ -1168,10 +1156,8 @@ class MultiDictProxy(_CSMixin, MultiMapping[_V]):
     @overload
     def getone(self, key: str) -> _V: ...
     @overload
-    def getone(self, key: str, default: _T) -> Union[_V, _T]: ...
-    def getone(
-        self, key: str, default: Union[_T, _SENTINEL] = sentinel
-    ) -> Union[_V, _T]:
+    def getone(self, key: str, default: _T) -> _V | _T: ...
+    def getone(self, key: str, default: _T | _SENTINEL = sentinel) -> _V | _T:
         """Get first value matching the key.
 
         Raises KeyError if the key is not found and no default is provided.
@@ -1187,10 +1173,10 @@ class MultiDictProxy(_CSMixin, MultiMapping[_V]):
         return self.getone(key)
 
     @overload
-    def get(self, key: str, /) -> Union[_V, None]: ...
+    def get(self, key: str, /) -> _V | None: ...
     @overload
-    def get(self, key: str, /, default: _T) -> Union[_V, _T]: ...
-    def get(self, key: str, default: Union[_T, None] = None) -> Union[_V, _T, None]:
+    def get(self, key: str, /, default: _T) -> _V | _T: ...
+    def get(self, key: str, default: _T | None = None) -> _V | _T | None:
         """Get first value matching the key.
 
         If the key is not found, returns the default (or None if no default is provided)
@@ -1234,7 +1220,7 @@ class MultiDictProxy(_CSMixin, MultiMapping[_V]):
 class CIMultiDictProxy(_CIMixin, MultiDictProxy[_V]):
     """Read-only proxy for CIMultiDict instance."""
 
-    def __init__(self, arg: Union[MultiDict[_V], MultiDictProxy[_V]]):
+    def __init__(self, arg: MultiDict[_V] | MultiDictProxy[_V]):
         if not isinstance(arg, (CIMultiDict, CIMultiDictProxy)):
             raise TypeError(
                 "ctor requires CIMultiDict or CIMultiDictProxy instance"
@@ -1248,7 +1234,7 @@ class CIMultiDictProxy(_CIMixin, MultiDictProxy[_V]):
         return CIMultiDict(self._md)
 
 
-def getversion(md: Union[MultiDict[object], MultiDictProxy[object]]) -> int:
+def getversion(md: MultiDict[object] | MultiDictProxy[object]) -> int:
     if isinstance(md, MultiDictProxy):
         md = md._md
     elif not isinstance(md, MultiDict):

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -667,7 +667,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
             return res
         if not res and default is not sentinel:
             return default
-        raise KeyError("Key not found: %r" % key)
+        raise KeyError(f"Key not found: {key!r}")
 
     @overload
     def getone(self, key: str) -> _V: ...
@@ -685,7 +685,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 return e.value
         if default is not sentinel:
             return default
-        raise KeyError("Key not found: %r" % key)
+        raise KeyError(f"Key not found: {key!r}")
 
     # Mapping interface #
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 target-version = "py310"
 
+[tool.ruff.lint]
+select = ["UP"]
+
 [tool.cibuildwheel]
 test-requires = "-r requirements/pytest.txt"
 test-command = 'pytest -m "not leaks" --no-cov {project}/tests'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from functools import cached_property
 from importlib import import_module
 from types import ModuleType
-from typing import Callable, Type, Union
+from typing import Type, Union
+from collections.abc import Callable
 
 import pytest
 
@@ -90,7 +91,7 @@ def any_multidict_class_name(request: pytest.FixtureRequest) -> str:
 def any_multidict_class(
     any_multidict_class_name: str,
     multidict_module: ModuleType,
-) -> Type[MutableMultiMapping[str]]:
+) -> type[MutableMultiMapping[str]]:
     """Return a class object of a mutable multidict implementation."""
     return getattr(multidict_module, any_multidict_class_name)  # type: ignore[no-any-return]
 
@@ -98,7 +99,7 @@ def any_multidict_class(
 @pytest.fixture(scope="session")
 def case_sensitive_multidict_class(
     multidict_module: ModuleType,
-) -> Type[MultiDict[str]]:
+) -> type[MultiDict[str]]:
     """Return a case-sensitive mutable multidict class."""
     return multidict_module.MultiDict  # type: ignore[no-any-return]
 
@@ -106,13 +107,13 @@ def case_sensitive_multidict_class(
 @pytest.fixture(scope="session")
 def case_insensitive_multidict_class(
     multidict_module: ModuleType,
-) -> Type[CIMultiDict[str]]:
+) -> type[CIMultiDict[str]]:
     """Return a case-insensitive mutable multidict class."""
     return multidict_module.CIMultiDict  # type: ignore[no-any-return]
 
 
 @pytest.fixture(scope="session")
-def case_insensitive_str_class(multidict_module: ModuleType) -> Type[str]:
+def case_insensitive_str_class(multidict_module: ModuleType) -> type[str]:
     """Return a case-insensitive string class."""
     return multidict_module.istr  # type: ignore[no-any-return]
 
@@ -127,7 +128,7 @@ def any_multidict_proxy_class_name(any_multidict_class_name: str) -> str:
 def any_multidict_proxy_class(
     any_multidict_proxy_class_name: str,
     multidict_module: ModuleType,
-) -> Type[MultiMapping[str]]:
+) -> type[MultiMapping[str]]:
     """Return an immutable multidict implementation class object."""
     return getattr(multidict_module, any_multidict_proxy_class_name)  # type: ignore[no-any-return]
 
@@ -135,7 +136,7 @@ def any_multidict_proxy_class(
 @pytest.fixture(scope="session")
 def case_sensitive_multidict_proxy_class(
     multidict_module: ModuleType,
-) -> Type[MutableMultiMapping[str]]:
+) -> type[MutableMultiMapping[str]]:
     """Return a case-sensitive immutable multidict class."""
     return multidict_module.MultiDictProxy  # type: ignore[no-any-return]
 
@@ -143,7 +144,7 @@ def case_sensitive_multidict_proxy_class(
 @pytest.fixture(scope="session")
 def case_insensitive_multidict_proxy_class(
     multidict_module: ModuleType,
-) -> Type[MutableMultiMapping[str]]:
+) -> type[MutableMultiMapping[str]]:
     """Return a case-insensitive immutable multidict class."""
     return multidict_module.CIMultiDictProxy  # type: ignore[no-any-return]
 
@@ -151,7 +152,7 @@ def case_insensitive_multidict_proxy_class(
 @pytest.fixture(scope="session")
 def multidict_getversion_callable(
     multidict_module: ModuleType,
-) -> Callable[[Union[MultiDict[object], MultiDictProxy[object]]], int]:
+) -> Callable[[MultiDict[object] | MultiDictProxy[object]], int]:
     """Return a ``getversion()`` function for current implementation."""
     return multidict_module.getversion  # type: ignore[no-any-return]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from functools import cached_property
 from importlib import import_module
 from types import ModuleType
-from typing import Type, Union
 from collections.abc import Callable
 
 import pytest

--- a/tests/gen_pickles.py
+++ b/tests/gen_pickles.py
@@ -1,12 +1,11 @@
 import pickle
 from importlib import import_module
 from pathlib import Path
-from typing import Union
 
 from multidict import CIMultiDict, MultiDict, istr
 
 TESTS_DIR = Path(__file__).parent.resolve()
-_MD_Classes = Union[type[MultiDict[int]], type[CIMultiDict[int]]]
+_MD_Classes = type[MultiDict[int]] | type[CIMultiDict[int]]
 
 
 def write(tag: str, cls: _MD_Classes, proto: int) -> None:

--- a/tests/test_circular_imports.py
+++ b/tests/test_circular_imports.py
@@ -18,7 +18,7 @@ import sys
 from itertools import chain
 from pathlib import Path
 from types import ModuleType
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,10 +1,9 @@
 import copy
-from typing import Union
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 
-_MD_Classes = Union[type[MultiDict[int]], type[CIMultiDict[int]]]
-_MDP_Classes = Union[type[MultiDictProxy[int]], type[CIMultiDictProxy[int]]]
+_MD_Classes = type[MultiDict[int]] | type[CIMultiDict[int]]
+_MDP_Classes = type[MultiDictProxy[int]] | type[CIMultiDictProxy[int]]
 
 
 def test_copy(any_multidict_class: _MD_Classes) -> None:

--- a/tests/test_istr.py
+++ b/tests/test_istr.py
@@ -1,6 +1,5 @@
 import gc
 import sys
-from typing import Type
 from collections.abc import Callable
 
 import pytest

--- a/tests/test_istr.py
+++ b/tests/test_istr.py
@@ -1,54 +1,55 @@
 import gc
 import sys
-from typing import Callable, Type
+from typing import Type
+from collections.abc import Callable
 
 import pytest
 
 IMPLEMENTATION = getattr(sys, "implementation")  # to suppress mypy error
 
 
-def test_ctor(case_insensitive_str_class: Type[str]) -> None:
+def test_ctor(case_insensitive_str_class: type[str]) -> None:
     s = case_insensitive_str_class()
     assert "" == s
 
 
-def test_ctor_str(case_insensitive_str_class: Type[str]) -> None:
+def test_ctor_str(case_insensitive_str_class: type[str]) -> None:
     s = case_insensitive_str_class("aBcD")
     assert "aBcD" == s
 
 
-def test_ctor_istr(case_insensitive_str_class: Type[str]) -> None:
+def test_ctor_istr(case_insensitive_str_class: type[str]) -> None:
     s = case_insensitive_str_class("A")
     s2 = case_insensitive_str_class(s)
     assert "A" == s
     assert s == s2
 
 
-def test_ctor_buffer(case_insensitive_str_class: Type[str]) -> None:
+def test_ctor_buffer(case_insensitive_str_class: type[str]) -> None:
     s = case_insensitive_str_class(b"aBc")
     assert "b'aBc'" == s
 
 
-def test_ctor_repr(case_insensitive_str_class: Type[str]) -> None:
+def test_ctor_repr(case_insensitive_str_class: type[str]) -> None:
     s = case_insensitive_str_class(None)
     assert "None" == s
 
 
-def test_str(case_insensitive_str_class: Type[str]) -> None:
+def test_str(case_insensitive_str_class: type[str]) -> None:
     s = case_insensitive_str_class("aBcD")
     s1 = str(s)
     assert s1 == "aBcD"
     assert type(s1) is str
 
 
-def test_eq(case_insensitive_str_class: Type[str]) -> None:
+def test_eq(case_insensitive_str_class: type[str]) -> None:
     s1 = "Abc"
     s2 = case_insensitive_str_class(s1)
     assert s1 == s2
 
 
 @pytest.fixture
-def create_istrs(case_insensitive_str_class: Type[str]) -> Callable[[], None]:
+def create_istrs(case_insensitive_str_class: type[str]) -> Callable[[], None]:
     """Make a callable populating memory with a few ``istr`` objects."""
 
     def _create_strs() -> None:
@@ -64,7 +65,7 @@ def create_istrs(case_insensitive_str_class: Type[str]) -> Callable[[], None]:
     reason="PyPy has different GC implementation",
 )
 def test_leak(
-    create_istrs: Callable[[], None], case_insensitive_str_class: Type[str]
+    create_istrs: Callable[[], None], case_insensitive_str_class: type[str]
 ) -> None:
     gc.collect()
     for _ in range(10000):

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -28,7 +28,6 @@ def test_leak(script: str) -> None:
 
     subprocess.run(
         [sys.executable, "-u", "-m", "coverage", "run", str(leak_test_script)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=True,
     )

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -8,7 +8,7 @@ import weakref
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator, KeysView, Mapping
 from types import ModuleType
-from typing import TypeVar, Union, cast
+from typing import TypeVar, cast
 
 import pytest
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -47,10 +47,7 @@ def chained_callable(
             value = element(value)
 
         return cast(
-            Union[
-                MultiMapping[Union[int, str]],
-                MutableMultiMapping[Union[int, str]],
-            ],
+            MultiMapping[int | str] | MutableMultiMapping[int | str],
             value,
         )
 
@@ -82,7 +79,7 @@ def test_exposed_names(any_multidict_class_name: str) -> None:
     indirect=["cls"],
 )
 def test__iter__types(
-    cls: type[MultiDict[Union[str, int]]],
+    cls: type[MultiDict[str | int]],
     key_cls: type[str],
 ) -> None:
     d = cls([("key", "one"), ("key2", "two"), ("key", 3)])
@@ -136,7 +133,7 @@ class BaseMultiDictTest:
     def test_instantiate__from_arg0(
         self,
         cls: type[MultiDict[str]],
-        arg0: Union[list[tuple[str, str]], dict[str, str]],
+        arg0: list[tuple[str, str]] | dict[str, str],
     ) -> None:
         d = cls(arg0)
 
@@ -159,7 +156,7 @@ class BaseMultiDictTest:
         assert sorted(d.items()) == [("key", "value1"), ("key2", "value2")]
 
     def test_instantiate__from_generator(
-        self, cls: Union[type[MultiDict[int]], type[CIMultiDict[int]]]
+        self, cls: type[MultiDict[int]] | type[CIMultiDict[int]]
     ) -> None:
         d = cls((str(i), i) for i in range(2))
 
@@ -212,20 +209,14 @@ class BaseMultiDictTest:
 
     def test__iter__(
         self,
-        cls: Union[
-            type[MultiDict[Union[str, int]]],
-            type[CIMultiDict[Union[str, int]]],
-        ],
+        cls: type[MultiDict[str | int]] | type[CIMultiDict[str | int]],
     ) -> None:
         d = cls([("key", "one"), ("key2", "two"), ("key", 3)])
         assert list(d) == ["key", "key2", "key"]
 
     def test__contains(
         self,
-        cls: Union[
-            type[MultiDict[Union[str, int]]],
-            type[CIMultiDict[Union[str, int]]],
-        ],
+        cls: type[MultiDict[str | int]] | type[CIMultiDict[str | int]],
     ) -> None:
         d = cls([("key", "one"), ("key2", "two"), ("key", 3)])
 
@@ -239,10 +230,7 @@ class BaseMultiDictTest:
 
     def test_keys__contains(
         self,
-        cls: Union[
-            type[MultiDict[Union[str, int]]],
-            type[CIMultiDict[Union[str, int]]],
-        ],
+        cls: type[MultiDict[str | int]] | type[CIMultiDict[str | int]],
     ) -> None:
         d = cls([("key", "one"), ("key2", "two"), ("key", 3)])
 
@@ -256,10 +244,7 @@ class BaseMultiDictTest:
 
     def test_values__contains(
         self,
-        cls: Union[
-            type[MultiDict[Union[str, int]]],
-            type[CIMultiDict[Union[str, int]]],
-        ],
+        cls: type[MultiDict[str | int]] | type[CIMultiDict[str | int]],
     ) -> None:
         d = cls([("key", "one"), ("key", "two"), ("key", 3)])
 
@@ -273,10 +258,7 @@ class BaseMultiDictTest:
 
     def test_items__contains(
         self,
-        cls: Union[
-            type[MultiDict[Union[str, int]]],
-            type[CIMultiDict[Union[str, int]]],
-        ],
+        cls: type[MultiDict[str | int]] | type[CIMultiDict[str | int]],
     ) -> None:
         d = cls([("key", "one"), ("key", "two"), ("key", 3)])
 
@@ -482,7 +464,7 @@ class BaseMultiDictTest:
         assert d1 != d2
 
     def test_eq_bad_mapping_len(
-        self, cls: Union[type[MultiDict[int]], type[CIMultiDict[int]]]
+        self, cls: type[MultiDict[int]] | type[CIMultiDict[int]]
     ) -> None:
         class BadMapping(Mapping[str, int]):
             def __getitem__(self, key: str) -> int:
@@ -501,7 +483,7 @@ class BaseMultiDictTest:
 
     def test_eq_bad_mapping_getitem(
         self,
-        cls: Union[type[MultiDict[int]], type[CIMultiDict[int]]],
+        cls: type[MultiDict[int]] | type[CIMultiDict[int]],
     ) -> None:
         class BadMapping(Mapping[str, int]):
             def __getitem__(self, key: str) -> int:
@@ -690,7 +672,7 @@ class BaseMultiDictTest:
 
     def test_iter_length_hint_keys(
         self,
-        cls: Union[type[MultiDict[int]], type[CIMultiDict[int]]],
+        cls: type[MultiDict[int]] | type[CIMultiDict[int]],
     ) -> None:
         md = cls(a=1, b=2)
         it = iter(md.keys())
@@ -698,7 +680,7 @@ class BaseMultiDictTest:
 
     def test_iter_length_hint_items(
         self,
-        cls: Union[type[MultiDict[int]], type[CIMultiDict[int]]],
+        cls: type[MultiDict[int]] | type[CIMultiDict[int]],
     ) -> None:
         md = cls(a=1, b=2)
         it = iter(md.items())
@@ -706,7 +688,7 @@ class BaseMultiDictTest:
 
     def test_iter_length_hint_values(
         self,
-        cls: Union[type[MultiDict[int]], type[CIMultiDict[int]]],
+        cls: type[MultiDict[int]] | type[CIMultiDict[int]],
     ) -> None:
         md = cls(a=1, b=2)
         it = iter(md.values())
@@ -714,7 +696,7 @@ class BaseMultiDictTest:
 
     def test_ctor_list_arg_and_kwds(
         self,
-        cls: Union[type[MultiDict[int]], type[CIMultiDict[int]]],
+        cls: type[MultiDict[int]] | type[CIMultiDict[int]],
     ) -> None:
         arg = [("a", 1)]
         obj = cls(arg, b=2)
@@ -723,7 +705,7 @@ class BaseMultiDictTest:
 
     def test_ctor_tuple_arg_and_kwds(
         self,
-        cls: Union[type[MultiDict[int]], type[CIMultiDict[int]]],
+        cls: type[MultiDict[int]] | type[CIMultiDict[int]],
     ) -> None:
         arg = (("a", 1),)
         obj = cls(arg, b=2)
@@ -732,7 +714,7 @@ class BaseMultiDictTest:
 
     def test_ctor_deque_arg_and_kwds(
         self,
-        cls: Union[type[MultiDict[int]], type[CIMultiDict[int]]],
+        cls: type[MultiDict[int]] | type[CIMultiDict[int]],
     ) -> None:
         arg = deque([("a", 1)])
         obj = cls(arg, b=2)
@@ -792,10 +774,10 @@ class TestMultiDict(BaseMultiDictTest):
 
     def test_preserve_stable_ordering(
         self,
-        cls: type[MultiDict[Union[str, int]]],
+        cls: type[MultiDict[str | int]],
     ) -> None:
         d = cls([("a", 1), ("b", "2"), ("a", 3)])
-        s = "&".join("{}={}".format(k, v) for k, v in d.items())
+        s = "&".join(f"{k}={v}" for k, v in d.items())
 
         assert s == "a=1&b=2&a=3"
 

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -741,11 +741,11 @@ class TestMultiDict(BaseMultiDictTest):
         d = cls()
         _cls = type(d)
 
-        assert str(d) == "<%s()>" % _cls.__name__
+        assert str(d) == f"<{_cls.__name__}()>"
 
         d = cls([("key", "one"), ("key", "two")])
 
-        assert str(d) == "<%s('key': 'one', 'key': 'two')>" % _cls.__name__
+        assert str(d) == f"<{_cls.__name__}('key': 'one', 'key': 'two')>"
 
     def test__repr___recursive(
         self, any_multidict_class: type[MultiDict[object]]
@@ -756,7 +756,7 @@ class TestMultiDict(BaseMultiDictTest):
         d = any_multidict_class()
         d["key"] = d
 
-        assert str(d) == "<%s('key': ...)>" % _cls.__name__
+        assert str(d) == f"<{_cls.__name__}('key': ...)>"
 
     def test_getall(self, cls: type[MultiDict[str]]) -> None:
         d = cls([("key", "value1")], key="value2")
@@ -868,7 +868,7 @@ class TestCIMultiDict(BaseMultiDictTest):
         d = cls([("KEY", "value1")], key="value2")
         _cls = type(d)
 
-        expected = "<%s('KEY': 'value1', 'key': 'value2')>" % _cls.__name__
+        expected = f"<{_cls.__name__}('KEY': 'value1', 'key': 'value2')>"
         assert str(d) == expected
 
     def test_items__repr__(self, cls: type[CIMultiDict[str]]) -> None:

--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -1,7 +1,5 @@
 """codspeed benchmarks for multidict."""
 
-from typing import Dict, Type, Union
-
 from pytest_codspeed import BenchmarkFixture
 
 from multidict import (

--- a/tests/test_multidict_benchmarks.py
+++ b/tests/test_multidict_benchmarks.py
@@ -19,7 +19,7 @@ _SENTINEL = object()
 
 
 def test_multidict_insert_str(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class()
     items = [str(i) for i in range(100)]
@@ -32,7 +32,7 @@ def test_multidict_insert_str(
 
 def test_cimultidict_insert_istr(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class()
@@ -45,7 +45,7 @@ def test_cimultidict_insert_istr(
 
 
 def test_multidict_add_str(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     base_md = any_multidict_class()
     items = [str(i) for i in range(100)]
@@ -60,7 +60,7 @@ def test_multidict_add_str(
 
 def test_cimultidict_add_istr(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     base_md = case_insensitive_multidict_class()
@@ -75,7 +75,7 @@ def test_cimultidict_add_istr(
 
 
 def test_multidict_pop_str(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md_base = any_multidict_class((str(i), str(i)) for i in range(200))
     items = [str(i) for i in range(50, 150)]
@@ -89,7 +89,7 @@ def test_multidict_pop_str(
 
 def test_cimultidict_pop_istr(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md_base = case_insensitive_multidict_class(
@@ -106,7 +106,7 @@ def test_cimultidict_pop_istr(
 
 
 def test_multidict_popitem_str(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md_base = any_multidict_class((str(i), str(i)) for i in range(100))
 
@@ -118,7 +118,7 @@ def test_multidict_popitem_str(
 
 
 def test_multidict_clear_str(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class((str(i), str(i)) for i in range(100))
 
@@ -128,7 +128,7 @@ def test_multidict_clear_str(
 
 
 def test_multidict_update_str(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class((str(i), str(i)) for i in range(150))
     items = {str(i): str(i) for i in range(100, 200)}
@@ -140,14 +140,14 @@ def test_multidict_update_str(
 
 def test_cimultidict_update_istr(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class(
         (case_insensitive_str_class(i), case_insensitive_str_class(i))
         for i in range(150)
     )
-    items: Dict[Union[str, istr], istr] = {
+    items: dict[str | istr, istr] = {
         case_insensitive_str_class(i): case_insensitive_str_class(i)
         for i in range(100, 200)
     }
@@ -158,7 +158,7 @@ def test_cimultidict_update_istr(
 
 
 def test_multidict_update_str_with_kwargs(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class((str(i), str(i)) for i in range(150))
     items = {str(i): str(i) for i in range(100, 200)}
@@ -171,14 +171,14 @@ def test_multidict_update_str_with_kwargs(
 
 def test_cimultidict_update_istr_with_kwargs(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class(
         (case_insensitive_str_class(i), case_insensitive_str_class(i))
         for i in range(150)
     )
-    items: Dict[Union[str, istr], istr] = {
+    items: dict[str | istr, istr] = {
         case_insensitive_str_class(i): case_insensitive_str_class(i)
         for i in range(100, 200)
     }
@@ -190,7 +190,7 @@ def test_cimultidict_update_istr_with_kwargs(
 
 
 def test_multidict_extend_str(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     base_md = any_multidict_class((str(i), str(i)) for i in range(100))
     items = {str(i): str(i) for i in range(200)}
@@ -204,7 +204,7 @@ def test_multidict_extend_str(
 
 def test_cimultidict_extend_istr(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     base_md = case_insensitive_multidict_class(
@@ -223,7 +223,7 @@ def test_cimultidict_extend_istr(
 
 
 def test_multidict_extend_str_with_kwargs(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     base_md = any_multidict_class((str(i), str(i)) for i in range(100))
     items = {str(i): str(i) for i in range(200)}
@@ -238,7 +238,7 @@ def test_multidict_extend_str_with_kwargs(
 
 def test_cimultidict_extend_istr_with_kwargs(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     base_md = case_insensitive_multidict_class(
@@ -258,7 +258,7 @@ def test_cimultidict_extend_istr_with_kwargs(
 
 
 def test_multidict_delitem_str(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md_base = any_multidict_class((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
@@ -272,7 +272,7 @@ def test_multidict_delitem_str(
 
 def test_cimultidict_delitem_istr(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md_base = case_insensitive_multidict_class(
@@ -289,7 +289,7 @@ def test_cimultidict_delitem_istr(
 
 
 def test_multidict_getall_str_hit(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class(
         (f"key{j}", str(f"{i}-{j}")) for i in range(100) for j in range(10)
@@ -304,7 +304,7 @@ def test_multidict_getall_str_hit(
 
 
 def test_multidict_getall_str_miss(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class(
         (f"key{j}", str(f"{i}-{j}")) for i in range(100) for j in range(10)
@@ -320,7 +320,7 @@ def test_multidict_getall_str_miss(
 
 def test_cimultidict_getall_istr_hit(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class(
@@ -339,7 +339,7 @@ def test_cimultidict_getall_istr_hit(
 
 def test_cimultidict_getall_istr_miss(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class(
@@ -357,7 +357,7 @@ def test_cimultidict_getall_istr_miss(
 
 
 def test_multidict_fetch(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
@@ -370,7 +370,7 @@ def test_multidict_fetch(
 
 def test_cimultidict_fetch_istr(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class(
@@ -386,7 +386,7 @@ def test_cimultidict_fetch_istr(
 
 
 def test_multidict_get_hit(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
@@ -398,7 +398,7 @@ def test_multidict_get_hit(
 
 
 def test_multidict_get_miss(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100, 200)]
@@ -411,7 +411,7 @@ def test_multidict_get_miss(
 
 def test_cimultidict_get_istr_hit(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class(
@@ -428,7 +428,7 @@ def test_cimultidict_get_istr_hit(
 
 def test_cimultidict_get_istr_miss(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class(
@@ -444,7 +444,7 @@ def test_cimultidict_get_istr_miss(
 
 
 def test_multidict_get_hit_with_default(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md = any_multidict_class((str(i), str(i)) for i in range(100))
     items = [str(i) for i in range(100)]
@@ -457,7 +457,7 @@ def test_multidict_get_hit_with_default(
 
 def test_cimultidict_get_istr_hit_with_default(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class(
@@ -474,7 +474,7 @@ def test_cimultidict_get_istr_hit_with_default(
 
 def test_cimultidict_get_istr_with_default_miss(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     md = case_insensitive_multidict_class(
@@ -490,7 +490,7 @@ def test_cimultidict_get_istr_with_default_miss(
 
 
 def test_multidict_repr(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     items = [str(i) for i in range(100)]
     md = any_multidict_class([(i, i) for i in items])
@@ -501,7 +501,7 @@ def test_multidict_repr(
 
 
 def test_create_empty_multidict(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     @benchmark
     def _run() -> None:
@@ -509,7 +509,7 @@ def test_create_empty_multidict(
 
 
 def test_create_multidict_with_items(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     items = [(str(i), str(i)) for i in range(100)]
 
@@ -520,7 +520,7 @@ def test_create_multidict_with_items(
 
 def test_create_cimultidict_with_items_istr(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     items = [
@@ -534,7 +534,7 @@ def test_create_cimultidict_with_items_istr(
 
 
 def test_create_multidict_with_dict(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     dct = {str(i): str(i) for i in range(100)}
 
@@ -545,7 +545,7 @@ def test_create_multidict_with_dict(
 
 def test_create_cimultidict_with_dict_istr(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     dct = {
@@ -558,7 +558,7 @@ def test_create_cimultidict_with_dict_istr(
 
 
 def test_create_multidict_with_items_with_kwargs(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     items = [(str(i), str(i)) for i in range(100)]
     kwargs = {str(i): str(i) for i in range(100)}
@@ -570,7 +570,7 @@ def test_create_multidict_with_items_with_kwargs(
 
 def test_create_cimultidict_with_items_istr_with_kwargs(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     items = [
@@ -628,7 +628,7 @@ def test_create_cimultidictproxy(
 
 def test_create_from_existing_cimultidict(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     existing = case_insensitive_multidict_class(
@@ -642,7 +642,7 @@ def test_create_from_existing_cimultidict(
 
 def test_copy_from_existing_cimultidict(
     benchmark: BenchmarkFixture,
-    case_insensitive_multidict_class: Type[CIMultiDict[istr]],
+    case_insensitive_multidict_class: type[CIMultiDict[istr]],
     case_insensitive_str_class: type[istr],
 ) -> None:
     existing = case_insensitive_multidict_class(
@@ -655,7 +655,7 @@ def test_copy_from_existing_cimultidict(
 
 
 def test_iterate_multidict(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     items = [(str(i), str(i)) for i in range(100)]
     md = any_multidict_class(items)
@@ -667,7 +667,7 @@ def test_iterate_multidict(
 
 
 def test_iterate_multidict_keys(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     items = [(str(i), str(i)) for i in range(100)]
     md = any_multidict_class(items)
@@ -679,7 +679,7 @@ def test_iterate_multidict_keys(
 
 
 def test_iterate_multidict_values(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     items = [(str(i), str(i)) for i in range(100)]
     md = any_multidict_class(items)
@@ -691,7 +691,7 @@ def test_iterate_multidict_values(
 
 
 def test_iterate_multidict_items(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     items = [(str(i), str(i)) for i in range(100)]
     md = any_multidict_class(items)

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -28,7 +28,7 @@ class TestMutableMultiDict:
         case_sensitive_multidict_class: type[MultiDict[str]],
     ) -> None:
         d = case_sensitive_multidict_class()
-        assert str(d) == "<%s()>" % case_sensitive_multidict_class.__name__
+        assert str(d) == f"<{case_sensitive_multidict_class.__name__}()>"
 
         d = case_sensitive_multidict_class([("key", "one"), ("key", "two")])
 
@@ -532,7 +532,7 @@ class TestCIMutableMultiDict:
         case_insensitive_multidict_class: type[CIMultiDict[str]],
     ) -> None:
         d = case_insensitive_multidict_class()
-        assert str(d) == "<%s()>" % case_insensitive_multidict_class.__name__
+        assert str(d) == f"<{case_insensitive_multidict_class.__name__}()>"
 
         d = case_insensitive_multidict_class([("KEY", "one"), ("KEY", "two")])
 

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -1,6 +1,5 @@
 import string
 import sys
-from typing import Union
 
 import pytest
 from multidict import (

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -77,7 +77,7 @@ class TestMutableMultiDict:
 
     def test_extend(
         self,
-        case_sensitive_multidict_class: type[MultiDict[Union[str, int]]],
+        case_sensitive_multidict_class: type[MultiDict[str | int]],
     ) -> None:
         d = case_sensitive_multidict_class()
         assert d == {}
@@ -348,7 +348,7 @@ class TestMutableMultiDict:
 
     def test_update(
         self,
-        case_sensitive_multidict_class: type[MultiDict[Union[str, int]]],
+        case_sensitive_multidict_class: type[MultiDict[str | int]],
     ) -> None:
         d = case_sensitive_multidict_class()
         assert d == {}
@@ -430,7 +430,7 @@ class TestMutableMultiDict:
 
     def test_merge(
         self,
-        case_sensitive_multidict_class: type[MultiDict[Union[str, int]]],
+        case_sensitive_multidict_class: type[MultiDict[str | int]],
     ) -> None:
         d = case_sensitive_multidict_class({"key": "one"})
         assert d == {"key": "one"}
@@ -575,7 +575,7 @@ class TestCIMutableMultiDict:
 
     def test_extend(
         self,
-        case_insensitive_multidict_class: type[CIMultiDict[Union[str, int]]],
+        case_insensitive_multidict_class: type[CIMultiDict[str | int]],
     ) -> None:
         d = case_insensitive_multidict_class()
         assert d == {}

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,4 @@
 from collections import deque
-from typing import Union
 
 from multidict import CIMultiDict, MultiDict
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -3,7 +3,7 @@ from typing import Union
 
 from multidict import CIMultiDict, MultiDict
 
-_MD_Classes = Union[type[MultiDict[int]], type[CIMultiDict[int]]]
+_MD_Classes = type[MultiDict[int]] | type[CIMultiDict[int]]
 
 
 def test_update_replace(any_multidict_class: _MD_Classes) -> None:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import TypeVar, Union
+from typing import TypeVar
 
 import pytest
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,9 +6,7 @@ import pytest
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 
 _T = TypeVar("_T")
-_MD_Types = Union[
-    MultiDict[_T], CIMultiDict[_T], MultiDictProxy[_T], CIMultiDictProxy[_T]
-]
+_MD_Types = MultiDict[_T] | CIMultiDict[_T] | MultiDictProxy[_T] | CIMultiDictProxy[_T]
 GetVersion = Callable[[_MD_Types[_T]], int]
 
 

--- a/tests/test_views_benchmarks.py
+++ b/tests/test_views_benchmarks.py
@@ -1,7 +1,5 @@
 """codspeed benchmarks for multidict views."""
 
-from typing import Type
-
 from pytest_codspeed import BenchmarkFixture
 
 from multidict import MultiDict

--- a/tests/test_views_benchmarks.py
+++ b/tests/test_views_benchmarks.py
@@ -8,7 +8,7 @@ from multidict import MultiDict
 
 
 def test_keys_view_equals(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
@@ -19,7 +19,7 @@ def test_keys_view_equals(
 
 
 def test_keys_view_not_equals(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(20, 120)})
@@ -30,7 +30,7 @@ def test_keys_view_not_equals(
 
 
 def test_keys_view_more(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     s = {str(i) for i in range(50)}
@@ -41,7 +41,7 @@ def test_keys_view_more(
 
 
 def test_keys_view_more_or_equal(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     s = {str(i) for i in range(100)}
@@ -52,7 +52,7 @@ def test_keys_view_more_or_equal(
 
 
 def test_keys_view_less(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     s = {str(i) for i in range(150)}
@@ -63,7 +63,7 @@ def test_keys_view_less(
 
 
 def test_keys_view_less_or_equal(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     s = {str(i) for i in range(100)}
@@ -74,7 +74,7 @@ def test_keys_view_less_or_equal(
 
 
 def test_keys_view_and(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(50, 150)})
@@ -85,7 +85,7 @@ def test_keys_view_and(
 
 
 def test_keys_view_or(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(50, 150)})
@@ -96,7 +96,7 @@ def test_keys_view_or(
 
 
 def test_keys_view_sub(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(50, 150)})
@@ -107,7 +107,7 @@ def test_keys_view_sub(
 
 
 def test_keys_view_xor(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(50, 150)})
@@ -118,7 +118,7 @@ def test_keys_view_xor(
 
 
 def test_keys_view_is_disjoint(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100, 200)})
@@ -129,7 +129,7 @@ def test_keys_view_is_disjoint(
 
 
 def test_keys_view_repr(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
 
@@ -139,7 +139,7 @@ def test_keys_view_repr(
 
 
 def test_items_view_equals(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
@@ -150,7 +150,7 @@ def test_items_view_equals(
 
 
 def test_items_view_not_equals(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(20, 120)})
@@ -161,7 +161,7 @@ def test_items_view_not_equals(
 
 
 def test_items_view_more(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     s = {(str(i), str(i)) for i in range(50)}
@@ -172,7 +172,7 @@ def test_items_view_more(
 
 
 def test_items_view_more_or_equal(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     s = {(str(i), str(i)) for i in range(100)}
@@ -183,7 +183,7 @@ def test_items_view_more_or_equal(
 
 
 def test_items_view_less(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     s = {(str(i), str(i)) for i in range(150)}
@@ -194,7 +194,7 @@ def test_items_view_less(
 
 
 def test_items_view_less_or_equal(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     s = {(str(i), str(i)) for i in range(100)}
@@ -205,7 +205,7 @@ def test_items_view_less_or_equal(
 
 
 def test_items_view_and(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(50, 150)})
@@ -216,7 +216,7 @@ def test_items_view_and(
 
 
 def test_items_view_or(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(50, 150)})
@@ -227,7 +227,7 @@ def test_items_view_or(
 
 
 def test_items_view_sub(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(50, 150)})
@@ -238,7 +238,7 @@ def test_items_view_sub(
 
 
 def test_items_view_xor(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(50, 150)})
@@ -249,7 +249,7 @@ def test_items_view_xor(
 
 
 def test_items_view_is_disjoint(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md1: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
     md2: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100, 200)})
@@ -260,7 +260,7 @@ def test_items_view_is_disjoint(
 
 
 def test_items_view_repr(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
 
@@ -270,7 +270,7 @@ def test_items_view_repr(
 
 
 def test_values_view_repr(
-    benchmark: BenchmarkFixture, any_multidict_class: Type[MultiDict[str]]
+    benchmark: BenchmarkFixture, any_multidict_class: type[MultiDict[str]]
 ) -> None:
     md: MultiDict[str] = any_multidict_class({str(i): str(i) for i in range(100)})
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change enables ruff to make automatic upgrades when moving up versions of python or dropping versions (for example 3.9)

## Are there changes in behavior for the user?

This should be helpful for other contributors and users.

## Related issue number

#1324 this was discussed by me and @bdraco, I decided to branch out once again as this portion is a big enough change that requires another PR.
close #1324

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
