### PR TITLE
feat: add __slots__ to istr for lower memory use

### DIFF
--- a/CHANGES/1360.feature.rst
+++ b/CHANGES/1360.feature.rst
@@ -1,0 +1,2 @@
+Reduced the memory used by pure-Python ``istr`` instances
+-- by :user:`ltsyk`.

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -34,10 +34,18 @@ else:
 class istr(str):
     """Case insensitive str."""
 
-    # Avoid per-instance __dict__ when used as dict keys (issue #1360).
     __slots__ = ("__istr_identity__",)
+    __istr_identity__: str | None
 
     __is_istr__ = True
+
+    def __new__(cls, value: object = "") -> Self:
+        self = super().__new__(cls, value)
+        self.__istr_identity__ = None
+        return self
+
+    def __reduce__(self) -> tuple[type[Self], tuple[str]]:
+        return type(self), (str(self),)
 
 
 _V = TypeVar("_V")

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -449,7 +449,9 @@ class _CIMixin:
 
     def _identity(self, key: str) -> str:
         if isinstance(key, istr):
-            ret = key.__istr_identity__
+            # Protocol 0/1 unpickling bypasses istr.__new__, so the slot may
+            # be unset; getattr keeps those keys usable in CIMultiDict.
+            ret = getattr(key, "__istr_identity__", None)
             if ret is None:
                 ret = key.lower()
                 key.__istr_identity__ = ret

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -34,8 +34,10 @@ else:
 class istr(str):
     """Case insensitive str."""
 
+    # Avoid per-instance __dict__ when used as dict keys (issue #1360).
+    __slots__ = ("__istr_identity__",)
+
     __is_istr__ = True
-    __istr_identity__: str | None = None
 
 
 _V = TypeVar("_V")

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1249,6 +1249,12 @@ def test_create_multidict_from_existing_multidict_new_pairs() -> None:
     assert "h4" not in original
 
 
+def test_istr_has_no_instance_dict(
+    case_insensitive_str_class: type[istr],
+) -> None:
+    assert not hasattr(case_insensitive_str_class("key"), "__dict__")
+
+
 def test_convert_multidict_to_cimultidict_and_back(
     case_sensitive_multidict_class: type[MultiDict[str]],
     case_insensitive_multidict_class: type[CIMultiDict[str]],

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from multidict import MultiDict, MultiDictProxy, istr
+from multidict import CIMultiDict, MultiDict, MultiDictProxy, istr
 
 if TYPE_CHECKING:
     from conftest import MultidictImplementation
@@ -82,3 +82,28 @@ def test_load_istr_from_file(
         obj = pickle.load(f)
     assert s == obj
     assert isinstance(obj, case_insensitive_str_class)
+
+
+def test_load_istr_as_cimultidict_key(
+    case_insensitive_str_class: type[istr],
+    case_insensitive_multidict_class: type[CIMultiDict[str]],
+    multidict_implementation: "MultidictImplementation",
+    pickle_protocol: int,
+) -> None:
+    """Unpickled istr (incl. protocol 0/1) must work as a CIMultiDict key."""
+    istr_class_name = case_insensitive_str_class.__name__
+    pickle_file_basename = "-".join(
+        (
+            istr_class_name.lower(),
+            multidict_implementation.tag,
+        )
+    )
+    fname = f"{pickle_file_basename}.pickle.{pickle_protocol}"
+    p = here / fname
+    with p.open("rb") as f:
+        obj = pickle.load(f)
+    d = case_insensitive_multidict_class()
+    d[obj] = "v"
+    assert d[obj] == "v"
+    assert d["STR"] == "v"
+

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -106,4 +106,3 @@ def test_load_istr_as_cimultidict_key(
     d[obj] = "v"
     assert d[obj] == "v"
     assert d["STR"] == "v"
-


### PR DESCRIPTION
## Summary
Add `__slots__` for `istr` so case-insensitive keys do not allocate a per-instance `__dict__` (issue #1360).

Fixes #1360
