### PR TITLE
Mark temporarily-removed entries via the hash's high bit, not -1

### DIFF
--- a/CHANGES/1426.misc.rst
+++ b/CHANGES/1426.misc.rst
@@ -1,0 +1,5 @@
+In the pure-Python implementation, a temporarily removed hash table entry
+is now marked by flipping the high bit of its hash instead of overwriting
+it with a sentinel value, so restoring the entry no longer needs to
+recompute the hash
+-- by :user:`asvetlov`

--- a/CHANGES/1426.misc.rst
+++ b/CHANGES/1426.misc.rst
@@ -1,5 +1,5 @@
-In both the pure-Python and C implementations, a temporarily removed hash
-table entry is now marked by setting the high bit of its hash instead of
+Changed both the pure-Python and C implementations to mark a temporarily
+removed hash table entry by setting the high bit of its hash instead of
 overwriting it with a sentinel value, so restoring the entry no longer
-needs to recompute the hash
+recomputes the hash
 -- by :user:`asvetlov`

--- a/CHANGES/1426.misc.rst
+++ b/CHANGES/1426.misc.rst
@@ -1,5 +1,5 @@
-In the pure-Python implementation, a temporarily removed hash table entry
-is now marked by flipping the high bit of its hash instead of overwriting
-it with a sentinel value, so restoring the entry no longer needs to
-recompute the hash
+In both the pure-Python and C implementations, a temporarily removed hash
+table entry is now marked by setting the high bit of its hash instead of
+overwriting it with a sentinel value, so restoring the entry no longer
+needs to recompute the hash
 -- by :user:`asvetlov`

--- a/CHANGES/1426.misc.rst
+++ b/CHANGES/1426.misc.rst
@@ -1,5 +1,5 @@
 Changed both the pure-Python and C implementations to mark a temporarily
 removed hash table entry by setting the high bit of its hash instead of
 overwriting it with a sentinel value, so restoring the entry no longer
-recomputes the hash
+recomputes the hash; :meth:`~multidict.MultiDict.getall` is faster ~10% now in C version
 -- by :user:`asvetlov`

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -569,7 +569,7 @@ class _HtKeys(Generic[_V]):
             else:
                 assert not (hash_ & HASH_MARK)
             i = hash_ & mask
-            perturb = hash_ & MAXSIZE
+            perturb = hash_
             while indices[i] != -1:
                 perturb >>= 5
                 i = mask & (i * 5 + perturb + 1)
@@ -579,7 +579,7 @@ class _HtKeys(Generic[_V]):
         mask = self.mask
         indices = self.indices
         i = hash_ & mask
-        perturb = hash_ & MAXSIZE
+        perturb = hash_
         ix = indices[i]
         while ix != -1:
             perturb >>= 5
@@ -592,7 +592,7 @@ class _HtKeys(Generic[_V]):
         indices = self.indices
         entries = self.entries
         i = hash_ & mask
-        perturb = hash_ & MAXSIZE
+        perturb = hash_
         ix = indices[i]
         while ix != -1:
             if ix != -2:
@@ -607,7 +607,7 @@ class _HtKeys(Generic[_V]):
         mask = self.mask
         indices = self.indices
         i = hash_ & mask
-        perturb = hash_ & MAXSIZE
+        perturb = hash_
         ix = indices[i]
         while ix != idx:
             perturb >>= 5
@@ -624,7 +624,7 @@ class _HtKeys(Generic[_V]):
         indices = self.indices
         entries = self.entries
         i = hash_ & mask
-        perturb = hash_ & MAXSIZE
+        perturb = hash_
         ix = indices[i]
         while ix != -1:
             if ix != -2:

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -564,10 +564,7 @@ class _HtKeys(Generic[_V]):
             assert e is not None
             hash_ = e.hash
             if update:
-                if hash_ & HASH_MARK:
-                    hash_ &= MAXSIZE
-            else:
-                assert not (hash_ & HASH_MARK)
+                hash_ &= MAXSIZE
             i = hash_ & mask
             perturb = hash_
             while indices[i] != -1:

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -32,15 +32,9 @@ else:
 
 MAXSIZE = sys.maxsize
 
-# hash() never returns a value outside [-(MAXSIZE + 1), MAXSIZE]. Entry
-# hashes are stored folded into that range's non-negative half by masking
-# with MAXSIZE (& MAXSIZE), same as the probing code already does to turn
-# a hash into a table index: it only ever looks at the low bits, so the
-# fold is invisible to it. Once an entry's hash is always non-negative,
-# HASH_MARK (its range's high bit) can be OR-ed in to mark it temporarily
-# invalid (its slot is being processed) and AND-ed out with MAXSIZE to
-# restore it, both cheap and unambiguous: a real folded hash never has
-# that bit set to begin with.
+# Entry hashes are folded non-negative (& MAXSIZE) so HASH_MARK, the
+# hash range's high bit, can mark a hash as temporarily invalid: OR it in,
+# AND it out with MAXSIZE. A real folded hash never has that bit set.
 HASH_MARK = MAXSIZE + 1
 
 

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -562,7 +562,13 @@ class _HtKeys(Generic[_V]):
             entries=entries,
         )
 
-    def build_indices(self, update: bool, *, _hash_mask: int = HASH_MARK) -> None:
+    def build_indices(
+        self,
+        update: bool,
+        *,
+        _hash_mask: int = HASH_MARK,
+        _maxsize: int = MAXSIZE,
+    ) -> None:
         mask = self.mask
         indices = self.indices
         for idx, e in enumerate(self.entries):
@@ -574,17 +580,17 @@ class _HtKeys(Generic[_V]):
             else:
                 assert not (hash_ >= _hash_mask or hash_ < -_hash_mask)
             i = hash_ & mask
-            perturb = hash_ & MAXSIZE
+            perturb = hash_ & _maxsize
             while indices[i] != -1:
                 perturb >>= 5
                 i = mask & (i * 5 + perturb + 1)
             indices[i] = idx
 
-    def find_empty_slot(self, hash_: int) -> int:
+    def find_empty_slot(self, hash_: int, *, _maxsize: int = MAXSIZE) -> int:
         mask = self.mask
         indices = self.indices
         i = hash_ & mask
-        perturb = hash_ & MAXSIZE
+        perturb = hash_ & _maxsize
         ix = indices[i]
         while ix != -1:
             perturb >>= 5
@@ -592,12 +598,14 @@ class _HtKeys(Generic[_V]):
             ix = indices[i]
         return i
 
-    def iter_hash(self, hash_: int) -> Iterator[tuple[int, int, _Entry[_V]]]:
+    def iter_hash(
+        self, hash_: int, *, _maxsize: int = MAXSIZE
+    ) -> Iterator[tuple[int, int, _Entry[_V]]]:
         mask = self.mask
         indices = self.indices
         entries = self.entries
         i = hash_ & mask
-        perturb = hash_ & MAXSIZE
+        perturb = hash_ & _maxsize
         ix = indices[i]
         while ix != -1:
             if ix != -2:
@@ -608,11 +616,11 @@ class _HtKeys(Generic[_V]):
             i = (i * 5 + perturb + 1) & mask
             ix = indices[i]
 
-    def del_idx(self, hash_: int, idx: int) -> None:
+    def del_idx(self, hash_: int, idx: int, *, _maxsize: int = MAXSIZE) -> None:
         mask = self.mask
         indices = self.indices
         i = hash_ & mask
-        perturb = hash_ & MAXSIZE
+        perturb = hash_ & _maxsize
         ix = indices[i]
         while ix != idx:
             perturb >>= 5
@@ -624,12 +632,18 @@ class _HtKeys(Generic[_V]):
         entries = reversed(self.entries) if reverse else self.entries
         return filter(None, entries)
 
-    def restore_hash(self, hash_: int, *, _hash_mask: int = HASH_MARK) -> None:
+    def restore_hash(
+        self,
+        hash_: int,
+        *,
+        _hash_mask: int = HASH_MARK,
+        _maxsize: int = MAXSIZE,
+    ) -> None:
         mask = self.mask
         indices = self.indices
         entries = self.entries
         i = hash_ & mask
