### PR TITLE
Use plain build frontend for iOS wheels in cibuildwheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ build-frontend = "build[uv]"
 test-requires = "-r requirements/pytest.txt"
 test-command = 'pytest -m "not leaks" --no-cov {project}/tests'
 
+[tool.cibuildwheel.ios]
+# uv does not support building for iOS; fall back to the plain `build`
+# frontend for this platform.
+build-frontend = "build"
+
 [tool.cibuildwheel.linux]
 # Re-enable 32-bit builds (disabled by default in cibuildwheel 3.0)
 archs = ["auto", "auto32"]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The iOS wheel build job (`Build wheels for mobile arches / Build ios wheels`)
fails with `cibuildwheel: uv doesn't support iOS`, because #1350 switched
the global `build-frontend` to `build[uv]` without an iOS-specific override,
and `uv` cannot build for iOS. Adding a `[tool.cibuildwheel.ios]` override
that falls back to the plain `build` frontend for that platform only fixes
the failure; other platforms keep using `uv`.

## Are there changes in behavior for the user?

No, this only affects the CI wheel build for iOS.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder
- [x] `make doc-spelling` passes and any new technical words are added to `docs/spelling_wordlist.txt`

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Validated the `pyproject.toml` change parses and the new
`[tool.cibuildwheel.ios]` section conforms to cibuildwheel 4.2.1's
JSON schema (`jsonschema.validate` against
`cibuildwheel/resources/cibuildwheel.schema.json`). Not run through
the actual iOS CI leg; no CHANGES fragment included at the
requester's instruction.

</details>

Drafted with Claude Code (Sonnet 5); reviewed by andrew.svetlov@gmail.com.