### PR TITLE
Explicitly mark empty_htkeys as const

### DIFF
--- a/CHANGES/1405.misc.rst
+++ b/CHANGES/1405.misc.rst
@@ -1,0 +1,12 @@
+Explicitly marked empty_htkeys as const.
+
+Moved the structure to .rodata linker section.
+
+Unexpected modification of the structure will lead to segfault instead
+of corrupting the data and fail fast.
+
+.rodata is mount as read-only-mapped, it is shared well across
+multiple threads without cache misses.
+
+The change is pretty trivial, it is made for the sake of correctness,
+not for speedup.

--- a/CHANGES/1405.misc.rst
+++ b/CHANGES/1405.misc.rst
@@ -10,3 +10,6 @@ multiple threads without cache misses.
 
 The change is pretty trivial, it is made for the sake of correctness,
 not for speedup.
+
+-- by :user:`asvetlov`.
+

--- a/CHANGES/1405.misc.rst
+++ b/CHANGES/1405.misc.rst
@@ -1,11 +1,11 @@
-Explicitly marked empty_htkeys as const.
+Explicitly marked ``empty_htkeys`` as ``const``.
 
-Moved the structure to .rodata linker section.
+Moved the structure to ``.rodata`` linker section.
 
 Unexpected modification of the structure will lead to segfault instead
 of corrupting the data and fail fast.
 
-.rodata is mount as read-only-mapped, it is shared well across
+``.rodata`` is mount as read-only-mapped, it is shared well across
 multiple threads without cache misses.
 
 The change is pretty trivial, it is made for the sake of correctness,

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -319,7 +319,7 @@ md_init(MultiDictObject* md, mod_state* state, bool is_ci, Py_ssize_t minused)
     htkeys_t* new_keys;
 
     if (minused <= USABLE_FRACTION(HT_MINSIZE)) {
-        md->keys = (htkeys_t *)&empty_htkeys;
+        md->keys = (htkeys_t*)&empty_htkeys;
         ASSERT_CONSISTENT(md, false);
         return 0;
     }
@@ -364,7 +364,7 @@ md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
         }
         md->keys = keys;
     } else {
-        md->keys = (htkeys_t *)&empty_htkeys;
+        md->keys = (htkeys_t*)&empty_htkeys;
     }
     ASSERT_CONSISTENT(md, false);
     return 0;
@@ -1895,7 +1895,7 @@ md_clear(MultiDictObject* md)
     md->used = 0;
     if (md->keys != &empty_htkeys) {
         htkeys_free(md->keys);
-        md->keys = (htkeys_t *)&empty_htkeys;
+        md->keys = (htkeys_t*)&empty_htkeys;
     }
     ASSERT_CONSISTENT(md, false);
     return 0;

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -319,7 +319,7 @@ md_init(MultiDictObject *md, mod_state *state, bool is_ci, Py_ssize_t minused)
     htkeys_t *new_keys;
 
     if (minused <= USABLE_FRACTION(HT_MINSIZE)) {
-        md->keys = (htkeys_t*) &empty_htkeys;
+        md->keys = (htkeys_t *)&empty_htkeys;
         ASSERT_CONSISTENT(md, false);
         return 0;
     }
@@ -364,7 +364,7 @@ md_clone_from_ht(MultiDictObject *md, MultiDictObject *other)
         }
         md->keys = keys;
     } else {
-        md->keys = (htkeys_t*) &empty_htkeys;
+        md->keys = (htkeys_t *)&empty_htkeys;
     }
     ASSERT_CONSISTENT(md, false);
     return 0;
@@ -1895,7 +1895,7 @@ md_clear(MultiDictObject *md)
     md->used = 0;
     if (md->keys != &empty_htkeys) {
         htkeys_free(md->keys);
-        md->keys = (htkeys_t*) &empty_htkeys;
+        md->keys = (htkeys_t *)&empty_htkeys;
     }
     ASSERT_CONSISTENT(md, false);
     return 0;

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -319,7 +319,7 @@ md_init(MultiDictObject *md, mod_state *state, bool is_ci, Py_ssize_t minused)
     htkeys_t *new_keys;
 
     if (minused <= USABLE_FRACTION(HT_MINSIZE)) {
-        md->keys = &empty_htkeys;
+        md->keys = (htkeys_t*) &empty_htkeys;
         ASSERT_CONSISTENT(md, false);
         return 0;
     }
@@ -364,7 +364,7 @@ md_clone_from_ht(MultiDictObject *md, MultiDictObject *other)
         }
         md->keys = keys;
     } else {
-        md->keys = &empty_htkeys;
+        md->keys = (htkeys_t*) &empty_htkeys;
     }
     ASSERT_CONSISTENT(md, false);
     return 0;
@@ -1895,7 +1895,7 @@ md_clear(MultiDictObject *md)
     md->used = 0;
     if (md->keys != &empty_htkeys) {
         htkeys_free(md->keys);
-        md->keys = &empty_htkeys;
+        md->keys = (htkeys_t*) &empty_htkeys;
     }
     ASSERT_CONSISTENT(md, false);
     return 0;

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -241,7 +241,7 @@ estimate_log2_keysize(Py_ssize_t n)
  * See https://github.com/python/cpython/pull/127568#discussion_r1868070614
  * for the rationale of using log2_index_bytes=3 instead of 0.
  */
-static htkeys_t empty_htkeys = {
+static const htkeys_t empty_htkeys = {
     0, /* log2_size */
     3, /* log2_index_bytes */
     0, /* usable (immutable) */


### PR DESCRIPTION
The linker moves the structure to .rodata section.
1. Unexpected modification of the structure leads to segfault instead of corrupting the data. Fail fast.
2. .rodata is mount as read-only-mapped, it is shared well across multiple threads without cashe misses.

The change is pretty subtle, it is made for the sake of correctness, not for speedup.
