### PR TITLE
Pin the coverage core so the suite runs on Python 3.14

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -30,7 +30,14 @@ branch = true
 # `filterwarnings = error` that turns each test into an error. `ctrace`
 # reports `supports_dynamic_contexts`, and falls back to `pytrace` (which
 # also supports them) where the C tracer is unavailable, such as PyPy.
-core = ctrace
+# NOTE: Coveragepy is incompatible with dynamic context that gets enabled via
+# NOTE: `pytest-cov` through a CLI arg to pytest. Refs:
+# * https://github.com/aio-libs/multidict/pull/1393
+# * https://github.com/pytest-dev/pytest-cov/issues/755
+# * https://coverage.rtfd.io/en/latest/changes.html#version-7-15-3-2026-08-02
+# * https://github.com/coveragepy/coveragepy/issues/2200
+# * https://github.com/coveragepy/coveragepy/pull/2234
+core = ${COVERAGE_CORE-ctrace}
 cover_pylib = false
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # dynamic_context = test_function  # conflicts with `pytest-cov` if set here

--- a/.coveragerc
+++ b/.coveragerc
@@ -22,6 +22,15 @@ show_missing = true
 
 [run]
 branch = true
+# `pytest-cov` switches contexts through `Coverage.switch_context()` at
+# runtime (see `--cov-context=test` in `pytest.ini`) rather than through the
+# `dynamic_context` setting below. Coverage's core selection only inspects
+# that setting, so on Python 3.14 it picks `sysmon`, which cannot record
+# dynamic contexts, and then warns from every `switch_context()` call. With
+# `filterwarnings = error` that turns each test into an error. `ctrace`
+# reports `supports_dynamic_contexts`, and falls back to `pytrace` (which
+# also supports them) where the C tracer is unavailable, such as PyPy.
+core = ctrace
 cover_pylib = false
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # dynamic_context = test_function  # conflicts with `pytest-cov` if set here

--- a/CHANGES/1393.contrib.rst
+++ b/CHANGES/1393.contrib.rst
@@ -1,0 +1,5 @@
+Pinned ``coverage`` to the ``ctrace`` measurement core so the test suite runs
+on Python 3.14. Coverage picks ``sysmon`` there, which cannot record the
+dynamic contexts ``pytest-cov`` switches at runtime, and the resulting warning
+became an error under the suite's ``filterwarnings`` setting
+-- by :user:`rodrigobnogueira`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Ask Coverage.py for the `ctrace` measurement core, so the suite runs on
Python 3.14.

Every `3.14` and `3.14t` job on `master` currently fails with one error per
test (3340 of them), while the "Re-run the failing tests with maximum
verbosity" step in the same job reports `1666 passed`. Every open PR inherits
this as soon as it merges `master`.

Coverage chooses its core before the suite starts and avoids `sysmon` when
dynamic contexts are configured, but it only inspects the `dynamic_context`
setting in `.coveragerc`, which this project deliberately leaves unset because
it conflicts with `pytest-cov`. `pytest-cov` switches contexts at runtime
through `Coverage.switch_context()` instead (`--cov-context=test` in
`pytest.ini`), which core selection cannot see. So on 3.14 `sysmon` is picked,
`switch_context()` warns `no-sysmon-context` on every call, and
`filterwarnings = error` turns each warning into an error at test setup.

`ctrace` reports `supports_dynamic_contexts`, and falls back to `pytrace`,
which also supports them, where the C tracer is unavailable. PyPy is therefore
unaffected.

## Are there changes in behavior for the user?

No. This only affects how the test suite measures coverage.

## Is it a substantial burden for the maintainers to support this?

No. One setting in `.coveragerc`, with a comment explaining why it is pinned.
No workflow change.

## Related issue number

None filed. `master` has been red on these jobs since at least 2026-08-06.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist - N/A, this is a test-infrastructure fix
- [ ] Documentation reflects the changes - N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` - N/A, no such file
- [x] Add a new news fragment into the `CHANGES/` folder

## Verification

Full suite with coverage enabled, exactly as CI invokes it:

| Python | before | after |
|---|---|---|
| 3.14 | errors, one per test | 1661 passed |
| 3.10 | 1661 passed | 1661 passed |

`pre-commit run --all-files` and `make doc-spelling` are clean.