-        perturb = hash_ & MAXSIZE
+        perturb = hash_ & _maxsize
         ix = indices[i]
         while ix != -1:
             if ix != -2:

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -30,6 +30,17 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
+MAXSIZE = sys.maxsize
+
+# hash() never returns a value outside [-(MAXSIZE + 1), MAXSIZE]. XORing a
+# real hash with its highest bit always pushes the result outside that
+# range, so it can be used to mark an entry's hash as temporarily invalid
+# (its slot is being processed) without losing the original bits: XORing
+# the same bit again restores the exact original hash, no recomputation
+# needed. A plain OR/AND wouldn't do: Python ints are arbitrary precision,
+# so any negative hash already reads that bit as set.
+HASH_MARK = MAXSIZE + 1
+
 
 class istr(str):
     """Case insensitive str."""
@@ -148,7 +159,7 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 continue
             hash_, identity, key, value = item
             for slot, idx, e in self._md._keys.iter_hash(hash_):
-                e.hash = -1
+                e.hash ^= HASH_MARK
                 if e.identity == identity and e.value == value:
                     ret.add((e.key, e.value))
             self._md._keys.restore_hash(hash_)
@@ -551,12 +562,12 @@ class _HtKeys(Generic[_V]):
             assert e is not None
             hash_ = e.hash
             if update:
-                if hash_ == -1:
-                    hash_ = hash(e.identity)
+                if hash_ > MAXSIZE or hash_ < -HASH_MARK:
+                    hash_ ^= HASH_MARK
             else:
-                assert hash_ != -1
+                assert not (hash_ > MAXSIZE or hash_ < -HASH_MARK)
             i = hash_ & mask
-            perturb = hash_ & sys.maxsize
+            perturb = hash_ & MAXSIZE
             while indices[i] != -1:
                 perturb >>= 5
                 i = mask & (i * 5 + perturb + 1)
@@ -566,7 +577,7 @@ class _HtKeys(Generic[_V]):
         mask = self.mask
         indices = self.indices
         i = hash_ & mask
-        perturb = hash_ & sys.maxsize
+        perturb = hash_ & MAXSIZE
         ix = indices[i]
         while ix != -1:
             perturb >>= 5
@@ -579,7 +590,7 @@ class _HtKeys(Generic[_V]):
         indices = self.indices
         entries = self.entries
         i = hash_ & mask
-        perturb = hash_ & sys.maxsize
+        perturb = hash_ & MAXSIZE
         ix = indices[i]
         while ix != -1:
             if ix != -2:
@@ -594,7 +605,7 @@ class _HtKeys(Generic[_V]):
         mask = self.mask
         indices = self.indices
         i = hash_ & mask
-        perturb = hash_ & sys.maxsize
+        perturb = hash_ & MAXSIZE
         ix = indices[i]
         while ix != idx:
             perturb >>= 5
@@ -611,13 +622,13 @@ class _HtKeys(Generic[_V]):
         indices = self.indices
         entries = self.entries
         i = hash_ & mask
-        perturb = hash_ & sys.maxsize
+        perturb = hash_ & MAXSIZE
         ix = indices[i]
         while ix != -1:
             if ix != -2:
                 entry = entries[ix]
-                if entry.hash == -1:
-                    entry.hash = hash_
+                if entry.hash > MAXSIZE or entry.hash < -HASH_MARK:
+                    entry.hash ^= HASH_MARK
             perturb >>= 5
             i = (i * 5 + perturb + 1) & mask
             ix = indices[i]
@@ -670,13 +681,13 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 res.append(e.value)
-                e.hash = -1
+                e.hash ^= HASH_MARK
                 restore.append(idx)
 
         if res:
             entries = self._keys.entries
             for idx in restore:
-                entries[idx].hash = hash_  # type: ignore[union-attr]
+                entries[idx].hash ^= HASH_MARK  # type: ignore[union-attr]
             return res
         if not res and default is not sentinel:
             return default
@@ -891,10 +902,10 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 if not found:
                     e.key = key
                     e.value = value
-                    e.hash = -1
+                    e.hash ^= HASH_MARK
                     found = True
                     self._incr_version()
-                elif e.hash != -1:  # pragma: no branch
+                elif not (e.hash > MAXSIZE or e.hash < -HASH_MARK):  # pragma: no branch
                     self._del_at(slot, idx)
 
         if not found:
@@ -1035,7 +1046,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                         found = True
                         e.key = entry.key
                         e.value = entry.value
-                        e.hash = -1
+                        e.hash ^= HASH_MARK
                     else:
                         self._del_at_for_upd(e)
             if not found:
@@ -1054,8 +1065,8 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                     entries[idx] = None
                     indices[slot] = -2
                     self._used -= 1
-                if e2.hash == -1:
-                    e2.hash = hash(e2.identity)
+                if e2.hash > MAXSIZE or e2.hash < -HASH_MARK:
+                    e2.hash ^= HASH_MARK
 
         self._incr_version()
 
@@ -1120,7 +1131,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         keys = self._keys
         slot = keys.find_empty_slot(entry.hash)
         keys.indices[slot] = len(keys.entries)
-        entry.hash = -1
+        entry.hash ^= HASH_MARK
         keys.entries.append(entry)
         self._incr_version()
         self._used += 1

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -32,18 +32,21 @@ else:
 
 MAXSIZE = sys.maxsize
 
-# hash() never returns a value outside [-(MAXSIZE + 1), MAXSIZE]. XORing a
-# real hash with its highest bit always pushes the result outside that
-# range, so it can be used to mark an entry's hash as temporarily invalid
-# (its slot is being processed) without losing the original bits: XORing
-# the same bit again restores the exact original hash, no recomputation
-# needed. A plain OR/AND wouldn't do: Python ints are arbitrary precision,
-# so any negative hash already reads that bit as set.
+# hash() never returns a value outside [-(MAXSIZE + 1), MAXSIZE]. Entry
+# hashes are stored folded into that range's non-negative half by masking
+# with MAXSIZE (& MAXSIZE), same as the probing code already does to turn
+# a hash into a table index: it only ever looks at the low bits, so the
+# fold is invisible to it. Once an entry's hash is always non-negative,
+# HASH_MARK (its range's high bit) can be OR-ed in to mark it temporarily
+# invalid (its slot is being processed) and AND-ed out with MAXSIZE to
+# restore it, both cheap and unambiguous: a real folded hash never has
+# that bit set to begin with.
 #
-# Functions on the hot path take it as a hidden ``_hash_mask`` default
-# argument rather than reading it off the module each time: default values
-# are bound once, at function definition time, so the lookup inside the
-# function body is a fast local access instead of a global one.
+# Functions on the hot path take these as hidden ``_hash_mask`` /
+# ``_maxsize`` default arguments rather than reading them off the module
+# each time: default values are bound once, at function definition time,
+# so referencing them inside the function body is a fast local access
+# instead of a global one.
 HASH_MARK = MAXSIZE + 1
 
 
@@ -97,7 +100,7 @@ class _ViewBase(Generic[_V]):
 
 
 class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
-    def __contains__(self, item: object) -> bool:
+    def __contains__(self, item: object, *, _maxsize: int = MAXSIZE) -> bool:
         if not isinstance(item, (tuple, list)) or len(item) != 2:
             return False
         key, value = item
@@ -105,7 +108,7 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
             identity = self._md._identity(key)
         except TypeError:
             return False
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         for slot, idx, e in self._md._keys.iter_hash(hash_):
             if e.identity == identity and value == e.value:
                 return True
@@ -131,14 +134,16 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
         body = ", ".join(lst)
         return f"<{self.__class__.__name__}({body})>"
 
-    def _parse_item(self, arg: tuple[str, _V] | _T) -> tuple[int, str, str, _V] | None:
+    def _parse_item(
+        self, arg: tuple[str, _V] | _T, *, _maxsize: int = MAXSIZE
+    ) -> tuple[int, str, str, _V] | None:
         if not isinstance(arg, tuple):
             return None
         if len(arg) != 2:
             return None
         try:
             identity = self._md._identity(arg[0])
-            return (hash(identity), identity, arg[0], arg[1])
+            return (hash(identity) & _maxsize, identity, arg[0], arg[1])
         except TypeError:
             return None
 
@@ -166,7 +171,7 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 continue
             hash_, identity, key, value = item
             for slot, idx, e in self._md._keys.iter_hash(hash_):
