### PR TITLE
Enforce top-level imports via ruff PLC0415

### DIFF
--- a/CHANGES/1349.contrib.rst
+++ b/CHANGES/1349.contrib.rst
@@ -1,0 +1,8 @@
+Enabled the ``PLC0415`` (import-outside-top-level) rule in
+``[tool.ruff.lint]``. Function-scoped imports must now opt in
+with ``# noqa: PLC0415`` plus a comment explaining the reason
+(typically avoiding a heavy optional dependency at import time).
+This catches a pattern that LLM contributors frequently introduce.
+There are currently no opt-outs in the tree, so the rule is
+enforced everywhere ``ruff check`` runs
+-- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ select = [
   # (ruff format) and the import sorter (ruff check --select I) come
   # from the same tool and rev.
   "I",
+  # Imports must live at the top of the module. Late/inside-function
+  # imports must be opted into explicitly with `# noqa: PLC0415` and a
+  # comment explaining why (e.g. avoiding a heavy optional dependency
+  # in the import path). Enforced because AI-assisted contributions
+  # frequently introduce function-scoped imports that are unnecessary.
+  "PLC0415",
   # pyupgrade: enforce modern Python syntax for the current
   # ``target-version`` (currently py310).
   "UP",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds ``PLC0415`` (import-outside-top-level) to ``[tool.ruff.lint]``
select alongside the existing ``I`` and ``UP`` groups. Function-scoped
imports must now opt in with ``# noqa: PLC0415`` plus a comment
explaining why (typically avoiding a heavy optional dependency at
import time). This catches a pattern that LLM contributors frequently
introduce.

There are no opt-outs needed in the tree today: ``ruff check --select
PLC0415`` against ``multidict/``, ``tests/``, and ``benchmarks/``
passes as-is. Conditional top-level imports under ``if
TYPE_CHECKING:`` / ``if sys.version_info >= ...:`` / ``try / except
ImportError`` are not flagged by the rule.

Mirrors the approach taken in yarl PR
[#1697](https://github.com/aio-libs/yarl/pull/1697), which added the
same rule there for the same reason. Following the AGENTS.md
guidance that each new ruff lint group should be its own PR.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Is it a substantial burden for the maintainers to support this?

No. The rule has zero opt-outs in the current tree. Future function-
scoped imports must be justified inline with ``# noqa: PLC0415`` and
a comment, which is the explicit intent.

## Related issue number

N/A; mirrors the approach taken in yarl #1697.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (lint-config-only change; verified by running ``ruff check`` and the pre-commit suite against the tree)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``: N/A (no such file in this repo)
- [x] Add a new news fragment into the ``CHANGES/`` folder (``CHANGES/1349.contrib.rst``)

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Verified:

```
$ ruff check --select PLC0415 multidict/ tests/ benchmarks/
All checks passed!
$ ruff check multidict/ tests/ benchmarks/
All checks passed!
$ ruff format --check multidict/ tests/ benchmarks/
31 files already formatted
$ python3 -m pytest tests/test_circular_imports.py tests/test_mutable_multidict.py --no-cov -q -W ignore::UserWarning
137 passed in 0.33s
$ pre-commit run --all-files
all hooks passed (including mypy py311 + py313)
$ make doc-spelling
5 pre-existing CHANGES.rst misspellings only; the new CHANGES/1349.contrib.rst fragment was checked through the towncrier-fragments preview (with sphinxcontrib-towncrier installed locally) and is clean.
```

</details>