### PR TITLE
Slightly optimize multidict creation

### DIFF
--- a/CHANGES/1420.misc.rst
+++ b/CHANGES/1420.misc.rst
@@ -1,6 +1,6 @@
 Slightly reorganized multidict creating process.
 
 1. Removed unnecessary calculations when ``md_init()`` creates an empty multidict.
-2. Now tp_new slot is used in object cloning instead of bare :c:func:`PyObject_GenericNew` call.
+2. Now tp_new slot is used in object cloning instead of bare :c:func:`PyType_GenericNew` call.
 
 -- by :user:`asvetlov`   

--- a/CHANGES/1420.misc.rst
+++ b/CHANGES/1420.misc.rst
@@ -1,6 +1,6 @@
 Slightly reorganized multidict creating process.
 
 1. Removed unnecessary calculations when ``md_init()`` creates an empty multidict.
-2. Now tp_new slot is used in object cloning instead of bare :c:func:`PyType_GenericNew` call.
+2. Now ``tp_alloc`` slot is used in object cloning instead of bare :c:func:`PyType_GenericNew` call.
 
 -- by :user:`asvetlov`   

--- a/CHANGES/1420.misc.rst
+++ b/CHANGES/1420.misc.rst
@@ -1,0 +1,6 @@
+Slightly reorganized multidict creating process.
+
+1. Removed unnecessary calculations when ``md_init()`` creates an empty multidict.
+2. Now tp_new slot is used in object cloning instead of bare :c:func:`PyObject_GenericNew` call.
+
+-- by :user:`asvetlov`   

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -235,7 +235,17 @@ static inline PyObject*
 multidict_copy(MultiDictObject* self)
 {
     PyTypeObject* tp = Py_TYPE(self);
-    PyObject* ret = tp->tp_new(tp, NULL, NULL);
+    PyObject* args = NULL;
+    PyObject* kwargs = NULL;
+    args = PyTuple_New(0);
+    if (args == NULL) {
+        goto fail;
+    }
+    kwargs = PyDict_New();
+    if (kwargs == NULL) {
+        goto fail;
+    }
+    PyObject* ret = tp->tp_new(tp, args, kwargs);
     if (ret == NULL) {
         goto fail;
     }
@@ -248,6 +258,8 @@ multidict_copy(MultiDictObject* self)
     return ret;
 fail:
     Py_XDECREF(ret);
+    Py_XDECREF(kwargs);
+    Py_XDECREF(args);
     return NULL;
 }
 

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -237,6 +237,7 @@ multidict_copy(MultiDictObject* self)
     PyTypeObject* tp = Py_TYPE(self);
     PyObject* args = NULL;
     PyObject* kwargs = NULL;