-                e.hash ^= _hash_mask
+                e.hash |= _hash_mask
                 if e.identity == identity and e.value == value:
                     ret.add((e.key, e.value))
             self._md._keys.restore_hash(hash_)
@@ -307,11 +312,11 @@ class _ValuesView(_ViewBase[_V], ValuesView[_V]):
 
 
 class _KeysView(_ViewBase[_V], KeysView[str]):
-    def __contains__(self, key: object) -> bool:
+    def __contains__(self, key: object, *, _maxsize: int = MAXSIZE) -> bool:
         if not isinstance(key, str):
             return False
         identity = self._md._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         for slot, idx, e in self._md._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 return True
@@ -336,7 +341,7 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
         body = ", ".join(lst)
         return f"<{self.__class__.__name__}({body})>"
 
-    def __and__(self, other: Iterable[object]) -> set[str]:
+    def __and__(self, other: Iterable[object], *, _maxsize: int = MAXSIZE) -> set[str]:
         ret = set()
         try:
             it = iter(other)
@@ -346,7 +351,7 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
             if not isinstance(key, str):
                 continue
             identity = self._md._identity(key)
-            hash_ = hash(identity)
+            hash_ = hash(identity) & _maxsize
             for slot, idx, e in self._md._keys.iter_hash(hash_):
                 if e.identity == identity:  # pragma: no branch
                     ret.add(e.key)
@@ -398,7 +403,7 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
                 ret.add(e.key)
         return ret
 
-    def __sub__(self, other: Iterable[object]) -> set[str]:
+    def __sub__(self, other: Iterable[object], *, _maxsize: int = MAXSIZE) -> set[str]:
         ret = set(self)
         try:
             it = iter(other)
@@ -408,7 +413,7 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
             if not isinstance(key, str):
                 continue
             identity = self._md._identity(key)
-            hash_ = hash(identity)
+            hash_ = hash(identity) & _maxsize
             for slot, idx, e in self._md._keys.iter_hash(hash_):
                 if e.identity == identity:  # pragma: no branch
                     ret.discard(e.key)
@@ -575,10 +580,10 @@ class _HtKeys(Generic[_V]):
             assert e is not None
             hash_ = e.hash
             if update:
-                if hash_ >= _hash_mask or hash_ < -_hash_mask:
-                    hash_ ^= _hash_mask
+                if hash_ & _hash_mask:
+                    hash_ &= _maxsize
             else:
-                assert not (hash_ >= _hash_mask or hash_ < -_hash_mask)
+                assert not (hash_ & _hash_mask)
             i = hash_ & mask
             perturb = hash_ & _maxsize
             while indices[i] != -1:
@@ -648,8 +653,8 @@ class _HtKeys(Generic[_V]):
         while ix != -1:
             if ix != -2:
                 entry = entries[ix]
-                if entry.hash >= _hash_mask or entry.hash < -_hash_mask:
-                    entry.hash ^= _hash_mask
+                if entry.hash & _hash_mask:
+                    entry.hash &= _maxsize
             perturb >>= 5
             i = (i * 5 + perturb + 1) & mask
             ix = indices[i]
@@ -699,22 +704,23 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         default: _T | _SENTINEL = sentinel,
         *,
         _hash_mask: int = HASH_MARK,
+        _maxsize: int = MAXSIZE,
     ) -> list[_V] | _T:
         """Return a list of all values matching the key."""
         identity = self._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         res = []
         restore = []
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 res.append(e.value)
-                e.hash ^= _hash_mask
+                e.hash |= _hash_mask
                 restore.append(idx)
 
         if res:
             entries = self._keys.entries
             for idx in restore:
-                entries[idx].hash ^= _hash_mask  # type: ignore[union-attr]
+                entries[idx].hash &= _maxsize  # type: ignore[union-attr]
             return res
         if not res and default is not sentinel:
             return default
@@ -724,13 +730,19 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def getone(self, key: str) -> _V: ...
     @overload
     def getone(self, key: str, default: _T) -> _V | _T: ...
-    def getone(self, key: str, default: _T | _SENTINEL = sentinel) -> _V | _T:
+    def getone(
+        self,
+        key: str,
+        default: _T | _SENTINEL = sentinel,
+        *,
+        _maxsize: int = MAXSIZE,
+    ) -> _V | _T:
         """Get first value matching the key.
 
         Raises KeyError if the key is not found and no default is provided.
         """
         identity = self._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 return e.value
@@ -794,11 +806,11 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 return False
         return True
 
-    def __contains__(self, key: object) -> bool:
+    def __contains__(self, key: object, *, _maxsize: int = MAXSIZE) -> bool:
         if not isinstance(key, str):
             return False
         identity = self._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 return True
@@ -817,9 +829,9 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def __reduce__(self) -> tuple[type[Self], tuple[list[tuple[str, _V]]]]:
         return (self.__class__, (list(self.items()),))
 
-    def add(self, key: str, value: _V) -> None:
+    def add(self, key: str, value: _V, *, _maxsize: int = MAXSIZE) -> None:
         identity = self._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         self._add_with_hash(_Entry(hash_, identity, key, value))
         self._incr_version()
 
@@ -844,6 +856,8 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         self,
         arg: MDArg[_V],
         kwargs: Mapping[str, _V],
+        *,
+        _maxsize: int = MAXSIZE,
     ) -> Iterator[int | _Entry[_V]]:
         identity_func = self._identity
         if isinstance(arg, MultiDictProxy):
@@ -859,14 +873,16 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 if self._ci is not arg._ci:
                     for e in arg._keys.iter_entries():
                         identity = identity_func(e.key)
-                        yield _Entry(hash(identity), identity, e.key, e.value)
+                        yield _Entry(
+                            hash(identity) & _maxsize, identity, e.key, e.value
+                        )
                 else:
                     for e in arg._keys.iter_entries():
                         yield _Entry(e.hash, e.identity, e.key, e.value)
                 if kwargs:
                     for key, value in kwargs.items():
                         identity = identity_func(key)
-                        yield _Entry(hash(identity), identity, key, value)
+                        yield _Entry(hash(identity) & _maxsize, identity, key, value)
             else:
                 if hasattr(arg, "keys"):
                     arg = cast(SupportsKeys[_V], arg)
@@ -899,12 +915,12 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                             f"value could not be fetched"
                         ) from exc
                     identity = identity_func(key)
-                    yield _Entry(hash(identity), identity, key, value)
+                    yield _Entry(hash(identity) & _maxsize, identity, key, value)
         else:
             yield len(kwargs)
             for key, value in kwargs.items():
                 identity = identity_func(key)
-                yield _Entry(hash(identity), identity, key, value)
+                yield _Entry(hash(identity) & _maxsize, identity, key, value)
 
     def _extend_items(self, items: Iterable[_Entry[_V]]) -> None:
         for e in items:
@@ -919,9 +935,16 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
 
     # Mapping interface #
 
-    def __setitem__(self, key: str, value: _V, *, _hash_mask: int = HASH_MARK) -> None:
+    def __setitem__(
+        self,
+        key: str,
+        value: _V,
+        *,
+        _hash_mask: int = HASH_MARK,
+        _maxsize: int = MAXSIZE,
+    ) -> None:
         identity = self._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         found = False
 
         for slot, idx, e in self._keys.iter_hash(hash_):
@@ -929,12 +952,10 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 if not found:
                     e.key = key
                     e.value = value
-                    e.hash ^= _hash_mask
+                    e.hash |= _hash_mask
                     found = True
                     self._incr_version()
-                elif not (
-                    e.hash >= _hash_mask or e.hash < -_hash_mask
-                ):  # pragma: no branch
+                elif not (e.hash & _hash_mask):  # pragma: no branch
                     self._del_at(slot, idx)
 
         if not found:
@@ -942,10 +963,10 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         else:
             self._keys.restore_hash(hash_)
 
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self, key: str, *, _maxsize: int = MAXSIZE) -> None:
         found = False
         identity = self._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 self._del_at(slot, idx)
@@ -961,10 +982,12 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     ) -> _T | None: ...
     @overload
     def setdefault(self, key: str, default: _V) -> _V: ...
