### PR TITLE
Fix self-extension in MultiDict

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -218,12 +218,6 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
-    env:
-      # Python 3.14 defaults coverage.py to sysmon, which does not support
-      # pytest-cov's dynamic test contexts. PyPy does not ship CTracer, so
-      # use its pytrace core instead.
-      COVERAGE_CORE: >-
-        ${{ startsWith(matrix.pyver, 'pypy') && 'pytrace' || 'ctrace' }}
 
     continue-on-error: >-
       ${{

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -218,6 +218,12 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
+    env:
+      # Python 3.14 defaults coverage.py to sysmon, which does not support
+      # pytest-cov's dynamic test contexts. PyPy does not ship CTracer, so
+      # use its pytrace core instead.
+      COVERAGE_CORE: >-
+        ${{ startsWith(matrix.pyver, 'pypy') && 'pytrace' || 'ctrace' }}
 
     continue-on-error: >-
       ${{

--- a/CHANGES/1398.bugfix.rst
+++ b/CHANGES/1398.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a segmentation fault when extending a multidict with itself
+-- by :user:`cananoo`.

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -76,14 +76,28 @@ _multidict_extend(MultiDictObject *self, PyObject *arg, PyObject *kwds,
     }
 
     if (arg != NULL) {
+        MultiDictObject *other = NULL;
         if (AnyMultiDict_Check(state, arg)) {
-            MultiDictObject *other = (MultiDictObject *)arg;
-            if (md_update_from_ht(self, other, op) < 0) {
-                goto fail;
-            }
+            other = (MultiDictObject *)arg;
         } else if (AnyMultiDictProxy_Check(state, arg)) {
-            MultiDictObject *other = ((MultiDictProxyObject *)arg)->md;
-            if (md_update_from_ht(self, other, op) < 0) {
+            other = ((MultiDictProxyObject *)arg)->md;
+        }
+
+        if (other != NULL) {
+            if (other == self) {
+                PyObject *items = multidict_itemsview_new(other);
+                if (items == NULL) {
+                    goto fail;
+                }
+                seq = PySequence_List(items);
+                Py_DECREF(items);
+                if (seq == NULL) {
+                    goto fail;
+                }
+                if (md_update_from_seq(self, seq, op) < 0) {
+                    goto fail;
+                }
+            } else if (md_update_from_ht(self, other, op) < 0) {
                 goto fail;
             }
         } else if (PyDict_CheckExact(arg)) {

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -76,16 +76,16 @@ _multidict_extend(MultiDictObject* self, PyObject* arg, PyObject* kwds,
     }
 
     if (arg != NULL) {
-        MultiDictObject *other = NULL;
+        MultiDictObject* other = NULL;
         if (AnyMultiDict_Check(state, arg)) {
-            other = (MultiDictObject *)arg;
+            other = (MultiDictObject*)arg;
         } else if (AnyMultiDictProxy_Check(state, arg)) {
-            other = ((MultiDictProxyObject *)arg)->md;
+            other = ((MultiDictProxyObject*)arg)->md;
         }
 
         if (other != NULL) {
             if (other == self) {
-                PyObject *items = multidict_itemsview_new(other);
+                PyObject* items = multidict_itemsview_new(other);
                 if (items == NULL) {
                     goto fail;
                 }

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -793,6 +793,11 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         kwargs: Mapping[str, _V],
     ) -> Iterator[int | _Entry[_V]]:
         identity_func = self._identity
+        if isinstance(arg, MultiDictProxy):
+            if arg._md is self:
+                arg = [(e.key, e.value) for e in self._keys.iter_entries()]
+        elif arg is self:
+            arg = [(e.key, e.value) for e in self._keys.iter_entries()]
         if arg:
             if isinstance(arg, MultiDictProxy):
                 arg = arg._md

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1309,6 +1309,21 @@ def test_extend_does_not_alter_refcount(
     assert sys.getrefcount(original) == original_refcount
 
 
+@pytest.mark.parametrize("use_proxy", (False, True), ids=("self", "proxy"))
+def test_extend_with_itself(
+    any_multidict_class: type[MultiDict[int]],
+    any_multidict_proxy_class: type[MultiDictProxy[int]],
+    use_proxy: bool,
+) -> None:
+    md = any_multidict_class((str(index), index) for index in range(6))
+    source = any_multidict_proxy_class(md) if use_proxy else md
+
+    md.extend(source)
+
+    expected = [(str(index), index) for index in range(6)]
+    assert list(md.items()) == expected * 2
+
+
 @pytest.mark.skipif(IS_PYPY, reason="getrefcount is not supported on PyPy")
 def test_update_does_not_alter_refcount(
     case_sensitive_multidict_class: type[MultiDict[str]],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Make `MultiDict.extend` safe when the source is the destination itself. The C extension and pure Python implementation snapshot the original items before appending, including proxy aliases.

## Are there changes in behavior for the user?

Yes. `mapping.extend(mapping)` now completes and appends exactly one copy of the original entries in their original order.

## Is it a substantial burden for the maintainers to support this?

No. The change is limited to the existing self-alias paths and regression coverage for both implementations and proxy aliases.

## Related issue number

Fixes #1398

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A: the existing API documentation does not describe self-extension semantics)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A: this repository has no `CONTRIBUTORS.txt`)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details</summary>

- Linux Python 3.12 build with the default C extension and pure Python implementation: `1662 passed, 7 deselected`
- `MULTIDICT_NO_EXTENSIONS=1` self and proxy smoke coverage for `MultiDict` and `CIMultiDict`: passed
- Ruff checks and formatting: passed
- clang-format check: passed
- `make doc-spelling`: the current tree reports eight existing spelling warnings in `CHANGES.rst`; the new fragment introduced no spelling warning

</details>

Drafted with OpenAI Codex (GPT-5); pending human review.
