### PR TITLE
Enable ruff I (import sorting) rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,14 @@ repos:
   rev: v0.15.8
   hooks:
   - id: ruff-check
-    args: ["--fix"]
+    # Uses the [tool.ruff] config in pyproject.toml. ``--fix`` is on
+    # so the ``I`` (import sorting) rule applies on commit; runs before
+    # ruff-format. See:
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    args:
+    - --exit-non-zero-on-fix
+    - --fix
+    - --show-fixes
     exclude: >-
       (?x)
       ^

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,8 +410,8 @@ Design tests so every line runs:
 ## Code style
 
 - `pyproject.toml` sets `[tool.ruff]` `target-version = "py310"` with
-  only the `UP` (pyupgrade) lint group enabled. Do not enable other
-  lint groups as a drive-by; that is its own PR.
+  the `UP` (pyupgrade) and `I` (import sorting) lint groups enabled.
+  Do not enable other lint groups as a drive-by; that is its own PR.
 - Minimum Python is **3.10**. Match the surrounding file's import
   and typing conventions; do not introduce `from __future__ import
   annotations` to files that do not already use it.

--- a/CHANGES/1348.contrib.rst
+++ b/CHANGES/1348.contrib.rst
@@ -1,0 +1,7 @@
+Enabled the ``I`` (import sorting) rule in
+``[tool.ruff.lint]`` so ``ruff check`` covers import order on top
+of the existing ``UP`` (pyupgrade) group, and updated the
+``ruff-check`` pre-commit hook to run with
+``--fix --exit-non-zero-on-fix --show-fixes`` so import-order
+fixes apply on commit. Sorted imports in four ``tests/`` files
+to match the new rule -- by :user:`bdraco`.

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -3,7 +3,6 @@ import textwrap
 
 import pyperf
 
-
 IMPLEMENTATIONS = {
     "dict": """\
     cls = dict

--- a/benchmarks/istr.py
+++ b/benchmarks/istr.py
@@ -3,7 +3,6 @@ import textwrap
 
 import perf
 
-
 IMPLEMENTATIONS = {
     "c": """\
     from multidict._multidict import istr

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -83,6 +83,7 @@ proxied
 pyenv
 pyinstaller
 pytest
+pyupgrade
 refactor
 refactored
 regex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,17 @@ build-backend = "setuptools.build_meta"
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["UP"]
+# Keep this list small and intentional. Each entry is enforced
+# repo-wide; do not enable additional lint groups as a drive-by.
+select = [
+  # Import sorting. Replaces a dedicated isort hook so the formatter
+  # (ruff format) and the import sorter (ruff check --select I) come
+  # from the same tool and rev.
+  "I",
+  # pyupgrade: enforce modern Python syntax for the current
+  # ``target-version`` (currently py310).
+  "UP",
+]
 
 [tool.cibuildwheel]
 test-requires = "-r requirements/pytest.txt"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import argparse
 import pickle
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
 from importlib import import_module
 from types import ModuleType
-from collections.abc import Callable
 
 import pytest
 

--- a/tests/isolated/multidict_pop.py
+++ b/tests/isolated/multidict_pop.py
@@ -8,6 +8,7 @@ import gc
 import os
 
 import psutil
+
 from multidict import MultiDict
 
 

--- a/tests/test_circular_imports.py
+++ b/tests/test_circular_imports.py
@@ -15,10 +15,10 @@ import os
 import pkgutil
 import subprocess
 import sys
+from collections.abc import Generator
 from itertools import chain
 from pathlib import Path
 from types import ModuleType
-from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -2,6 +2,7 @@ import string
 import sys
 
 import pytest
+
 from multidict import (
     CIMultiDict,
     CIMultiDictProxy,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Enables the ``I`` (import sorting) rule in ``[tool.ruff.lint]``
alongside the existing ``UP`` (pyupgrade) group, and updates the
``ruff-check`` pre-commit hook to run with
``--fix --exit-non-zero-on-fix --show-fixes`` so import-order fixes
apply on commit (and abort the commit when something changed). This
follows the same pattern as yarl PR
[#1698](https://github.com/aio-libs/yarl/pull/1698): one tool, one
rev, for both formatting and import sorting.

Sorted imports in six files where ``ruff check --select I --fix``
found drift (``tests/conftest.py``,
``tests/isolated/multidict_pop.py``,
``tests/test_circular_imports.py``,
``tests/test_mutable_multidict.py``,
``benchmarks/benchmark.py``, ``benchmarks/istr.py``).

``AGENTS.md`` updated to reflect the additional lint group, so the
"only the ``UP`` group enabled" guidance no longer contradicts the
config.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Is it a substantial burden for the maintainers to support this?

No. One additional lint rule sharing the existing ``[tool.ruff]``
config; no new pre-commit hooks were added.

## Related issue number

N/A; mirrors the approach taken in yarl #1698.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (tooling-only change; ran the touched test modules and the full pre-commit suite to verify)
- [x] Documentation reflects the changes: N/A (no user-visible API change; ``AGENTS.md`` updated)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``: N/A (no such file in this repo)
- [x] Add a new news fragment into the ``CHANGES/`` folder (``CHANGES/1348.contrib.rst``)

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Verified:

```
$ ruff check multidict/ tests/ benchmarks/
All checks passed!
$ ruff format --check multidict/ tests/
29 files already formatted
$ python3 -m pytest tests/test_circular_imports.py tests/test_mutable_multidict.py --no-cov -q -W ignore::UserWarning
137 passed in 0.30s
$ pre-commit run --all-files
all hooks passed (including mypy py311 + py313)
$ make doc-spelling
5 pre-existing CHANGES.rst misspellings only; CHANGES/1348.contrib.rst is clean
```

</details>