### PR TITLE
Declare `istr` with `__slots__ = ()` in `_multidict_py.py`

### DIFF
--- a/CHANGES/1361.misc.rst
+++ b/CHANGES/1361.misc.rst
@@ -1,0 +1,1 @@
+Made `istr` slotted in the Python implementation to prevent excessive creations of instance dictionaries -- by :user:`jonathandung4`.

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -34,7 +34,7 @@ else:
 class istr(str):
     """Case insensitive str."""
 
-    __slots__ = ()
+    __slots__ = ("__istr_identity__",)
 
     __is_istr__ = True
     __istr_identity__: str | None = None

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -38,7 +38,10 @@ class istr(str):
 
     __is_istr__ = True
     __istr_identity__: str | None
-
+    def __new__(cls, s: Any, /):
+        self = super().__new__(cls, s)
+        self.__istr_identity__ = None
+        return self
 
 _V = TypeVar("_V")
 _T = TypeVar("_T")
@@ -441,10 +444,9 @@ class _CIMixin:
 
     def _identity(self, key: str) -> str:
         if isinstance(key, istr):
-            ret = getattr(key, "__istr_identity__", None)
+            ret = key.__istr_identity__
             if ret is None:
-                ret = key.lower()
-                key.__istr_identity__ = ret
+                key.__istr_identity__ = ret = key.lower()
             return ret
         if isinstance(key, str):
             return key.lower()

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -38,10 +38,12 @@ class istr(str):
 
     __is_istr__ = True
     __istr_identity__: str | None
+
     def __new__(cls, s: Any, /):
         self = super().__new__(cls, s)
         self.__istr_identity__ = None
         return self
+
 
 _V = TypeVar("_V")
 _T = TypeVar("_T")

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -441,7 +441,7 @@ class _CIMixin:
 
     def _identity(self, key: str) -> str:
         if isinstance(key, istr):
-            ret = getattr(key, '__istr_identity__', None)
+            ret = getattr(key, "__istr_identity__", None)
             if ret is None:
                 ret = key.lower()
                 key.__istr_identity__ = ret

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -37,7 +37,7 @@ class istr(str):
     __slots__ = ("__istr_identity__",)
 
     __is_istr__ = True
-    __istr_identity__: str | None = None
+    __istr_identity__: str | None
 
 
 _V = TypeVar("_V")
@@ -441,7 +441,7 @@ class _CIMixin:
 
     def _identity(self, key: str) -> str:
         if isinstance(key, istr):
-            ret = key.__istr_identity__
+            ret = getattr(key, '__istr_identity__', None)
             if ret is None:
                 ret = key.lower()
                 key.__istr_identity__ = ret

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -34,6 +34,8 @@ else:
 class istr(str):
     """Case insensitive str."""
 
+    __slots__ = ()
+
     __is_istr__ = True
     __istr_identity__: str | None = None
 


### PR DESCRIPTION
## What do these changes do?

Optimizes memory usage by preventing a dictionary to store attributes to be created on every `istr` instance.

## Are there changes in behavior for the user?

Users can no longer set attributes on the keys of the Python version of case-insensitive multidicts, mutable or otherwise.

## Related issue number

Fixes #1360.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
