### PR TITLE
Fix hashtable insertion race. (Free-Threaded)

### DIFF
--- a/CHANGES/1327.bugfix.rst
+++ b/CHANGES/1327.bugfix.rst
@@ -1,2 +1,3 @@
 Fixed insertion race on free-threaded mode.
+
 -- by :user:`Vizonex`

--- a/CHANGES/1327.bugfix.rst
+++ b/CHANGES/1327.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed hashtable insertion race on free-threaded mode.
+-- by :user:`Vizonex`

--- a/CHANGES/1327.bugfix.rst
+++ b/CHANGES/1327.bugfix.rst
@@ -1,2 +1,2 @@
-Fixed hashtable insertion race on free-threaded mode.
+Fixed insertion race on free-threaded mode.
 -- by :user:`Vizonex`

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -412,6 +412,7 @@ _md_add_with_hash_steal_refs(MultiDictObject *md, Py_hash_t hash,
                              PyObject *identity, PyObject *key,
                              PyObject *value)
 {
+    Py_BEGIN_CRITICAL_SECTION(md);
     htkeys_t *keys = md->keys;
     if (keys->usable <= 0 || keys == &empty_htkeys) {
         /* Need to resize. */
@@ -435,6 +436,7 @@ _md_add_with_hash_steal_refs(MultiDictObject *md, Py_hash_t hash,
     md->used += 1;
     keys->usable -= 1;
     keys->nentries += 1;
+    Py_END_CRITICAL_SECTION();
     return 0;
 }
 

--- a/tests/isolated/multidict_add_ft.py
+++ b/tests/isolated/multidict_add_ft.py
@@ -1,0 +1,30 @@
+import os
+import subprocess
+import sys
+import sysconfig
+import textwrap
+
+FREETHREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+if __name__ == "__main__" and FREETHREADED:
+    child = textwrap.dedent("""
+        import threading
+        from multidict import MultiDict
+        md: MultiDict[int] = MultiDict()
+        def worker(tid: int):
+            for i in range(800):
+                md.add(f"k{tid}_{i}", i)
+        ts = [threading.Thread(target=worker, args=(tid,), daemon=True) for tid in range(4)]
+        for t in ts: 
+            t.start()
+        for t in ts: 
+            t.join()
+        print(f"missing: {4*800 - len(md)}")
+    """)
+    subprocess.run(
+        [sys.executable, "-c", child],
+        env={**os.environ, "PYTHON_GIL": "0"},
+        capture_output=True,
+        timeout=60,
+        check=True,
+    )

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -11,6 +11,7 @@ IS_PYPY = platform.python_implementation() == "PyPy"
 @pytest.mark.parametrize(
     ("script"),
     (
+        "multidict_add_ft.py",
         "multidict_extend_dict.py",
         "multidict_extend_multidict.py",
         "multidict_extend_tuple.py",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change comes related to [_md_add_with_hash_steal_refs](https://gist.github.com/devdanzin/fa00e03ef041c030660f083116a7e1b6#2-hashtable-insert-race--_md_add_with_hash_steal_refs) Which mentions a possible hashtable insertion race in free-threaded mode.

## Are there changes in behavior for the user?

this should not affect the pure python version of multidict only the C version.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
