### PR TITLE
Use faster identity comparison function

### DIFF
--- a/CHANGES/1406.feature.rst
+++ b/CHANGES/1406.feature.rst
@@ -1,7 +1,7 @@
 Optimized key identity comparison for C Extension.
 
 Now it uses fast path that is equal to ``PyUnicode_Equal()`` from
-Python 3.14+ but without redundant tyupe checks.
+Python 3.14+ but without redundant type checks.
 
 Benchmarks for ``getall()`` shows 10% speedup for this change. 
 

--- a/CHANGES/1406.feature.rst
+++ b/CHANGES/1406.feature.rst
@@ -1,0 +1,8 @@
+Optimized key identity comparison for C Extension.
+
+Now it uses fast path that is equal to ``PyUnicode_Equal()`` from
+Python 3.14+ but without redundant tyupe checks.
+
+Benchmarks for ``getall()`` shows 10% speedup for this change. 
+
+-- by :user:`asvetlov`.

--- a/CHANGES/1406.feature.rst
+++ b/CHANGES/1406.feature.rst
@@ -5,4 +5,4 @@ Python 3.14+ but without redundant type checks.
 
 Benchmarks for ``getall()`` shows 10% speedup for this change. 
 
--- by :user:`asvetlov`.
+-- by :user:`asvetlov`

--- a/CHANGES/1406.misc.rst
+++ b/CHANGES/1406.misc.rst
@@ -1,6 +1,6 @@
 Optimized key identity comparison for C Extension.
 
-Now it uses fast path that is equal to ``PyUnicode_Equal()`` from
+Now it uses fast path that is equal to :c:func:`PyUnicode_Equal` from
 Python 3.14+ but without redundant type checks.
 
 -- by :user:`asvetlov`

--- a/CHANGES/1406.misc.rst
+++ b/CHANGES/1406.misc.rst
@@ -3,6 +3,4 @@ Optimized key identity comparison for C Extension.
 Now it uses fast path that is equal to ``PyUnicode_Equal()`` from
 Python 3.14+ but without redundant type checks.
 
-Benchmarks for ``getall()`` shows 10% speedup for this change. 
-
 -- by :user:`asvetlov`

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -118,8 +118,8 @@ _str_cmp(PyObject* s1, PyObject* s2)
         return 0;
     }
 
