### PR TITLE
Switch cibuildwheel to the uv build frontend

### DIFF
--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -110,6 +110,11 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.4.1
       with:
+        # `build-frontend = "build[uv]"` (pyproject.toml) requires uv to be
+        # available on the runner for Windows and macOS. Installing
+        # cibuildwheel with the `uv` extra bundles uv with it; Linux
+        # already has uv inside the manylinux/musllinux container.
+        extras: uv
         package-dir: >-  # not necessarily a dir, we pass an acceptable sdist
           dist/${{ inputs.source-tarball-name }}
 

--- a/CHANGES/1350.contrib.rst
+++ b/CHANGES/1350.contrib.rst
@@ -1,0 +1,6 @@
+Switched the ``cibuildwheel`` build frontend to ``build[uv]`` so
+that ``uv`` provisions every build and test virtual environment
+in the wheel matrix. Test-dependency installation in particular
+drops from a multi-second ``pip install`` per ABI to a roughly
+sub-second ``uv`` resolve
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -39,6 +39,7 @@ fallback
 fastpath
 filename
 formatters
+frontend
 RST
 docstring
 gcc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,13 @@ select = [
 ]
 
 [tool.cibuildwheel]
+# `build[uv]` makes cibuildwheel use `uv` for every venv it provisions,
+# both on the build side (passed to `python -m build` as `--installer=uv`)
+# and when materializing the test environment. uv resolves and installs
+# the wheel plus `requirements/pytest.txt` in roughly a second; the previous
+# pip-based path took noticeably longer per ABI and ran once per matrix
+# cell.
+build-frontend = "build[uv]"
 test-requires = "-r requirements/pytest.txt"
 test-command = 'pytest -m "not leaks" --no-cov {project}/tests'
 # don't build PyPy wheels, install from source instead


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Set ``build-frontend = "build[uv]"`` in ``[tool.cibuildwheel]``
so that ``uv`` provisions every virtual environment cibuildwheel
creates, both on the build side (passed to ``python -m build`` as
``--installer=uv``) and when materializing the per-ABI test
environment. The previous default ``build-frontend = "build"``
left every test env doing a multi-second pip resolve of
``requirements/pytest.txt`` per ABI; ``uv`` resolves and installs
the same set in roughly a second, which compounds across the
ABIs and host platforms in the wheel matrix.

Also adds ``extras: uv`` to the ``pypa/cibuildwheel`` action
invocation in ``reusable-cibuildwheel.yml`` so that Windows and
macOS runners get ``uv`` bundled alongside cibuildwheel (Linux
already has ``uv`` inside the manylinux/musllinux containers).

The corresponding change in ``aio-libs/propcache`` is
[propcache#234](https://github.com/aio-libs/propcache/pull/234).

## Are there changes in behavior for the user?

No, contributor tooling only.

## Is it a substantial burden for the maintainers to support this?

No; cibuildwheel maintains the ``build[uv]`` frontend.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (CI-only change; the wheel-matrix run on this PR is the verification path)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``: N/A (no such file in this repo)
- [x] Add a new news fragment into the ``CHANGES/`` folder (``CHANGES/1350.contrib.rst``)

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Local validation:

```
$ python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"
$ make doc-spelling
5 pre-existing misspellings only in CHANGES.rst (parametrization, postfix, instantiation, init, parametrized); CHANGES/1350.contrib.rst is clean after adding "frontend" to the wordlist. Verified by temporarily removing "frontend" from the wordlist and re-running, which reported the fragment-sourced flag at ``[towncrier-fragments]:169``, then restored.
$ pre-commit run --files .github/workflows/reusable-cibuildwheel.yml docs/spelling_wordlist.txt pyproject.toml CHANGES/1350.contrib.rst
all hooks pass (ran via the commit hook).
```

Not verified locally: the actual cibuildwheel + uv interaction
inside the build container; that requires running cibuildwheel
which is impractical without pushing. The live CI run on this
branch is the verification.

This repo's ``[tool.cibuildwheel]`` did not have the ``before-test``
PyYAML pre-cache block or the ``[tool.cibuildwheel.windows]``
``before-test = []`` override that propcache#234 removed, so this
PR is strictly additive relative to propcache's version of the
change.
</details>