### PR TITLE
ci: build aarch64 and armv7l wheels on native ARM runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -520,11 +520,38 @@ jobs:
         tag:
         - ''
         - musllinux
+        include:
+        # Build aarch64 natively on the GH-hosted ARM runner instead of
+        # x86_64-under-QEMU; this drops the build from ~40 min of emulation
+        # to a few minutes of native execution. Each `(qemu, tag)` combo
+        # is listed explicitly so the include unambiguously augments the
+        # existing matrix cell rather than relying on the partial-key
+        # merge behaviour of `matrix.include`.
+        - qemu: aarch64
+          tag: ''
+          runner-vm-os: ubuntu-24.04-arm
+          native-arch: true
+        - qemu: aarch64
+          tag: musllinux
+          runner-vm-os: ubuntu-24.04-arm
+          native-arch: true
+        # armv7l also builds on aarch64 hosts. We still register QEMU so
+        # binfmt picks up the 32-bit ARM userspace handler regardless of
+        # whether the host kernel has CONFIG_COMPAT enabled. Even with
+        # emulation, aarch64-on-aarch64 hosting beats x86_64 by a wide
+        # margin.
+        - qemu: armv7l
+          tag: ''
+          runner-vm-os: ubuntu-24.04-arm
+        - qemu: armv7l
+          tag: musllinux
+          runner-vm-os: ubuntu-24.04-arm
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
       check-name: >-
         Build ${{ matrix.tag }} wheels for ${{ matrix.qemu }}
-      qemu: true
+      qemu: ${{ ! matrix.native-arch }}
+      runner-vm-os: ${{ matrix.runner-vm-os || 'ubuntu-latest' }}
       timeout-minutes: 120
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}

--- a/CHANGES/1354.contrib.rst
+++ b/CHANGES/1354.contrib.rst
@@ -1,0 +1,5 @@
+Switched the aarch64 and armv7l wheel builds to GitHub's native ARM
+runners. The aarch64 wheels now build without QEMU emulation, and
+armv7l runs on aarch64 hosts so its 32-bit ARM execution is far
+cheaper than the previous aarch64-on-x86_64 path
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,4 +1,5 @@
 armv
+aarch
 aarch64
 i686
 ppc64le


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Move the aarch64 and armv7l legs of the odd-arch wheel matrix off the
x86_64 QEMU path and onto GitHub's public ``ubuntu-24.04-arm`` hosted
runner. aarch64 now builds natively with no emulation. armv7l still
gets ``docker/setup-qemu-action`` so binfmt registers a 32-bit ARM
handler whether or not the host kernel ships ``CONFIG_COMPAT``; even
under emulation, running on an aarch64 host is far cheaper than the
previous aarch64-on-x86_64 layout.

ppc64le, s390x, and riscv64 keep the ``ubuntu-latest`` + QEMU setup
since there are no native GH-hosted runners for those.

The matrix gains an ``include:`` block that overrides ``runner-vm-os``
and a ``native-arch`` flag per arch; the job-level ``qemu`` and
``runner-vm-os`` expressions fall back to the previous behaviour for
the unmodified arches.

Ported from the equivalent yarl change in aio-libs/yarl#1724.

## Are there changes in behavior for the user?

No. Wheels are still built for the same architectures and tags; only
the host that builds them changes. Release CI time on the aarch64
leg should drop from roughly 40 minutes to a few minutes.

## Is it a substantial burden for the maintainers to support this?

No. ``ubuntu-24.04-arm`` is GA on public repositories; the
``windows-11-arm`` precedent already in this workflow has the same
shape, and the reusable workflow's ``qemu`` / ``runner-vm-os`` inputs
stay unchanged.

## Related issue number

No tracking issue; ported from aio-libs/yarl#1724.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist - N/A (CI-only change, exercised by the next release run)
- [ ] Documentation reflects the changes - N/A
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt`` - already listed
- [x] Add a new news fragment into the ``CHANGES/`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.

Local validation:

- ``pre-commit run --files .github/workflows/ci-cd.yml CHANGES/1354.contrib.rst docs/spelling_wordlist.txt`` (yamllint, Validate GitHub Workflows, Check GitHub Workflows set timeout-minutes, changelog ``:user:`` role check) all passed.
- ``python -c "yaml.safe_load(open('.github/workflows/ci-cd.yml'))"`` confirms the matrix ``include:`` shape and that the ``${{ ! matrix.native-arch }}`` / ``${{ matrix.runner-vm-os || 'ubuntu-latest' }}`` expressions parse cleanly.
- ``make doc-spelling`` reports only 5 pre-existing misspellings in ``CHANGES.rst`` that are also present on ``master``; the fragment introduced ``aarch`` only, added to ``docs/spelling_wordlist.txt``.

Not validated locally: actual native-ARM cibuildwheel run. The runner
label and matrix wiring look correct, but the real proof is the first
CI run on this branch.

</details>