-    def setdefault(self, key: str, default: _V | None = None) -> _V | None:  # type: ignore[misc]
+    def setdefault(  # type: ignore[misc]
+        self, key: str, default: _V | None = None, *, _maxsize: int = MAXSIZE
+    ) -> _V | None:
         """Return value for key, set value to default if key is not present."""
         identity = self._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 return e.value
@@ -975,7 +998,13 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def popone(self, key: str) -> _V: ...
     @overload
     def popone(self, key: str, default: _T) -> _V | _T: ...
-    def popone(self, key: str, default: _T | _SENTINEL = sentinel) -> _V | _T:
+    def popone(
+        self,
+        key: str,
+        default: _T | _SENTINEL = sentinel,
+        *,
+        _maxsize: int = MAXSIZE,
+    ) -> _V | _T:
         """Remove specified key and return the corresponding value.
 
         If key is not found, d is returned if given, otherwise
@@ -983,7 +1012,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
 
         """
         identity = self._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 value = e.value
@@ -1003,7 +1032,13 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def popall(self, key: str) -> list[_V]: ...
     @overload
     def popall(self, key: str, default: _T) -> list[_V] | _T: ...
-    def popall(self, key: str, default: _T | _SENTINEL = sentinel) -> list[_V] | _T:
+    def popall(
+        self,
+        key: str,
+        default: _T | _SENTINEL = sentinel,
+        *,
+        _maxsize: int = MAXSIZE,
+    ) -> list[_V] | _T:
         """Remove all occurrences of key and return the list of corresponding
         values.
 
@@ -1013,7 +1048,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         """
         found = False
         identity = self._identity(key)
-        hash_ = hash(identity)
+        hash_ = hash(identity) & _maxsize
         ret = []
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
@@ -1077,13 +1112,15 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                         found = True
                         e.key = entry.key
                         e.value = entry.value
-                        e.hash ^= _hash_mask
+                        e.hash |= _hash_mask
                     else:
                         self._del_at_for_upd(e)
             if not found:
                 self._add_with_hash_for_upd(entry)
 
-    def _post_update(self, *, _hash_mask: int = HASH_MARK) -> None:
+    def _post_update(
+        self, *, _hash_mask: int = HASH_MARK, _maxsize: int = MAXSIZE
+    ) -> None:
         keys = self._keys
         indices = keys.indices
         entries = keys.entries
@@ -1096,8 +1133,8 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                     entries[idx] = None
                     indices[slot] = -2
                     self._used -= 1
-                if e2.hash >= _hash_mask or e2.hash < -_hash_mask:
-                    e2.hash ^= _hash_mask
+                if e2.hash & _hash_mask:
+                    e2.hash &= _maxsize
 
         self._incr_version()
 
@@ -1164,7 +1201,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         keys = self._keys
         slot = keys.find_empty_slot(entry.hash)
         keys.indices[slot] = len(keys.entries)
-        entry.hash ^= _hash_mask
+        entry.hash |= _hash_mask
         keys.entries.append(entry)
         self._incr_version()
         self._used += 1

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -41,12 +41,6 @@ MAXSIZE = sys.maxsize
 # invalid (its slot is being processed) and AND-ed out with MAXSIZE to
 # restore it, both cheap and unambiguous: a real folded hash never has
 # that bit set to begin with.
-#
-# Functions on the hot path take these as hidden ``_hash_mask`` /
-# ``_maxsize`` default arguments rather than reading them off the module
-# each time: default values are bound once, at function definition time,
-# so referencing them inside the function body is a fast local access
-# instead of a global one.
 HASH_MARK = MAXSIZE + 1
 
 
@@ -100,7 +94,7 @@ class _ViewBase(Generic[_V]):
 
 
 class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
-    def __contains__(self, item: object, *, _maxsize: int = MAXSIZE) -> bool:
+    def __contains__(self, item: object) -> bool:
         if not isinstance(item, (tuple, list)) or len(item) != 2:
             return False
         key, value = item
@@ -108,7 +102,7 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
             identity = self._md._identity(key)
         except TypeError:
             return False
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         for slot, idx, e in self._md._keys.iter_hash(hash_):
             if e.identity == identity and value == e.value:
                 return True
@@ -134,16 +128,14 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
         body = ", ".join(lst)
         return f"<{self.__class__.__name__}({body})>"
 
-    def _parse_item(
-        self, arg: tuple[str, _V] | _T, *, _maxsize: int = MAXSIZE
-    ) -> tuple[int, str, str, _V] | None:
+    def _parse_item(self, arg: tuple[str, _V] | _T) -> tuple[int, str, str, _V] | None:
         if not isinstance(arg, tuple):
             return None
         if len(arg) != 2:
             return None
         try:
             identity = self._md._identity(arg[0])
-            return (hash(identity) & _maxsize, identity, arg[0], arg[1])
+            return (hash(identity) & MAXSIZE, identity, arg[0], arg[1])
         except TypeError:
             return None
 
@@ -157,9 +149,7 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 tmp.add((item[1], item[3]))
         return tmp
 
-    def __and__(
-        self, other: Iterable[Any], *, _hash_mask: int = HASH_MARK
-    ) -> set[tuple[str, _V]]:
+    def __and__(self, other: Iterable[Any]) -> set[tuple[str, _V]]:
         ret = set()
         try:
             it = iter(other)
@@ -171,7 +161,7 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 continue
             hash_, identity, key, value = item
             for slot, idx, e in self._md._keys.iter_hash(hash_):
-                e.hash |= _hash_mask
+                e.hash |= HASH_MARK
                 if e.identity == identity and e.value == value:
                     ret.add((e.key, e.value))
             self._md._keys.restore_hash(hash_)
@@ -312,11 +302,11 @@ class _ValuesView(_ViewBase[_V], ValuesView[_V]):
 
 
 class _KeysView(_ViewBase[_V], KeysView[str]):
-    def __contains__(self, key: object, *, _maxsize: int = MAXSIZE) -> bool:
+    def __contains__(self, key: object) -> bool:
         if not isinstance(key, str):
             return False
         identity = self._md._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         for slot, idx, e in self._md._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 return True
@@ -341,7 +331,7 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
         body = ", ".join(lst)
         return f"<{self.__class__.__name__}({body})>"
 
-    def __and__(self, other: Iterable[object], *, _maxsize: int = MAXSIZE) -> set[str]:
+    def __and__(self, other: Iterable[object]) -> set[str]:
         ret = set()
         try:
             it = iter(other)
@@ -351,7 +341,7 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
             if not isinstance(key, str):
                 continue
             identity = self._md._identity(key)
-            hash_ = hash(identity) & _maxsize
+            hash_ = hash(identity) & MAXSIZE
             for slot, idx, e in self._md._keys.iter_hash(hash_):
                 if e.identity == identity:  # pragma: no branch
                     ret.add(e.key)
@@ -403,7 +393,7 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
                 ret.add(e.key)
         return ret
 
-    def __sub__(self, other: Iterable[object], *, _maxsize: int = MAXSIZE) -> set[str]:
+    def __sub__(self, other: Iterable[object]) -> set[str]:
         ret = set(self)
         try:
             it = iter(other)
@@ -413,7 +403,7 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
             if not isinstance(key, str):
                 continue
             identity = self._md._identity(key)
-            hash_ = hash(identity) & _maxsize
+            hash_ = hash(identity) & MAXSIZE
             for slot, idx, e in self._md._keys.iter_hash(hash_):
                 if e.identity == identity:  # pragma: no branch
                     ret.discard(e.key)
@@ -567,35 +557,29 @@ class _HtKeys(Generic[_V]):
             entries=entries,
         )
 
-    def build_indices(
-        self,
-        update: bool,
-        *,
-        _hash_mask: int = HASH_MARK,
-        _maxsize: int = MAXSIZE,
-    ) -> None:
+    def build_indices(self, update: bool) -> None:
         mask = self.mask
         indices = self.indices
         for idx, e in enumerate(self.entries):
             assert e is not None
             hash_ = e.hash
             if update:
-                if hash_ & _hash_mask:
-                    hash_ &= _maxsize
+                if hash_ & HASH_MARK:
+                    hash_ &= MAXSIZE
             else:
-                assert not (hash_ & _hash_mask)
+                assert not (hash_ & HASH_MARK)
             i = hash_ & mask
