### PR TITLE
ci: fall back to plain build frontend for odd-arch wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -530,10 +530,14 @@ jobs:
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
       dists-artifact-name: ${{ needs.pre-setup.outputs.dists-artifact-name }}
       # CIBW_ARCHS_LINUX: Build emulated architectures if QEMU, else "auto"
+      # CIBW_BUILD_FRONTEND: override pyproject.toml's `build[uv]` because
+      # the pypa odd-arch containers do not ship `uv` preinstalled
       environment-variables: |-
         CIBW_ARCHS_LINUX=${{ matrix.qemu }}
 
         CIBW_ARCHS_MACOS=x86_64 arm64 universal2
+
+        CIBW_BUILD_FRONTEND=build
 
         CIBW_SKIP=${{
           (matrix.tag == 'musllinux')

--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -112,8 +112,10 @@ jobs:
       with:
         # `build-frontend = "build[uv]"` (pyproject.toml) requires uv to be
         # available on the runner for Windows and macOS. Installing
-        # cibuildwheel with the `uv` extra bundles uv with it; Linux
-        # already has uv inside the manylinux/musllinux container.
+        # cibuildwheel with the `uv` extra bundles uv with it; the
+        # tested-arch manylinux/musllinux containers also ship uv
+        # preinstalled. The odd-arch containers do not, so the odd-arch
+        # matrix in `ci-cd.yml` overrides `CIBW_BUILD_FRONTEND=build`.
         extras: uv
         package-dir: >-  # not necessarily a dir, we pass an acceptable sdist
           dist/${{ inputs.source-tarball-name }}

--- a/CHANGES/1352.contrib.rst
+++ b/CHANGES/1352.contrib.rst
@@ -1,0 +1,4 @@
+Overrode ``CIBW_BUILD_FRONTEND=build`` for the odd-arch wheel
+matrix; the upstream ``manylinux``/``musllinux`` images for
+those arches do not ship ``uv``
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Override `CIBW_BUILD_FRONTEND=build` for the `build-wheels-for-odd-archs`
matrix in `.github/workflows/ci-cd.yml`, so cibuildwheel uses plain pip
to drive the per-ABI builds for the QEMU-emulated odd arches
(`aarch64`, `armv7l`, `ppc64le`, `riscv64`, `s390x` x
manylinux/musllinux).

The project's `pyproject.toml` sets `build-frontend = "build[uv]"`,
which requires a `uv` binary on `PATH` inside the build container.
The pypa tested-arch manylinux/musllinux images ship `uv` preinstalled,
but the odd-arch images (as of the `2026.03.20-1` tag) do not. Without
this override, `cibuildwheel`'s pre-build `which uv` check would fail
every odd-arch job. Same regression as the one observed on yarl's
v1.24.0 release CI after switching to the `uv` build frontend in #1350.

Comment in `reusable-cibuildwheel.yml` updated to call out the split.

## Are there changes in behavior for the user?

No user-visible API change. Keeps odd-arch wheels building once the
`build[uv]` frontend ships in a release.

## Is it a substantial burden for the maintainers to support this?

No; the override is two lines in `ci-cd.yml` plus a comment update,
and can be reverted once the pypa odd-arch images ship `uv`.

## Related issue number

Ports https://github.com/aio-libs/yarl/pull/1720 to `multidict`,
which made the same `build[uv]` switch in #1350.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist — N/A, CI workflow change
- [ ] Documentation reflects the changes — N/A
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

- The `build-wheels-for-odd-archs` matrix is gated on `pre-deploy`,
  which only runs on tag pushes; this change cannot be smoke-tested
  on a PR. Verification path is the next tagged release.
- `make doc-spelling` was run locally; the 5 misspellings it reports
  all pre-date this branch on `master` (verified by stashing the
  diff and re-running). The new `CHANGES/1352.contrib.rst` fragment
  introduces no new misspellings and no `docs/spelling_wordlist.txt`
  changes were needed.
- `pre-commit run` was run on the three touched files and passed
  (`Validate GitHub Workflows`, `yamllint`, changelog `:user:` role).

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco before flipping out of draft.

</details>