### PR TITLE
ci: install Python via astral-sh/setup-uv to skip slow downloads

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,8 +71,9 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_LATEST }}
         activate-environment: true
+        enable-cache: true
     - name: Install core libraries for build
-      run: python -Im pip install build
+      run: uv pip install build
     - name: Build sdists and pure-python wheel
       env:
         MULTIDICT_NO_EXTENSIONS: Y
@@ -256,6 +257,7 @@ jobs:
       with:
         python-version: ${{ matrix.pyver }}
         activate-environment: true
+        enable-cache: true
     - name: Compute runtime Python version
       id: python-install
       run: |
@@ -282,96 +284,29 @@ jobs:
             )
       shell: python
 
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> "${GITHUB_OUTPUT}"
-      shell: bash
-    - name: Cache PyPI
-      uses: actions/cache@v5
-      with:
-        key: >-
-          pip-ci-${{
-            runner.os
-          }}-${{
-            matrix.pyver
-          }}-${{
-            matrix.no-extensions
-          }}-${{
-            matrix.debug
-          }}-${{
-            hashFiles('requirements/*.txt')
-          }}
-        path: ${{ steps.pip-cache.outputs.dir }}
-        restore-keys: >-
-          pip-ci-${{
-            runner.os
-          }}-${{
-            matrix.pyver
-          }}-${{
-            matrix.no-extensions
-          }}-${{
-            matrix.debug
-          }}
     - name: Install dependencies
-      uses: py-actions/py-dependency-install@v4
-      with:
-        path: requirements/pytest.txt
-    - name: Determine pre-compiled compatible wheel
-      if: steps.build_type.outputs.build_type == 'wheel'
-      env:
-        # NOTE: When `pip` is forced to colorize output piped into `jq`,
-        # NOTE: the latter can't parse it. So we're overriding the color
-        # NOTE: preference here via https://no-color.org.
-        # NOTE: Setting `FORCE_COLOR` to any value (including 0, an empty
-        # NOTE: string, or a "YAML null" `~`) doesn't have any effect and
-        # NOTE: `pip` (through its verndored copy of `rich`) treats the
-        # NOTE: presence of the variable as "force-color" regardless.
-        #
-        # NOTE: This doesn't actually work either, so we'll resort to unsetting
-        # NOTE: in the Bash script.
-        # NOTE: Ref: https://github.com/Textualize/rich/issues/2622
-        NO_COLOR: 1
-      id: wheel-file
-      run: >
-        echo -n path= | tee -a "${GITHUB_OUTPUT}"
-
-
-        unset FORCE_COLOR
-
-
-        python
-        -X utf8
-        -u -I
-        -m pip install
-        --find-links=./dist
-        --no-index
-        '${{ env.PROJECT_NAME }}'
-        --force-reinstall
-        --no-color
-        --no-deps
-        --only-binary=:all:
-        --dry-run
-        --report=-
-        --quiet
-        | jq --raw-output .install[].download_info.url
-        | tee -a "${GITHUB_OUTPUT}"
-      shell: bash
+      run: uv pip install -r requirements/pytest.txt
     - name: Ensure clean for source build
       if: steps.build_type.outputs.build_type == 'source'
       run: >-
         make clean
       shell: bash
-    - name: Self-install (from ${{ steps.build_type.outputs.build_type }})
+    - name: Install ${{ env.PROJECT_NAME }} from source
+      if: steps.build_type.outputs.build_type == 'source'
       env:
         MULTIDICT_NO_EXTENSIONS: ${{ matrix.no-extensions }}
-        MULTIDICT_DEBUG_BUILD: 1  # Always on for source builds
+        MULTIDICT_DEBUG_BUILD: 1
+      run: uv pip install .
+    - name: Install ${{ env.PROJECT_NAME }} from a pre-built wheel
+      if: steps.build_type.outputs.build_type == 'wheel'
       run: >-
-        pip install '${{
-          steps.build_type.outputs.build_type == 'source'
-          && '.'
-          || steps.wheel-file.outputs.path
-        }}'
+        uv pip install
+        --find-links=./dist
+        --no-index
+        --no-deps
+        --force-reinstall
+        --only-binary=:all:
+        '${{ env.PROJECT_NAME }}'
     - name: Run unittests
       run: >-
         python -Im pytest tests -v

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Set up Python ${{ env.PYTHON_LATEST }}
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ env.PYTHON_LATEST }}
         activate-environment: true
@@ -252,7 +252,7 @@ jobs:
         path: dist
 
     - name: Setup Python ${{ matrix.pyver }}
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}
         activate-environment: true

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,9 +67,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Set up Python ${{ env.PYTHON_LATEST }}
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8
       with:
         python-version: ${{ env.PYTHON_LATEST }}