-            perturb = hash_ & _maxsize
+            perturb = hash_ & MAXSIZE
             while indices[i] != -1:
                 perturb >>= 5
                 i = mask & (i * 5 + perturb + 1)
             indices[i] = idx
 
-    def find_empty_slot(self, hash_: int, *, _maxsize: int = MAXSIZE) -> int:
+    def find_empty_slot(self, hash_: int) -> int:
         mask = self.mask
         indices = self.indices
         i = hash_ & mask
-        perturb = hash_ & _maxsize
+        perturb = hash_ & MAXSIZE
         ix = indices[i]
         while ix != -1:
             perturb >>= 5
@@ -603,14 +587,12 @@ class _HtKeys(Generic[_V]):
             ix = indices[i]
         return i
 
-    def iter_hash(
-        self, hash_: int, *, _maxsize: int = MAXSIZE
-    ) -> Iterator[tuple[int, int, _Entry[_V]]]:
+    def iter_hash(self, hash_: int) -> Iterator[tuple[int, int, _Entry[_V]]]:
         mask = self.mask
         indices = self.indices
         entries = self.entries
         i = hash_ & mask
-        perturb = hash_ & _maxsize
+        perturb = hash_ & MAXSIZE
         ix = indices[i]
         while ix != -1:
             if ix != -2:
@@ -621,11 +603,11 @@ class _HtKeys(Generic[_V]):
             i = (i * 5 + perturb + 1) & mask
             ix = indices[i]
 
-    def del_idx(self, hash_: int, idx: int, *, _maxsize: int = MAXSIZE) -> None:
+    def del_idx(self, hash_: int, idx: int) -> None:
         mask = self.mask
         indices = self.indices
         i = hash_ & mask
-        perturb = hash_ & _maxsize
+        perturb = hash_ & MAXSIZE
         ix = indices[i]
         while ix != idx:
             perturb >>= 5
@@ -637,24 +619,18 @@ class _HtKeys(Generic[_V]):
         entries = reversed(self.entries) if reverse else self.entries
         return filter(None, entries)
 
-    def restore_hash(
-        self,
-        hash_: int,
-        *,
-        _hash_mask: int = HASH_MARK,
-        _maxsize: int = MAXSIZE,
-    ) -> None:
+    def restore_hash(self, hash_: int) -> None:
         mask = self.mask
         indices = self.indices
         entries = self.entries
         i = hash_ & mask
-        perturb = hash_ & _maxsize
+        perturb = hash_ & MAXSIZE
         ix = indices[i]
         while ix != -1:
             if ix != -2:
                 entry = entries[ix]
-                if entry.hash & _hash_mask:
-                    entry.hash &= _maxsize
+                if entry.hash & HASH_MARK:
+                    entry.hash &= MAXSIZE
             perturb >>= 5
             i = (i * 5 + perturb + 1) & mask
             ix = indices[i]
@@ -698,29 +674,22 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def getall(self, key: str) -> list[_V]: ...
     @overload
     def getall(self, key: str, default: _T) -> list[_V] | _T: ...
-    def getall(
-        self,
-        key: str,
-        default: _T | _SENTINEL = sentinel,
-        *,
-        _hash_mask: int = HASH_MARK,
-        _maxsize: int = MAXSIZE,
-    ) -> list[_V] | _T:
+    def getall(self, key: str, default: _T | _SENTINEL = sentinel) -> list[_V] | _T:
         """Return a list of all values matching the key."""
         identity = self._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         res = []
         restore = []
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 res.append(e.value)
-                e.hash |= _hash_mask
+                e.hash |= HASH_MARK
                 restore.append(idx)
 
         if res:
             entries = self._keys.entries
             for idx in restore:
-                entries[idx].hash &= _maxsize  # type: ignore[union-attr]
+                entries[idx].hash &= MAXSIZE  # type: ignore[union-attr]
             return res
         if not res and default is not sentinel:
             return default
@@ -730,19 +699,13 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def getone(self, key: str) -> _V: ...
     @overload
     def getone(self, key: str, default: _T) -> _V | _T: ...
-    def getone(
-        self,
-        key: str,
-        default: _T | _SENTINEL = sentinel,
-        *,
-        _maxsize: int = MAXSIZE,
-    ) -> _V | _T:
+    def getone(self, key: str, default: _T | _SENTINEL = sentinel) -> _V | _T:
         """Get first value matching the key.
 
         Raises KeyError if the key is not found and no default is provided.
         """
         identity = self._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 return e.value
@@ -806,11 +769,11 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 return False
         return True
 
-    def __contains__(self, key: object, *, _maxsize: int = MAXSIZE) -> bool:
+    def __contains__(self, key: object) -> bool:
         if not isinstance(key, str):
             return False
         identity = self._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 return True
@@ -829,9 +792,9 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def __reduce__(self) -> tuple[type[Self], tuple[list[tuple[str, _V]]]]:
         return (self.__class__, (list(self.items()),))
 
-    def add(self, key: str, value: _V, *, _maxsize: int = MAXSIZE) -> None:
+    def add(self, key: str, value: _V) -> None:
         identity = self._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         self._add_with_hash(_Entry(hash_, identity, key, value))
         self._incr_version()
 
@@ -856,8 +819,6 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         self,
         arg: MDArg[_V],
         kwargs: Mapping[str, _V],
-        *,
-        _maxsize: int = MAXSIZE,
     ) -> Iterator[int | _Entry[_V]]:
         identity_func = self._identity
         if isinstance(arg, MultiDictProxy):
@@ -873,16 +834,14 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 if self._ci is not arg._ci:
                     for e in arg._keys.iter_entries():
                         identity = identity_func(e.key)
-                        yield _Entry(
-                            hash(identity) & _maxsize, identity, e.key, e.value
-                        )
+                        yield _Entry(hash(identity) & MAXSIZE, identity, e.key, e.value)
                 else:
                     for e in arg._keys.iter_entries():
                         yield _Entry(e.hash, e.identity, e.key, e.value)
                 if kwargs:
                     for key, value in kwargs.items():
                         identity = identity_func(key)
-                        yield _Entry(hash(identity) & _maxsize, identity, key, value)
+                        yield _Entry(hash(identity) & MAXSIZE, identity, key, value)
             else:
                 if hasattr(arg, "keys"):
                     arg = cast(SupportsKeys[_V], arg)
@@ -915,12 +874,12 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                             f"value could not be fetched"
                         ) from exc
                     identity = identity_func(key)
-                    yield _Entry(hash(identity) & _maxsize, identity, key, value)
+                    yield _Entry(hash(identity) & MAXSIZE, identity, key, value)
         else:
             yield len(kwargs)
             for key, value in kwargs.items():
                 identity = identity_func(key)
-                yield _Entry(hash(identity) & _maxsize, identity, key, value)
+                yield _Entry(hash(identity) & MAXSIZE, identity, key, value)
 
     def _extend_items(self, items: Iterable[_Entry[_V]]) -> None:
         for e in items:
@@ -935,16 +894,9 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
 
     # Mapping interface #
 
-    def __setitem__(
-        self,
-        key: str,
-        value: _V,
-        *,
-        _hash_mask: int = HASH_MARK,
-        _maxsize: int = MAXSIZE,
-    ) -> None:
+    def __setitem__(self, key: str, value: _V) -> None:
         identity = self._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         found = False
 
         for slot, idx, e in self._keys.iter_hash(hash_):
@@ -952,10 +904,10 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 if not found:
                     e.key = key
                     e.value = value
-                    e.hash |= _hash_mask
+                    e.hash |= HASH_MARK
                     found = True
                     self._incr_version()
-                elif not (e.hash & _hash_mask):  # pragma: no branch
+                elif not (e.hash & HASH_MARK):  # pragma: no branch
                     self._del_at(slot, idx)
 
         if not found:
@@ -963,10 +915,10 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         else:
             self._keys.restore_hash(hash_)
 
-    def __delitem__(self, key: str, *, _maxsize: int = MAXSIZE) -> None:
+    def __delitem__(self, key: str) -> None:
         found = False
         identity = self._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 self._del_at(slot, idx)
@@ -982,12 +934,10 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     ) -> _T | None: ...
     @overload
     def setdefault(self, key: str, default: _V) -> _V: ...
