### PR TITLE
Drop 3.13t support

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -176,6 +176,7 @@ jobs:
         pyver:
         - 3.14t
         - 3.14
+        # Skipping 3.13t because cibuildwheel dropped support
         - 3.13
         - 3.12
         - 3.11

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -176,7 +176,6 @@ jobs:
         pyver:
         - 3.14t
         - 3.14
-        - 3.13t
         - 3.13
         - 3.12
         - 3.11
@@ -191,10 +190,6 @@ jobs:
           no-extensions: Y
         - os: windows
           no-extensions: Y
-        - os: macos
-          pyver: 3.13t  # this is still tested within cibuildwheel
-        - os: windows
-          pyver: 3.13t  # this is still tested within cibuildwheel
         - no-extensions: Y
           debug: Y
         include:

--- a/CHANGES/1326.breaking.rst
+++ b/CHANGES/1326.breaking.rst
@@ -1,1 +1,0 @@
-Dropped support for free-threaded Python 3.13 -- by :user:`ngoldbaum`.

--- a/CHANGES/1326.breaking.rst
+++ b/CHANGES/1326.breaking.rst
@@ -1,1 +1,1 @@
-Dropped support for free-threaded Python 3.13
+Dropped support for free-threaded Python 3.13 -- by :user:`ngoldbaum`.

--- a/CHANGES/1326.breaking.rst
+++ b/CHANGES/1326.breaking.rst
@@ -1,0 +1,1 @@
+1326.packaging.rst

--- a/CHANGES/1326.breaking.rst
+++ b/CHANGES/1326.breaking.rst
@@ -1,0 +1,1 @@
+Dropped support for free-threaded Python 3.13

--- a/CHANGES/1326.packaging.rst
+++ b/CHANGES/1326.packaging.rst
@@ -1,1 +1,1 @@
-CHANGES/1326.breaking.rst
+Dropped support for free-threaded Python 3.13 -- by :user:`ngoldbaum`.

--- a/CHANGES/1326.packaging.rst
+++ b/CHANGES/1326.packaging.rst
@@ -1,0 +1,1 @@
+CHANGES/1326.breaking.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ test-requires = "-r requirements/pytest.txt"
 test-command = 'pytest -m "not leaks" --no-cov {project}/tests'
 # don't build PyPy wheels, install from source instead
 skip = "pp*"
-enable = ["cpython-freethreading"]
 
 [tool.cibuildwheel.linux]
 # Re-enable 32-bit builds (disabled by default in cibuildwheel 3.0)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

See the note at https://cibuildwheel.pypa.io/en/stable/changelog/#v341 and https://github.com/pypa/cibuildwheel/pull/2787.

The `cpython-freethreading` option will be removed in the next release of cibuildwheel.

I'm going through repositories on GitHub that enable this option and sending in PRs to disable it. Happy to answer questions about this. I also took the opportunity to drop 3.13t CI.

If you're curious why 3.13t support is going away so soon, see https://py-free-threading.github.io/ci/#building-free-threaded-wheels-with-cibuildwheel for further guidance.

## Are there changes in behavior for the user?

The next release will not include cp313t wheel builds.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
