### PR TITLE
docs: Update spelling wordlist and AGENTS.md checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Fixes #NNNN
 - [x] Documentation reflects the changes
 - [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
 - [x] Add a new news fragment into the `CHANGES/` folder
+- [x] `make doc-spelling` passes and any new technical words are added to `docs/spelling_wordlist.txt`
 ```
 
 Tick the boxes that actually apply. If a row does not apply (e.g. a

--- a/CHANGES/1343.contrib.1.rst
+++ b/CHANGES/1343.contrib.1.rst
@@ -1,0 +1,3 @@
+Added ``unparseable`` to the docs spelling list so news
+fragments can use the word without failing the spell check
+build -- by :user:`pctablet505`.

--- a/CHANGES/1343.contrib.1.rst
+++ b/CHANGES/1343.contrib.1.rst
@@ -1,3 +1,4 @@
-Added ``unparseable`` to the docs spelling list so news
-fragments can use the word without failing the spell check
-build -- by :user:`pctablet505`.
+Added ``init``, ``installable``, ``instantiation``, ``parametrization``,
+``parametrized``, ``postfix``, and ``unparseable`` to the docs spelling list
+so news fragments and docs can use these words without failing the spell
+check build -- by :user:`pctablet505`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -51,7 +51,10 @@ google
 gunicorn
 Gunicorn
 Indices
+init
 inplace
+installable
+instantiation
 ionaries
 IP
 IPv
@@ -78,10 +81,13 @@ Multipart
 mypy
 Nikolay
 param
+parametrization
+parametrized
 params
 performant
 pickable
 pickleable
+postfix
 pre
 proxied
 pyenv
@@ -109,6 +115,7 @@ toolset
 tuples
 un
 uncompiled
+unparseable
 upstr
 url
 urlencoded


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add `unparseable` to `docs/spelling_wordlist.txt` and backfill other
technical words already used in `CHANGES.rst` that the docs spell check
flags. Also add a `make doc-spelling` checklist item to the agent pull
request template in `AGENTS.md`.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Fixes #1343

## Checklist

- [x] I think the code is well written
- [ ] N/A Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] N/A If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
- [x] `make doc-spelling` passes and any new technical words are added to `docs/spelling_wordlist.txt`

Drafted with Kimi Code CLI; reviewed by operator.