-    def setdefault(  # type: ignore[misc]
-        self, key: str, default: _V | None = None, *, _maxsize: int = MAXSIZE
-    ) -> _V | None:
+    def setdefault(self, key: str, default: _V | None = None) -> _V | None:  # type: ignore[misc]
         """Return value for key, set value to default if key is not present."""
         identity = self._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 return e.value
@@ -998,13 +948,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def popone(self, key: str) -> _V: ...
     @overload
     def popone(self, key: str, default: _T) -> _V | _T: ...
-    def popone(
-        self,
-        key: str,
-        default: _T | _SENTINEL = sentinel,
-        *,
-        _maxsize: int = MAXSIZE,
-    ) -> _V | _T:
+    def popone(self, key: str, default: _T | _SENTINEL = sentinel) -> _V | _T:
         """Remove specified key and return the corresponding value.
 
         If key is not found, d is returned if given, otherwise
@@ -1012,7 +956,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
 
         """
         identity = self._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 value = e.value
@@ -1032,13 +976,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def popall(self, key: str) -> list[_V]: ...
     @overload
     def popall(self, key: str, default: _T) -> list[_V] | _T: ...
-    def popall(
-        self,
-        key: str,
-        default: _T | _SENTINEL = sentinel,
-        *,
-        _maxsize: int = MAXSIZE,
-    ) -> list[_V] | _T:
+    def popall(self, key: str, default: _T | _SENTINEL = sentinel) -> list[_V] | _T:
         """Remove all occurrences of key and return the list of corresponding
         values.
 
@@ -1048,7 +986,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         """
         found = False
         identity = self._identity(key)
-        hash_ = hash(identity) & _maxsize
+        hash_ = hash(identity) & MAXSIZE
         ret = []
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
@@ -1099,9 +1037,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         finally:
             self._post_update()
 
-    def _update_items(
-        self, items: Iterator[_Entry[_V]], *, _hash_mask: int = HASH_MARK
-    ) -> None:
+    def _update_items(self, items: Iterator[_Entry[_V]]) -> None:
         for entry in items:
             found = False
             hash_ = entry.hash
@@ -1112,15 +1048,13 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                         found = True
                         e.key = entry.key
                         e.value = entry.value
-                        e.hash |= _hash_mask
+                        e.hash |= HASH_MARK
                     else:
                         self._del_at_for_upd(e)
             if not found:
                 self._add_with_hash_for_upd(entry)
 
-    def _post_update(
-        self, *, _hash_mask: int = HASH_MARK, _maxsize: int = MAXSIZE
-    ) -> None:
+    def _post_update(self) -> None:
         keys = self._keys
         indices = keys.indices
         entries = keys.entries
@@ -1133,8 +1067,8 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                     entries[idx] = None
                     indices[slot] = -2
                     self._used -= 1
-                if e2.hash & _hash_mask:
-                    e2.hash &= _maxsize
+                if e2.hash & HASH_MARK:
+                    e2.hash &= MAXSIZE
 
         self._incr_version()
 
@@ -1193,15 +1127,13 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         self._used += 1
         keys.usable -= 1
 
-    def _add_with_hash_for_upd(
-        self, entry: _Entry[_V], *, _hash_mask: int = HASH_MARK
-    ) -> None:
+    def _add_with_hash_for_upd(self, entry: _Entry[_V]) -> None:
         if self._keys.usable <= 0:
             self._resize((self._used * 3 | _HtKeys.MINSIZE - 1).bit_length(), True)
         keys = self._keys
         slot = keys.find_empty_slot(entry.hash)
         keys.indices[slot] = len(keys.entries)
-        entry.hash |= _hash_mask
+        entry.hash |= HASH_MARK
         keys.entries.append(entry)
         self._incr_version()
         self._used += 1

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -160,8 +160,9 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
             if item is None:
                 continue
             hash_, identity, key, value = item
+            marked = hash_ | HASH_MARK
             for slot, idx, e in self._md._keys.iter_hash(hash_):
-                e.hash |= HASH_MARK
+                e.hash = marked
                 if e.identity == identity and e.value == value:
                     ret.add((e.key, e.value))
             self._md._keys.restore_hash(hash_)
@@ -627,7 +628,7 @@ class _HtKeys(Generic[_V]):
             if ix != -2:
                 entry = entries[ix]
                 if entry.hash & HASH_MARK:
-                    entry.hash &= MAXSIZE
+                    entry.hash = hash_
             perturb >>= 5
             i = (i * 5 + perturb + 1) & mask
             ix = indices[i]
@@ -675,18 +676,19 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         """Return a list of all values matching the key."""
         identity = self._identity(key)
         hash_ = hash(identity) & MAXSIZE
+        marked = hash_ | HASH_MARK
         res = []
         restore = []
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 res.append(e.value)
-                e.hash |= HASH_MARK
+                e.hash = marked
                 restore.append(idx)
 
         if res:
             entries = self._keys.entries
             for idx in restore:
-                entries[idx].hash &= MAXSIZE  # type: ignore[union-attr]
+                entries[idx].hash = hash_  # type: ignore[union-attr]
             return res
         if not res and default is not sentinel:
             return default
@@ -901,7 +903,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 if not found:
                     e.key = key
                     e.value = value
-                    e.hash |= HASH_MARK
+                    e.hash = hash_ | HASH_MARK
                     found = True
                     self._incr_version()
                 elif not (e.hash & HASH_MARK):  # pragma: no branch
@@ -1045,7 +1047,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                         found = True
                         e.key = entry.key
                         e.value = entry.value
-                        e.hash |= HASH_MARK
+                        e.hash = hash_ | HASH_MARK
                     else:
                         self._del_at_for_upd(e)
             if not found:
@@ -1064,8 +1066,9 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                     entries[idx] = None
                     indices[slot] = -2
                     self._used -= 1
-                if e2.hash & HASH_MARK:
-                    e2.hash &= MAXSIZE
+                h = e2.hash
+                if h & HASH_MARK:
+                    e2.hash = h & MAXSIZE
 
         self._incr_version()
 
@@ -1128,9 +1131,10 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         if self._keys.usable <= 0:
             self._resize((self._used * 3 | _HtKeys.MINSIZE - 1).bit_length(), True)
         keys = self._keys
-        slot = keys.find_empty_slot(entry.hash)
+        hash_ = entry.hash
+        slot = keys.find_empty_slot(hash_)
         keys.indices[slot] = len(keys.entries)
-        entry.hash |= HASH_MARK
+        entry.hash = hash_ | HASH_MARK
         keys.entries.append(entry)
         self._incr_version()
         self._used += 1

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -39,6 +39,11 @@ MAXSIZE = sys.maxsize
 # the same bit again restores the exact original hash, no recomputation
 # needed. A plain OR/AND wouldn't do: Python ints are arbitrary precision,
 # so any negative hash already reads that bit as set.
+#
+# Functions on the hot path take it as a hidden ``_hash_mask`` default
+# argument rather than reading it off the module each time: default values
+# are bound once, at function definition time, so the lookup inside the
+# function body is a fast local access instead of a global one.
 HASH_MARK = MAXSIZE + 1
 
 
@@ -147,7 +152,9 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 tmp.add((item[1], item[3]))
         return tmp
 
-    def __and__(self, other: Iterable[Any]) -> set[tuple[str, _V]]:
+    def __and__(
+        self, other: Iterable[Any], *, _hash_mask: int = HASH_MARK
+    ) -> set[tuple[str, _V]]:
         ret = set()
         try:
             it = iter(other)
@@ -159,7 +166,7 @@ class _ItemsView(_ViewBase[_V], ItemsView[str, _V]):
                 continue
             hash_, identity, key, value = item
             for slot, idx, e in self._md._keys.iter_hash(hash_):
-                e.hash ^= HASH_MARK
+                e.hash ^= _hash_mask
                 if e.identity == identity and e.value == value:
                     ret.add((e.key, e.value))
             self._md._keys.restore_hash(hash_)
@@ -555,17 +562,17 @@ class _HtKeys(Generic[_V]):
             entries=entries,
         )
 
-    def build_indices(self, update: bool) -> None:
+    def build_indices(self, update: bool, *, _hash_mask: int = HASH_MARK) -> None:
         mask = self.mask
         indices = self.indices
         for idx, e in enumerate(self.entries):
             assert e is not None
             hash_ = e.hash
             if update:
