### PR TITLE
Parallelize C extension compilation

### DIFF
--- a/CHANGES/1341.packaging.rst
+++ b/CHANGES/1341.packaging.rst
@@ -1,0 +1,3 @@
+Parallelized C extension compilation by defaulting ``build_ext.parallel``
+to ``os.cpu_count()`` so per-file compilations run concurrently instead of
+serially -- by :user:`bdraco`.

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,18 @@ import platform
 import sys
 
 from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 
 NO_EXTENSIONS = bool(os.environ.get("MULTIDICT_NO_EXTENSIONS"))
 DEBUG_BUILD = bool(os.environ.get("MULTIDICT_DEBUG_BUILD"))
+
+
+class BuildExt(build_ext):
+    def build_extensions(self) -> None:
+        if self.parallel is None:
+            self.parallel = os.cpu_count() or 1
+        super().build_extensions()
+
 
 if sys.implementation.name != "cpython":
     NO_EXTENSIONS = True
@@ -38,7 +47,7 @@ if not NO_EXTENSIONS:
     print("*********************")
     print("* Accelerated build *")
     print("*********************")
-    setup(ext_modules=extensions)
+    setup(ext_modules=extensions, cmdclass={"build_ext": BuildExt})
 else:
     print("*********************")
     print("* Pure Python build *")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Default `build_ext.parallel` to `os.cpu_count()` when the caller has not
set it, so per source file compilations of the C extension run
concurrently instead of one at a time. Mirrors the same change in
[python-zeroconf#1689](https://github.com/python-zeroconf/python-zeroconf/pull/1689),
[habluetooth#421](https://github.com/Bluetooth-Devices/habluetooth/pull/421),
and [aioesphomeapi#1662](https://github.com/esphome/aioesphomeapi/pull/1662).

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No; the override only kicks in when `parallel` is unset, so anyone
passing `--parallel` on the command line keeps full control.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A; build-time change)
- [ ] Documentation reflects the changes (N/A)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A; no `CONTRIBUTORS.txt` in this repo)
- [x] Add a new news fragment into the `CHANGES/` folder