+        activate-environment: true
     - name: Install core libraries for build
       run: python -Im pip install build
     - name: Build sdists and pure-python wheel
@@ -251,10 +252,10 @@ jobs:
         path: dist
 
     - name: Setup Python ${{ matrix.pyver }}
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8
       with:
         python-version: ${{ matrix.pyver }}
-        allow-prereleases: true
+        activate-environment: true
     - name: Compute runtime Python version
       id: python-install
       run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ env:
   PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: 1
-  PYTHON_LATEST: 3.x
+  PYTHON_LATEST: 3.13
 
 
 jobs:

--- a/CHANGES/1351.contrib.rst
+++ b/CHANGES/1351.contrib.rst
@@ -1,0 +1,6 @@
+Switched the CI test matrix from ``actions/setup-python`` to
+``astral-sh/setup-uv`` for installing interpreters, cutting the
+``Setup Python`` step from 40-58s to a few seconds on macOS and
+Windows runners for variants not in the hosted tool-cache
+(notably the free-threaded ``3.14t``)
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Port aio-libs/yarl#1704 to multidict. Three logical steps, mirrored
1:1 in the commit history:

1. Swap ``actions/setup-python@v6`` for ``astral-sh/setup-uv@v8`` in
   the two CI jobs that install a Python interpreter
   (``build-pure-python-dists`` and the matrix ``test``).
   ``activate-environment: true`` keeps ``python``/``pip`` on PATH so
   the rest of the pipeline is unchanged. The ``allow-prereleases``
   input has no equivalent on setup-uv because uv treats prereleases
   as first-class.
2. Pin to the immutable ``v8.1.0`` tag. The floating ``v8`` major tag
   does not exist; setup-uv switched to immutable releases at v8.0.0
   and only publishes per-version tags from then on.
3. Drop the pip-cache wrapper and ``py-actions/py-dependency-install``
   and install via ``uv pip`` instead. ``setup-uv`` does not seed
   pip into the venv, so the existing ``pip cache dir`` probe would
   crash the job; rather than seed pip back in just to keep the
   wrapper working, switch to ``enable-cache: true`` (which persists
   uv's own wheel cache across runs) and ``uv pip install -r
   requirements/pytest.txt``. The ``pip --dry-run --report=- | jq``
   wheel-discovery trick collapses into a single ``uv pip install
   --find-links=./dist`` call; uv picks the right wheel for the
   active interpreter directly.

Net: 58 fewer lines in the workflow and one tool (uv) doing both
the interpreter install and the dependency install with one cache.

## Are there changes in behavior for the user?

No. This only affects CI runner provisioning. End-user-visible
behavior of ``multidict`` is unaffected.

Unlike yarl, multidict computes its runtime Python version in a
separate ``Compute runtime Python version`` step rather than
reading ``steps.python-install.outputs.python-version`` off the
setup action, so no Codecov flag shape changes here.

## Is it a substantial burden for the maintainers to support this?

No. ``astral-sh/setup-uv`` is widely used across aio-libs and the
broader Python ecosystem; ``activate-environment: true`` plus
``uv pip install`` reproduce the behavior the existing pipeline
already relies on.

## Related issue number

N/A; ports https://github.com/aio-libs/yarl/pull/1704 across to
multidict, whose matrix has the same ``3.14t`` entry on macOS and
Windows.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist -- N/A (CI configuration)
- [x] Documentation reflects the changes -- N/A (no user-visible change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES/`` folder (``1351.contrib.rst``)

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Direct port of aio-libs/yarl#1704 (merged). Commits mirror the
yarl PR's structure so the diff is easy to compare side-by-side:

| multidict commit | yarl commit |
| --- | --- |
| ``ci: install Python via astral-sh/setup-uv to skip slow downloads`` | ``d10eecb`` |
| ``ci: pin astral-sh/setup-uv to the exact v8.1.0 tag`` | ``07327e0`` |
| ``ci: drop pip cache wrapper, install via uv pip`` | ``d4ab3be`` |

(yarl's intermediate ``Symlink CHANGES/1704.contrib.rst -> 1703.contrib.rst``
commit does not apply here -- multidict has no separate tracking issue,
so the news fragment is named after the PR directly.)

This is a CI-only change; it cannot be exercised against the local
test suite. The full proof is the post-merge CI run on this PR
showing the matrix completing on all three OSes, which the
operator will check before flipping the PR out of draft.

Local verification:

- ``make doc-spelling`` passes for the new fragment (the five
  misspellings reported are pre-existing entries in ``CHANGES.rst``;
  the new ``1351.contrib.rst`` is scanned by
  ``sphinxcontrib-towncrier`` and clean).
- ``pre-commit`` ran on each commit: YAML lint, workflow
  validation, and the changelog/news-fragment role check all pass.

</details>