### PR TITLE
Fix heap type reference leak

### DIFF
--- a/CHANGES/1415.bugfix.rst
+++ b/CHANGES/1415.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a memory leak when destroying C-extension multidict instances
+and proxies -- by :user:`asvetlov`.

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -507,12 +507,12 @@ multidict_tp_richcompare(MultiDictObject* self, PyObject* other, int op)
 static void
 multidict_tp_dealloc(MultiDictObject* self)
 {
-    PyTypeObject *tp = Py_TYPE(self);
+    PyTypeObject* tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
     Py_TRASHCAN_BEGIN(self, multidict_tp_dealloc)
         PyObject_ClearWeakRefs((PyObject*)self);
     md_clear(self);
-    tp->tp_free((PyObject *)self);
+    tp->tp_free((PyObject*)self);
     Py_DECREF(tp);
     Py_TRASHCAN_END  // there should be no code after this
 }
@@ -1194,11 +1194,11 @@ multidict_proxy_tp_richcompare(MultiDictProxyObject* self, PyObject* other,
 static void
 multidict_proxy_tp_dealloc(MultiDictProxyObject* self)
 {
-    PyTypeObject *tp = Py_TYPE(self);
+    PyTypeObject* tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
     PyObject_ClearWeakRefs((PyObject*)self);
     Py_XDECREF(self->md);
-    tp->tp_free((PyObject *)self);
+    tp->tp_free((PyObject*)self);
     Py_DECREF(tp);
 }
 

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -493,11 +493,13 @@ multidict_tp_richcompare(MultiDictObject *self, PyObject *other, int op)
 static void
 multidict_tp_dealloc(MultiDictObject *self)
 {
+    PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
     Py_TRASHCAN_BEGIN(self, multidict_tp_dealloc)
         PyObject_ClearWeakRefs((PyObject *)self);
     md_clear(self);
-    Py_TYPE(self)->tp_free((PyObject *)self);
+    tp->tp_free((PyObject *)self);
+    Py_DECREF(tp);
     Py_TRASHCAN_END  // there should be no code after this
 }
 
@@ -1178,10 +1180,12 @@ multidict_proxy_tp_richcompare(MultiDictProxyObject *self, PyObject *other,
 static void
 multidict_proxy_tp_dealloc(MultiDictProxyObject *self)
 {
+    PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
     PyObject_ClearWeakRefs((PyObject *)self);
     Py_XDECREF(self->md);
-    Py_TYPE(self)->tp_free((PyObject *)self);
+    tp->tp_free((PyObject *)self);
+    Py_DECREF(tp);
 }
 
 static int

--- a/tests/isolated/multidict_type_leak.py
+++ b/tests/isolated/multidict_type_leak.py
@@ -2,7 +2,7 @@ import gc
 import sys
 import sysconfig
 
-from multidict import MultiDict, istr
+from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy, istr
 
 # sys.getrefcount is not meaningful under the free-threaded build:
 # refcounts are biased per-thread and types may be immortalized, so
@@ -27,6 +27,31 @@ if __name__ == "__main__":
     gc.collect()
     after = sys.getrefcount(iter_type)
     assert after == baseline, f"iterator type leaked: {after - baseline}"
+
+    # MultiDict type leak
+    for md_type in (MultiDict, CIMultiDict):
+        gc.collect()
+        baseline = sys.getrefcount(md_type)
+        for _ in range(1000):
+            md_type()
+        gc.collect()
+        after = sys.getrefcount(md_type)
+        assert after == baseline, f"{md_type.__name__} type leaked: {after - baseline}"
+
+    # MultiDictProxy type leak
+    for proxy_type, proxy_md in (
+        (MultiDictProxy, md),
+        (CIMultiDictProxy, CIMultiDict(md)),
+    ):
+        gc.collect()
+        baseline = sys.getrefcount(proxy_type)
+        for _ in range(1000):
+            proxy_type(proxy_md)
+        gc.collect()
+        after = sys.getrefcount(proxy_type)
+        assert after == baseline, (
+            f"{proxy_type.__name__} type leaked: {after - baseline}"
+        )
 
     # View type leak
     view_type = type(md.keys())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixed C-extension multidict and proxy deallocators to release the heap-type reference owned by each instance. Added regression coverage for dictionary and proxy type reference counts.

## Are there changes in behavior for the user?

No API behavior changed. Repeated construction and destruction of these C-extension objects no longer retains type references.

## Is it a substantial burden for the maintainers to support this?

No. The cleanup follows the existing deallocation pattern used by multidict views and iterators.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` N/A, this repository does not contain this file
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: `python -m pytest -q` passed with the C extension, 1661 tests passed.

Tests: `python -m pytest -q --no-c-extensions` passed with the pure-Python implementation, 850 tests passed.

Lint: targeted pre-commit hooks passed.

Docs: `make doc-spelling` is blocked by five pre-existing misspellings in generated `CHANGES.rst`; this fragment introduced none.
</details>

Drafted with GitHub Copilot App 1.0.83-5; reviewed by Andrew Svetlov.