-    const void *data1 = PyUnicode_DATA(s1);
-    const void *data2 = PyUnicode_DATA(s2);
+    const void* data1 = PyUnicode_DATA(s1);
+    const void* data2 = PyUnicode_DATA(s2);
     return (memcmp(data1, data2, len * kind) == 0);
 }
 

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -17,6 +17,7 @@ extern "C" {
 #include "istr.h"
 #include "state.h"
 
+
 typedef struct _md_pos {
     Py_ssize_t pos;
     uint64_t version;
@@ -100,16 +101,27 @@ _md_dump(MultiDictObject *md);
 static inline int
 _str_cmp(PyObject *s1, PyObject *s2)
 {
-    PyObject *ret = PyUnicode_RichCompare(s1, s2, Py_EQ);
-    if (Py_IsTrue(ret)) {
-        Py_DECREF(ret);
+    /* implementation is borrowed from PyUnicode_Equal() but without
+       type checks, arguments are identities that are always strings */
+    assert(PyUnicode_Check(s1));
+    assert(PyUnicode_Check(s2));
+
+    if (s1 == s2) {
         return 1;
-    } else if (ret == NULL) {
-        return -1;
-    } else {
-        Py_DECREF(ret);
+    }
+    Py_ssize_t len = PyUnicode_GET_LENGTH(s1);
+    if (PyUnicode_GET_LENGTH(s2) != len) {
         return 0;
     }
+
+    int kind = PyUnicode_KIND(s1);
+    if (PyUnicode_KIND(s2) != kind) {
+        return 0;
+    }
+
+    const void *data1 = PyUnicode_DATA(s1);
+    const void *data2 = PyUnicode_DATA(s2);
+    return (memcmp(data1, data2, len * kind) == 0);
 }
 
 static inline PyObject *

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -17,7 +17,6 @@ extern "C" {
 #include "istr.h"
 #include "state.h"
 
-
 typedef struct _md_pos {
     Py_ssize_t pos;
     uint64_t version;

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -97,7 +97,7 @@ _md_dump(MultiDictObject* md);
 #define ASSERT_CONSISTENT(md, update) assert(1)
 #endif
 
-static inline int
+static inline bool
 _str_cmp(PyObject* s1, PyObject* s2)
 {
     /* implementation is borrowed from PyUnicode_Equal() but without
@@ -106,16 +106,16 @@ _str_cmp(PyObject* s1, PyObject* s2)
     assert(PyUnicode_Check(s2));
 
     if (s1 == s2) {
-        return 1;
+        return true;
     }
     Py_ssize_t len = PyUnicode_GET_LENGTH(s1);
     if (PyUnicode_GET_LENGTH(s2) != len) {
-        return 0;
+        return false;
     }
 
     int kind = PyUnicode_KIND(s1);
     if (PyUnicode_KIND(s2) != kind) {
-        return 0;
+        return false;
     }
 
     const void* data1 = PyUnicode_DATA(s1);
@@ -574,11 +574,7 @@ md_del(MultiDictObject* md, PyObject* key)
         if (hash != entry->hash) {
             continue;
         }
-        int tmp = _str_cmp(entry->identity, identity);
-        if (tmp < 0) {
-            goto fail;
-        }
-        if (tmp == 0) {
+        if (!_str_cmp(entry->identity, identity)) {
             continue;
         }
 
@@ -727,12 +723,7 @@ md_find_next(md_finder_t* finder, PyObject** pkey, PyObject** pvalue)
         if (entry->hash != finder->hash) {
             continue;
         }
-        int tmp = _str_cmp(finder->identity, entry->identity);
-        if (tmp < 0) {
-            ret = -1;
-            goto cleanup;
-        }
-        if (tmp == 0) {
+        if (!_str_cmp(finder->identity, entry->identity)) {
             continue;
         }
 
@@ -813,8 +804,7 @@ md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
         if (hash != entry->hash) {
             continue;
         }
-        int tmp = _str_cmp(identity, entry->identity);
-        if (tmp > 0) {
+        if (_str_cmp(identity, entry->identity)) {
             Py_DECREF(identity);
             if (pret != NULL) {
                 *pret = _md_ensure_key(md, entry);
@@ -823,8 +813,6 @@ md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
                 }
             }
             return 1;
-        } else if (tmp < 0) {
-            goto fail;
         }
     }
 
@@ -866,13 +854,10 @@ md_get_one(MultiDictObject* md, PyObject* key, PyObject** ret)
         if (hash != entry->hash) {
             continue;
         }
-        int tmp = _str_cmp(identity, entry->identity);
-        if (tmp > 0) {
+        if (_str_cmp(identity, entry->identity)) {
             Py_DECREF(identity);
             *ret = Py_NewRef(entry->value);
             return 1;
-        } else if (tmp < 0) {
-            goto fail;
         }
     }
 
@@ -963,14 +948,11 @@ md_set_default(MultiDictObject* md, PyObject* key, PyObject* value,
         if (hash != entry->hash) {
             continue;
         }
-        int tmp = _str_cmp(identity, entry->identity);
-        if (tmp > 0) {
+        if (_str_cmp(identity, entry->identity)) {
             Py_DECREF(identity);
             ASSERT_CONSISTENT(md, false);
             *result = Py_NewRef(entry->value);
             return 1;
-        } else if (tmp < 0) {
-            goto fail;
         }
     }
 
@@ -1015,8 +997,7 @@ md_pop_one(MultiDictObject* md, PyObject* key, PyObject** ret)
         if (hash != entry->hash) {
             continue;
         }
-        int tmp = _str_cmp(identity, entry->identity);
-        if (tmp > 0) {
+        if (_str_cmp(identity, entry->identity)) {
             value = Py_NewRef(entry->value);
             if (_md_del_at(md, iter.slot, entry) < 0) {
                 goto fail;
@@ -1026,8 +1007,6 @@ md_pop_one(MultiDictObject* md, PyObject* key, PyObject** ret)
             md->version = NEXT_VERSION(md->state);
             ASSERT_CONSISTENT(md, false);
             return 1;
-        } else if (tmp < 0) {
-            goto fail;
         }
     }
     Py_DECREF(identity);
@@ -1072,8 +1051,7 @@ md_pop_all(MultiDictObject* md, PyObject* key, PyObject** ret)
         if (hash != entry->hash) {
             continue;
         }
-        int tmp = _str_cmp(identity, entry->identity);
-        if (tmp > 0) {
+        if (_str_cmp(identity, entry->identity)) {
             if (lst == NULL) {
                 lst = PyList_New(1);
                 if (lst == NULL) {
@@ -1089,8 +1067,6 @@ md_pop_all(MultiDictObject* md, PyObject* key, PyObject** ret)
                 goto fail;
             }
             md->version = NEXT_VERSION(md->state);
-        } else if (tmp < 0) {
-            goto fail;
         }
     }
 
@@ -1231,8 +1207,7 @@ _md_update(MultiDictObject* md, Py_hash_t hash, PyObject* identity,
         if (hash != entry->hash) {
             continue;
         }
-        int tmp = _str_cmp(identity, entry->identity);
-        if (tmp > 0) {
+        if (_str_cmp(identity, entry->identity)) {
             if (!found) {
                 found = true;
                 if (entry->key == NULL) {
@@ -1252,8 +1227,6 @@ _md_update(MultiDictObject* md, Py_hash_t hash, PyObject* identity,
                     goto fail;
                 }
             }
-        } else if (tmp < 0) {
-            goto fail;
         }
     }
 
@@ -1283,11 +1256,8 @@ _md_merge(MultiDictObject* md, Py_hash_t hash, PyObject* identity,
         if (hash != entry->hash) {
             continue;
         }
-        int tmp = _str_cmp(identity, entry->identity);
-        if (tmp > 0) {
+        if (_str_cmp(identity, entry->identity)) {
             return 0;
-        } else if (tmp < 0) {
-            goto fail;
         }
     }
 
@@ -1694,15 +1664,12 @@ md_eq(MultiDictObject* md, MultiDictObject* other)
             return 0;
         }
 
-        int cmp = _str_cmp(entry1->identity, entry2->identity);
-        if (cmp < 0) {
-            return -1;
-        };
-        if (cmp == 0) {
+        if (!_str_cmp(entry1->identity, entry2->identity)) {
             return 0;
         }
 
-        cmp = PyObject_RichCompareBool(entry1->value, entry2->value, Py_EQ);
+        int cmp =
+            PyObject_RichCompareBool(entry1->value, entry2->value, Py_EQ);
         if (cmp < 0) {
             return -1;
         };

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -721,6 +721,18 @@ class BaseMultiDictTest:
         assert list(obj.items()) == [("a", 1), ("b", 2)]
         assert arg == deque([("a", 1)])
 
+    def test_ucs2_ucs4_comparison(self, cls: type[MultiDict[str]]) -> None:
+        expected = [
+            ("k\u00e9y", "1"),  # UCS-1
+            ("k\u4f60y", "2"),  # UCS-2
+            ("k\U0001f600y", "3"),  # UCS-4
+            ("k\U0001f600y1", "4"),  # UCS-4
+            ("k\U0001f600y2", "5"),  # UCS-4
+        ]
+        obj = cls(expected)
+        for k, v in expected:
+            assert obj[k] == v
+
 
 class TestMultiDict(BaseMultiDictTest):
     @pytest.fixture(


### PR DESCRIPTION
It is equal to PyUnicode_Equal() from Python 3.14+ but without type checks, arguments are always strings.