### PR TITLE
Fix repeated multidict initialization leak

### DIFF
--- a/CHANGES/1412.bugfix.rst
+++ b/CHANGES/1412.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a memory leak when ``MultiDict`` and ``CIMultiDict`` instances are
+initialized more than once -- by :user:`asvetlov`.

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -545,7 +545,7 @@ multidict_tp_init(MultiDictObject* self, PyObject* args, PyObject* kwds)
     if (size < 0) {
         goto fail;
     }
-    int tmp = _multidict_clone_fast(state, self, false, args, kwds);
+    int tmp = _multidict_clone_fast(state, self, false, arg, kwds);
     if (tmp < 0) {
         goto fail;
     } else if (tmp == 1) {
@@ -1003,7 +1003,7 @@ cimultidict_tp_init(MultiDictObject* self, PyObject* args, PyObject* kwds)
     if (size < 0) {
         goto fail;
     }
-    int tmp = _multidict_clone_fast(state, self, true, args, kwds);
+    int tmp = _multidict_clone_fast(state, self, true, arg, kwds);
     if (tmp < 0) {
         goto fail;
     } else if (tmp == 1) {

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -317,35 +317,36 @@ md_reserve(MultiDictObject* md, Py_ssize_t extra_size)
 }
 
 static inline int
+md_clear(MultiDictObject* md);
+
+static inline int
 md_init(MultiDictObject* md, mod_state* state, bool is_ci, Py_ssize_t minused)
 {
+    const uint8_t log2_max_presize = 17;
+    const Py_ssize_t max_presize = ((Py_ssize_t)1) << log2_max_presize;
+    uint8_t log2_newsize;
+    htkeys_t* new_keys = (htkeys_t*)&empty_htkeys;
+
+    if (minused > USABLE_FRACTION(HT_MINSIZE)) {
+        /* There are no strict guarantee that returned dict can contain minused
+         * items without resize.  So we create medium size dict instead of very
+         * large dict or MemoryError.
+         */
+        if (minused > USABLE_FRACTION(max_presize)) {
+            log2_newsize = log2_max_presize;
+        } else {
+            log2_newsize = estimate_log2_keysize(minused);
+        }
+
+        new_keys = htkeys_new(log2_newsize);
+        if (new_keys == NULL) return -1;
+    }
+
+    md_clear(md);
     md->state = state;
     md->is_ci = is_ci;
     md->used = 0;
     md->version = NEXT_VERSION(md->state);
-
-    const uint8_t log2_max_presize = 17;
-    const Py_ssize_t max_presize = ((Py_ssize_t)1) << log2_max_presize;
-    uint8_t log2_newsize;
-    htkeys_t* new_keys;
-
-    if (minused <= USABLE_FRACTION(HT_MINSIZE)) {
-        md->keys = (htkeys_t*)&empty_htkeys;
-        ASSERT_CONSISTENT(md, false);
-        return 0;
-    }
-    /* There are no strict guarantee that returned dict can contain minused
-     * items without resize.  So we create medium size dict instead of very
-     * large dict or MemoryError.
-     */
-    if (minused > USABLE_FRACTION(max_presize)) {
-        log2_newsize = log2_max_presize;
-    } else {
-        log2_newsize = estimate_log2_keysize(minused);
-    }
-
-    new_keys = htkeys_new(log2_newsize);
-    if (new_keys == NULL) return -1;
     md->keys = new_keys;
     ASSERT_CONSISTENT(md, false);
     return 0;
@@ -355,13 +356,14 @@ static inline int
 md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
 {
     ASSERT_CONSISTENT(other, false);
-    md->state = other->state;
-    md->used = other->used;
-    md->version = other->version;
-    md->is_ci = other->is_ci;
+    mod_state* state = other->state;
+    Py_ssize_t used = other->used;
+    uint64_t version = other->version;
+    bool is_ci = other->is_ci;
+    htkeys_t* keys = (htkeys_t*)&empty_htkeys;
     if (other->keys != &empty_htkeys) {
         size_t size = htkeys_sizeof(other->keys);
-        htkeys_t* keys = PyMem_Malloc(size);
+        keys = PyMem_Malloc(size);
         if (keys == NULL) {
             PyErr_NoMemory();
             return -1;
@@ -373,10 +375,13 @@ md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
             Py_XINCREF(entry->key);
             Py_XINCREF(entry->value);
         }
-        md->keys = keys;
-    } else {
-        md->keys = (htkeys_t*)&empty_htkeys;
     }
+    md_clear(md);
+    md->state = state;
+    md->used = used;
+    md->version = version;
+    md->is_ci = is_ci;
+    md->keys = keys;
     ASSERT_CONSISTENT(md, false);
     return 0;
 }

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1309,6 +1309,32 @@ def test_convert_multidict_to_cimultidict_eq(
     )
 
 
+def test_reinitialize_releases_previous_values(
+    any_multidict_class: type[MultiDict[object]],
+) -> None:
+    class Value:
+        pass
+
+    value = Value()
+    value_ref = weakref.ref(value)
+    d = any_multidict_class([("old", value)])
+    del value
+
+    d.__init__([("new", "value")])  # type: ignore[misc]
+
+    assert value_ref() is None
+    assert list(d.items()) == [("new", "value")]
+
+    source = any_multidict_class([("source", "value")])
+    d.__init__(source)  # type: ignore[misc]
+
+    assert list(d.items()) == [("source", "value")]
+
+    d.__init__(d)  # type: ignore[misc]
+
+    assert list(d.items()) == [("source", "value")]
+
+
 @pytest.mark.skipif(IS_PYPY, reason="getrefcount is not supported on PyPy")
 def test_extend_does_not_alter_refcount(
     case_sensitive_multidict_class: type[MultiDict[str]],

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1322,6 +1322,7 @@ def test_reinitialize_releases_previous_values(
 
     d.__init__([("new", "value")])  # type: ignore[misc]
 
+    gc.collect()
     assert value_ref() is None
     assert list(d.items()) == [("new", "value")]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixed the C extension to release an existing table before replacing it during repeated initialization. The fast clone path now receives the supplied mapping and handles self-initialization correctly.

## Are there changes in behavior for the user?

Yes. Reinitializing a C-extension ``MultiDict`` or ``CIMultiDict`` no longer retains the replaced values. Initialization from a matching multidict, including itself, now preserves its entries.

## Is it a substantial burden for the maintainers to support this?

No. The change uses the existing table cleanup path and adds coverage for direct, clone, and self initialization.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` N/A, already listed
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: C extension, 1665 passed. Pure Python, 852 passed with 813 C-extension cases deselected.

Documentation spelling: the new fragment passed; the target remains blocked by five existing misspellings in `CHANGES.rst`.
</details>

Drafted with GitHub Copilot App 1.0.83-5; reviewed by @asvetlov.