### PR TITLE
Fix items view set operation leak

### DIFF
--- a/CHANGES/1413.bugfix.rst
+++ b/CHANGES/1413.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a reference leak in items-view set operations
+-- by :user:`asvetlov`.

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -569,6 +569,7 @@ multidict_itemsview_or2(_Multidict_ViewObject *self, PyObject *other)
                 goto fail;
             }
             tmp = PySet_Contains(tmp_set, tpl);
+            Py_DECREF(tpl);
             if (tmp < 0) {
                 goto fail;
             }
@@ -678,6 +679,7 @@ multidict_itemsview_sub1(_Multidict_ViewObject *self, PyObject *other)
                 goto fail;
             }
             tmp = PySet_Contains(tmp_set, tpl);
+            Py_DECREF(tpl);
             if (tmp < 0) {
                 goto fail;
             }

--- a/tests/isolated/multidict_itemsview_set_operations.py
+++ b/tests/isolated/multidict_itemsview_set_operations.py
@@ -1,0 +1,41 @@
+import gc
+
+import objgraph  # type: ignore[import-untyped]
+
+from multidict import MultiDict
+
+
+class SubtractionValue:
+    pass
+
+
+class ReflectedUnionValue:
+    pass
+
+
+def _run_isolated_case() -> None:
+    for _ in range(100):
+        subtraction_value = SubtractionValue()
+        subtraction_md = MultiDict([("key", subtraction_value)])
+        subtraction_result = subtraction_md.items() - set()
+        del subtraction_result, subtraction_md, subtraction_value
+
+    for _ in range(100):
+        reflected_union_value = ReflectedUnionValue()
+        reflected_union_md = MultiDict([("key", reflected_union_value)])
+        reflected_union_result = set() | reflected_union_md.items()
+        del reflected_union_result, reflected_union_md, reflected_union_value
+
+    gc.collect()
+    leaked_subtraction = len(objgraph.by_type("SubtractionValue"))
+    leaked_reflected_union = len(objgraph.by_type("ReflectedUnionValue"))
+    assert leaked_subtraction == 0, (
+        f"{leaked_subtraction} subtraction values not collected by GC"
+    )
+    assert leaked_reflected_union == 0, (
+        f"{leaked_reflected_union} reflected union values not collected by GC"
+    )
+
+
+if __name__ == "__main__":
+    _run_isolated_case()

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -17,6 +17,7 @@ IS_PYPY = platform.python_implementation() == "PyPy"
         "multidict_update_multidict.py",
         "multidict_type_leak.py",
         "multidict_type_leak_items_values.py",
+        "multidict_itemsview_set_operations.py",
         "multidict_pop.py",
     ),
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixed a C-extension reference leak in items-view subtraction and reflected union by releasing each temporary tuple after the set-membership check. Added isolated leak coverage for both operations.

## Are there changes in behavior for the user?

No. Items-view set operations retain their existing results and now release temporary objects correctly.

## Is it a substantial burden for the maintainers to support this?

No. The regression test follows the existing isolated leak-test pattern.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` N/A, existing contributor
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: `python -m pytest -q` passed with the default C extension and after a `MULTIDICT_NO_EXTENSIONS=1` reinstall, 1662 passed on each run.

Lint: changed-file pre-commit hooks passed.

Docs spelling: `make doc-spelling` was blocked by five pre-existing misspellings in `CHANGES.rst`: `parametrization`, `postfix`, `instantiation`, `init`, and `parametrized`.
</details>

Drafted with GitHub Copilot App 1.0.83-5; pending review by asvetlov.