-                if hash_ > MAXSIZE or hash_ < -HASH_MARK:
-                    hash_ ^= HASH_MARK
+                if hash_ >= _hash_mask or hash_ < -_hash_mask:
+                    hash_ ^= _hash_mask
             else:
-                assert not (hash_ > MAXSIZE or hash_ < -HASH_MARK)
+                assert not (hash_ >= _hash_mask or hash_ < -_hash_mask)
             i = hash_ & mask
             perturb = hash_ & MAXSIZE
             while indices[i] != -1:
@@ -617,7 +624,7 @@ class _HtKeys(Generic[_V]):
         entries = reversed(self.entries) if reverse else self.entries
         return filter(None, entries)
 
-    def restore_hash(self, hash_: int) -> None:
+    def restore_hash(self, hash_: int, *, _hash_mask: int = HASH_MARK) -> None:
         mask = self.mask
         indices = self.indices
         entries = self.entries
@@ -627,8 +634,8 @@ class _HtKeys(Generic[_V]):
         while ix != -1:
             if ix != -2:
                 entry = entries[ix]
-                if entry.hash > MAXSIZE or entry.hash < -HASH_MARK:
-                    entry.hash ^= HASH_MARK
+                if entry.hash >= _hash_mask or entry.hash < -_hash_mask:
+                    entry.hash ^= _hash_mask
             perturb >>= 5
             i = (i * 5 + perturb + 1) & mask
             ix = indices[i]
@@ -672,7 +679,13 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
     def getall(self, key: str) -> list[_V]: ...
     @overload
     def getall(self, key: str, default: _T) -> list[_V] | _T: ...
-    def getall(self, key: str, default: _T | _SENTINEL = sentinel) -> list[_V] | _T:
+    def getall(
+        self,
+        key: str,
+        default: _T | _SENTINEL = sentinel,
+        *,
+        _hash_mask: int = HASH_MARK,
+    ) -> list[_V] | _T:
         """Return a list of all values matching the key."""
         identity = self._identity(key)
         hash_ = hash(identity)
@@ -681,13 +694,13 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         for slot, idx, e in self._keys.iter_hash(hash_):
             if e.identity == identity:  # pragma: no branch
                 res.append(e.value)
-                e.hash ^= HASH_MARK
+                e.hash ^= _hash_mask
                 restore.append(idx)
 
         if res:
             entries = self._keys.entries
             for idx in restore:
-                entries[idx].hash ^= HASH_MARK  # type: ignore[union-attr]
+                entries[idx].hash ^= _hash_mask  # type: ignore[union-attr]
             return res
         if not res and default is not sentinel:
             return default
@@ -892,7 +905,7 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
 
     # Mapping interface #
 
-    def __setitem__(self, key: str, value: _V) -> None:
+    def __setitem__(self, key: str, value: _V, *, _hash_mask: int = HASH_MARK) -> None:
         identity = self._identity(key)
         hash_ = hash(identity)
         found = False
@@ -902,10 +915,12 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                 if not found:
                     e.key = key
                     e.value = value
-                    e.hash ^= HASH_MARK
+                    e.hash ^= _hash_mask
                     found = True
                     self._incr_version()
-                elif not (e.hash > MAXSIZE or e.hash < -HASH_MARK):  # pragma: no branch
+                elif not (
+                    e.hash >= _hash_mask or e.hash < -_hash_mask
+                ):  # pragma: no branch
                     self._del_at(slot, idx)
 
         if not found:
@@ -1035,7 +1050,9 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         finally:
             self._post_update()
 
-    def _update_items(self, items: Iterator[_Entry[_V]]) -> None:
+    def _update_items(
+        self, items: Iterator[_Entry[_V]], *, _hash_mask: int = HASH_MARK
+    ) -> None:
         for entry in items:
             found = False
             hash_ = entry.hash
@@ -1046,13 +1063,13 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                         found = True
                         e.key = entry.key
                         e.value = entry.value
-                        e.hash ^= HASH_MARK
+                        e.hash ^= _hash_mask
                     else:
                         self._del_at_for_upd(e)
             if not found:
                 self._add_with_hash_for_upd(entry)
 
-    def _post_update(self) -> None:
+    def _post_update(self, *, _hash_mask: int = HASH_MARK) -> None:
         keys = self._keys
         indices = keys.indices
         entries = keys.entries
@@ -1065,8 +1082,8 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
                     entries[idx] = None
                     indices[slot] = -2
                     self._used -= 1
-                if e2.hash > MAXSIZE or e2.hash < -HASH_MARK:
-                    e2.hash ^= HASH_MARK
+                if e2.hash >= _hash_mask or e2.hash < -_hash_mask:
+                    e2.hash ^= _hash_mask
 
         self._incr_version()
 
@@ -1125,13 +1142,15 @@ class MultiDict(_CSMixin, MutableMultiMapping[_V]):
         self._used += 1
         keys.usable -= 1
 
-    def _add_with_hash_for_upd(self, entry: _Entry[_V]) -> None:
+    def _add_with_hash_for_upd(
+        self, entry: _Entry[_V], *, _hash_mask: int = HASH_MARK
+    ) -> None:
         if self._keys.usable <= 0:
             self._resize((self._used * 3 | _HtKeys.MINSIZE - 1).bit_length(), True)
         keys = self._keys
         slot = keys.find_empty_slot(entry.hash)
         keys.indices[slot] = len(keys.entries)
-        entry.hash ^= HASH_MARK
+        entry.hash ^= _hash_mask
         keys.entries.append(entry)
         self._incr_version()
         self._used += 1

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -1361,7 +1361,9 @@ md_post_update(MultiDictObject* md)
                 htkeys_set_index(keys, slot, DKIX_DUMMY);
                 md->used -= 1;
             }
-            entry->hash &= PY_SSIZE_T_MAX;
+            if (entry->hash < 0) {
+                entry->hash &= PY_SSIZE_T_MAX;
+            }
         }
     }
     ASSERT_CONSISTENT(md, false);

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -36,7 +36,6 @@ typedef enum _UpdateOp {
     Merge,
 } UpdateOp;
 
-/* The hash range's high bit; see the marking scheme described below. */
 #define MD_HASH_MARK PY_SSIZE_T_MIN
 
 /*

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -36,6 +36,9 @@ typedef enum _UpdateOp {
     Merge,
 } UpdateOp;
 
+/* The hash range's high bit; see the marking scheme described below. */
+#define MD_HASH_MARK PY_SSIZE_T_MIN
+
 /*
 The multidict's implementation is close to Python's dict except for multiple
 keys.
@@ -57,10 +60,13 @@ amount.
 
 The iteration for operations like getall() is a little tricky. The next index
 calculation could return the already visited index before reaching the end. To
-eliminate duplicates, the code marks already visited entries by entry->hash =
--1. -1 hash is an invalid hash value that could be used as a marker. After the
-iteration finishes, all marked entries are restored.  Double iteration over the
-indices still has O(1) amortized time, it is ok.
+eliminate duplicates, the code marks already visited entries. Entry hashes are
+folded non-negative (_unicode_hash() masks with PY_SSIZE_T_MAX), so
+MD_HASH_MARK, the hash range's high bit, can mark a hash as temporarily
+invalid: OR it in, AND it out with PY_SSIZE_T_MAX to restore. A real folded
+hash never has that bit set, so a marked entry is simply one whose hash is
+negative. After the iteration finishes, all marked entries are restored. Double
+iteration over the indices still has O(1) amortized time, it is ok.
 
 `.add()`, `val = md[key]`, `md[key] = val`, `md.setdefault()` all have O(1).
 `.getall()` / `.popall()` have O(N) where N is the amount of returned items.
@@ -484,7 +490,7 @@ _md_add_for_upd_steal_refs(MultiDictObject* md, Py_hash_t hash,
     entry->identity = identity;
     entry->key = key;
     entry->value = value;
-    entry->hash = -1;
+    entry->hash = hash | MD_HASH_MARK;
 
     md->version = NEXT_VERSION(md->state);
     md->used += 1;
@@ -807,7 +813,7 @@ md_find_next(md_finder_t* finder, PyObject** pkey, PyObject** pvalue)
         }
 
         /* found, mark the entry as visited */