+    PyObject* ret = NULL;
     args = PyTuple_New(0);
     if (args == NULL) {
         goto fail;
@@ -245,7 +246,7 @@ multidict_copy(MultiDictObject* self)
     if (kwargs == NULL) {
         goto fail;
     }
-    PyObject* ret = tp->tp_new(tp, args, kwargs);
+    ret = tp->tp_new(tp, args, kwargs);
     if (ret == NULL) {
         goto fail;
     }

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -237,7 +237,7 @@ multidict_copy(MultiDictObject* self)
     PyTypeObject* tp = Py_TYPE(self);
     PyObject* ret = NULL;
 
-    ret = type->tp_alloc(tp, 0);
+    ret = tp->tp_alloc(tp, 0);
     if (ret == NULL) {
         goto fail;
     }

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -235,18 +235,9 @@ static inline PyObject*
 multidict_copy(MultiDictObject* self)
 {
     PyTypeObject* tp = Py_TYPE(self);
-    PyObject* args = NULL;
-    PyObject* kwargs = NULL;
     PyObject* ret = NULL;
-    args = PyTuple_New(0);
-    if (args == NULL) {
-        goto fail;
-    }
-    kwargs = PyDict_New();
-    if (kwargs == NULL) {
-        goto fail;
-    }
-    ret = tp->tp_new(tp, args, kwargs);
+
+    ret = type->tp_alloc(tp, 0);
     if (ret == NULL) {
         goto fail;
     }
@@ -259,8 +250,6 @@ multidict_copy(MultiDictObject* self)
     return ret;
 fail:
     Py_XDECREF(ret);
-    Py_XDECREF(kwargs);
-    Py_XDECREF(args);
     return NULL;
 }
 

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -234,7 +234,8 @@ done:
 static inline PyObject*
 multidict_copy(MultiDictObject* self)
 {
-    PyObject* ret = PyType_GenericNew(Py_TYPE(self), NULL, NULL);
+    PyTypeObject* tp = Py_TYPE(self);
+    PyObject* ret = tp->tp_new(tp, NULL, NULL);
     if (ret == NULL) {
         goto fail;
     }
@@ -585,23 +586,21 @@ fail:
 static PyObject*
 multidict_tp_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 {
-    /* Initialise the object to a valid empty state here rather than relying on
-       tp_init.  Otherwise ``MultiDict.__new__(MultiDict)`` (or a subclass that
-       skips ``super().__init__()``) leaves md->state / md->keys NULL, and the
-       first method call dereferences NULL and segfaults.  The empty state uses
-       the shared &empty_htkeys sentinel (no allocation), so the subsequent
-       md_init() from tp_init does not leak. */
+    /* Initialize the object to a valid empty container.
+       Otherwise ``MultiDict.__new__(MultiDict)`` (or a subclass that
+       skips ``super().__init__()``) without subsequent ``md.__init__()``
+       call leaves the object in incorrect state,
+       any its usage leads to segfault. */
     PyObject* mod = PyType_GetModuleByDef(type, &multidict_module);
     if (mod == NULL) {
         return NULL;
     }
     mod_state* state = get_mod_state(mod);
-    bool is_ci = PyType_IsSubtype(type, state->CIMultiDictType);
     MultiDictObject* self = (MultiDictObject*)type->tp_alloc(type, 0);
     if (self == NULL) {
         return NULL;
     }
-    if (md_init(self, state, is_ci, 0) < 0) {
+    if (md_init(self, state, false, 0) < 0) {
         Py_DECREF(self);
         return NULL;
     }
@@ -1035,6 +1034,18 @@ static PyType_Spec multidict_spec = {
 
 /******************** CIMultiDict ********************/
 
+static PyObject*
+cimultidict_tp_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
+{
+    MultiDictObject* self =
+        (MultiDictObject*)multidict_tp_new(type, args, kwds);
+    if (self == NULL) {
+        return NULL;
+    }
+    self->is_ci = true;
+    return (PyObject*)self;
+}
+
 static int
 cimultidict_tp_init(MultiDictObject* self, PyObject* args, PyObject* kwds)
 {
@@ -1073,6 +1084,7 @@ PyDoc_STRVAR(
 static PyType_Slot cimultidict_slots[] = {
     {Py_tp_doc, (void*)CIMultDict_doc},
     {Py_tp_init, cimultidict_tp_init},
+    {Py_tp_new, cimultidict_tp_new},
     {0, NULL},
 };
 

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -322,12 +322,12 @@ md_clear(MultiDictObject* md);
 static inline int
 md_init(MultiDictObject* md, mod_state* state, bool is_ci, Py_ssize_t minused)
 {
-    const uint8_t log2_max_presize = 17;
-    const Py_ssize_t max_presize = ((Py_ssize_t)1) << log2_max_presize;
-    uint8_t log2_newsize;
     htkeys_t* new_keys = (htkeys_t*)&empty_htkeys;
 
     if (minused > USABLE_FRACTION(HT_MINSIZE)) {
+        const uint8_t log2_max_presize = 17;
+        const Py_ssize_t max_presize = ((Py_ssize_t)1) << log2_max_presize;
+        uint8_t log2_newsize;
         /* There are no strict guarantee that returned dict can contain minused
          * items without resize.  So we create medium size dict instead of very
          * large dict or MemoryError.


### PR DESCRIPTION
1. Remove unnecessary calculations when `md_init()` creates an empty multidict.
2. Use `tp_alloc` slot in object cloning instead of bare `PyObject_GenericNew()` call.