-        entry->hash = -1;
+        entry->hash = finder->hash | MD_HASH_MARK;
 
         if (pkey) {
             *pkey = _md_ensure_key(finder->md, entry);
@@ -846,7 +852,7 @@ md_finder_cleanup(md_finder_t* finder)
             continue;
         }
         entry_t* entry = entries + finder->iter.index;
-        if (entry->hash == -1) {
+        if (entry->hash < 0) {
             entry->hash = finder->hash;
         }
     }
@@ -1215,7 +1221,7 @@ _md_replace(MultiDictObject* md, PyObject* key, PyObject* value,
             found = 1;
             Py_SETREF(entry->key, Py_NewRef(key));
             Py_SETREF(entry->value, Py_NewRef(value));
-            entry->hash = -1;
+            entry->hash = finder.hash | MD_HASH_MARK;
         } else {
             _md_del_at(md, md_finder_slot(&finder), entry);
         }
@@ -1292,7 +1298,7 @@ _md_update(MultiDictObject* md, Py_hash_t hash, PyObject* identity,
                     Py_SETREF(entry->key, Py_NewRef(key));
                     Py_SETREF(entry->value, Py_NewRef(value));
                 }
-                entry->hash = -1;
+                entry->hash = hash | MD_HASH_MARK;
             } else {
                 _md_del_at_for_upd(md, iter.slot, entry);
             }
@@ -1355,10 +1361,7 @@ md_post_update(MultiDictObject* md)
                 htkeys_set_index(keys, slot, DKIX_DUMMY);
                 md->used -= 1;
             }
-            if (entry->hash == -1) {
-                entry->hash = _unicode_hash(entry->identity);
-            }
-            assert(entry->hash != -1);
+            entry->hash &= PY_SSIZE_T_MAX;
         }
     }
     ASSERT_CONSISTENT(md, false);
@@ -2054,7 +2057,7 @@ _md_check_consistency(MultiDictObject* md, bool update)
 
         if (identity != NULL) {
             if (!update) {
-                CHECK(entry->hash != -1);
+                CHECK(entry->hash >= 0);
                 CHECK(entry->key != NULL);
                 CHECK(entry->value != NULL);
             } else {
@@ -2066,7 +2069,7 @@ _md_check_consistency(MultiDictObject* md, bool update)
             }
 
             CHECK(PyUnicode_CheckExact(identity));
-            if (entry->hash != -1) {
+            if (entry->hash >= 0) {
                 Py_hash_t hash = _unicode_hash(identity);
                 CHECK(entry->hash == hash);
             }

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -342,7 +342,7 @@ htkeys_build_indices(htkeys_t* keys, entry_t* ep, Py_ssize_t n, bool update)
     size_t mask = htkeys_mask(keys);
     for (Py_ssize_t ix = 0; ix != n; ix++, ep++) {
         Py_hash_t hash = ep->hash;
-        if (update) {
+        if (update && hash < 0) {
             hash &= PY_SSIZE_T_MAX;
         }
         size_t i = hash & mask;

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -313,15 +313,24 @@ htkeys_free(htkeys_t* dk)
     PyMem_Free(dk);
 }
 
+/* Returns the identity's hash folded into its non-negative half (see the
+   MD_HASH_MARK comment in hashtable.h), or -1 if hashing raised. Only the
+   value returned to the caller is folded; the unicode object's own cached
+   hash slot is left untouched, since it is shared with the rest of the
+   process. */
 static inline Py_hash_t
 _unicode_hash(PyObject* o)
 {
     assert(PyUnicode_CheckExact(o));
     PyASCIIObject* ascii = (PyASCIIObject*)o;
-    if (ascii->hash != -1) {
-        return ascii->hash;
+    Py_hash_t hash = ascii->hash;
+    if (hash == -1) {
+        hash = PyUnicode_Type.tp_hash(o);
+        if (hash == -1) {
+            return -1;
+        }
     }
-    return PyUnicode_Type.tp_hash(o);
+    return hash & PY_SSIZE_T_MAX;
 }
 
 /*
@@ -334,14 +343,7 @@ htkeys_build_indices(htkeys_t* keys, entry_t* ep, Py_ssize_t n, bool update)
     for (Py_ssize_t ix = 0; ix != n; ix++, ep++) {
         Py_hash_t hash = ep->hash;
         if (update) {
-            if (hash == -1) {
-                hash = _unicode_hash(ep->identity);
-                if (hash == -1) {
-                    return -1;
-                }
-            }
-        } else {
-            assert(hash != -1);
+            hash &= PY_SSIZE_T_MAX;
         }
         size_t i = hash & mask;
         for (size_t perturb = hash; htkeys_get_index(keys, i) != DKIX_EMPTY;) {

--- a/tests/test_mutable_multidict.py
+++ b/tests/test_mutable_multidict.py
@@ -484,6 +484,22 @@ class TestMutableMultiDict:
         d = case_sensitive_multidict_class((str(i), i) for i in range(size))
         assert d[str(size // 2)] == size // 2
 
+    def test_update_resizes_mid_update_on_capped_huge_md(
+        self,
+        case_sensitive_multidict_class: type[MultiDict[int]],
+    ) -> None:
+        # The upfront size estimate in update()/merge() is capped to avoid
+        # overallocating on huge inputs, so a multidict already at that cap
+        # can run out of usable slots while update() is still processing
+        # new keys, forcing a resize in the middle of the update instead of
+        # upfront.
+        size = 87381  # usable slot count once the size estimate hits its cap
+        d = case_sensitive_multidict_class((str(i), i) for i in range(size))
+        d.update({"newkey": -1})
+        assert d["newkey"] == -1
+        assert d[str(size // 2)] == size // 2
+        assert len(d) == size + 1
+
     def test_create_from_proxy(
         self,
         case_sensitive_multidict_class: type[MultiDict[int]],


### PR DESCRIPTION
## What do these changes do?

Both backends marked a hash table entry invalid mid-update by overwriting its hash with `-1`, then recomputed it from the identity to restore it. This replaces that with a marker bit (the hash's high bit): OR to set, AND to clear. That needs every hash non-negative first, so hashes are folded once, right where computed (`& MAXSIZE` in Python, inside `_unicode_hash()` in C). Restoring is then a bit-clear or a direct assignment of an already-known value, never a recomputation.

Python's `hash()` is arbitrary precision, so a negative hash already reads the high bit as set, which is why plain OR/AND needs the fold first. C's `Py_hash_t` is fixed-width, so once folded, "is marked" is just `entry->hash < 0`. `_unicode_hash()` folds only the value it returns to multidict, never the unicode object's own cached hash slot (shared process-wide). The ~15 `_unicode_hash(...) == -1` checks for a genuine hash-computation error are untouched — a different, CPython-standard meaning of `-1`.

Also adds a test for a related previously-uncovered path: a multidict already at `update()`'s size-estimate cap needing a resize mid-`update()`, which no existing test reached.

CodSpeed flagged a transient regression on `getall` partway through this PR (a read-modify-write per marked entry where the `-1` sentinel only wrote a constant); fixed by assigning known values directly and hoisting the loop-invariant mark value out of the hot loops. Latest CodSpeed run shows a **12.98% improvement**, including measurable C-extension `getall` gains.

## Are there changes in behavior for the user?

No. Internal implementation detail of both backends.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (existing suite covers these paths; added a test for the previously-uncovered resize-during-update path)
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
- [x] `make doc-spelling` passes and any new technical words are added to `docs/spelling_wordlist.txt`

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: `pytest -q` (C extension, 1802 passed) and `MULTIDICT_NO_EXTENSIONS=1 pytest -q --no-c-extensions` (pure Python, 914 passed), plus a full run under a debug build (`-UNDEBUG`) so `_md_check_consistency()`'s assertions verify every mutation.

Verified with a stress script exercising every mutating method against a deliberate mix of negative- and positive-hash keys, since normal runs only hit negative hashes by chance of `PYTHONHASHSEED`.

Compiled clean with `-Werror -Wsign-compare -Wconversion -std=c11` in both release and debug modes.

`make doc-spelling`: passes for this change; one pre-existing, unrelated failure on `master` (a "fallbacks" false positive) is not introduced by this PR.

Drafted with Claude Code (Sonnet 5); reviewed by asvetlov.

</details>