### PR TITLE
Protect MultiDict repr() with a critical section and fix recursion guards

### DIFF
--- a/CHANGES/1431.bugfix.1.rst
+++ b/CHANGES/1431.bugfix.1.rst
@@ -1,0 +1,4 @@
+Guarded ``repr()`` of ``MultiDictProxy`` and ``KeysView`` in the C
+extension against infinite recursion on self-referential containers,
+matching the existing guard on ``MultiDict``, ``ItemsView``, and
+``ValuesView`` -- by :user:`asvetlov`.

--- a/CHANGES/1431.bugfix.1.rst
+++ b/CHANGES/1431.bugfix.1.rst
@@ -1,4 +1,5 @@
-Guarded ``repr()`` of ``MultiDictProxy`` and ``KeysView`` in the C
-extension against infinite recursion on self-referential containers,
-matching the existing guard on ``MultiDict``, ``ItemsView``, and
-``ValuesView`` -- by :user:`asvetlov`.
+Guarded ``repr()`` of ``MultiDictProxy`` in the C extension and of
+``KeysView`` in both the C extension and the pure-Python
+implementation against infinite recursion on self-referential
+containers, matching the existing guard on ``MultiDict``,
+``ItemsView``, and ``ValuesView`` -- by :user:`asvetlov`.

--- a/CHANGES/1431.bugfix.rst
+++ b/CHANGES/1431.bugfix.rst
@@ -1,0 +1,3 @@
+Protected ``repr()`` of ``MultiDict``, ``MultiDictProxy``, and their views
+in the C extension with a critical section, avoiding data races on the
+free-threaded build of CPython -- by :user:`asvetlov`.

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -1264,13 +1264,24 @@ multidict_proxy_tp_clear(MultiDictProxyObject* self)
 static PyObject*
 multidict_proxy_repr(MultiDictProxyObject* self)
 {
+    int tmp = Py_ReprEnter((PyObject*)self);
+    if (tmp < 0) {
+        return NULL;
+    }
+    if (tmp > 0) {
+        return PyUnicode_FromString("...");
+    }
     PyObject* name =
         PyObject_GetAttr((PyObject*)Py_TYPE(self), self->md->state->str_name);
-    if (name == NULL) return NULL;
+    if (name == NULL) {
+        Py_ReprLeave((PyObject*)self);
+        return NULL;
+    }
     PyObject* ret;
     Py_BEGIN_CRITICAL_SECTION(self->md);
     ret = md_repr(self->md, name, true, true);
     Py_END_CRITICAL_SECTION();
+    Py_ReprLeave((PyObject*)self);
     Py_CLEAR(name);
     return ret;
 }

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -414,7 +414,10 @@ multidict_repr(MultiDictObject* self)
         Py_ReprLeave((PyObject*)self);
         return NULL;
     }
-    PyObject* ret = md_repr(self, name, true, true);
+    PyObject* ret;
+    Py_BEGIN_CRITICAL_SECTION(self);
+    ret = md_repr(self, name, true, true);
+    Py_END_CRITICAL_SECTION();
     Py_ReprLeave((PyObject*)self);
     Py_CLEAR(name);
     return ret;
@@ -1264,7 +1267,10 @@ multidict_proxy_repr(MultiDictProxyObject* self)
     PyObject* name =
         PyObject_GetAttr((PyObject*)Py_TYPE(self), self->md->state->str_name);
     if (name == NULL) return NULL;
-    PyObject* ret = md_repr(self->md, name, true, true);
+    PyObject* ret;
+    Py_BEGIN_CRITICAL_SECTION(self->md);
+    ret = md_repr(self->md, name, true, true);
+    Py_END_CRITICAL_SECTION();
     Py_CLEAR(name);
     return ret;
 }

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -401,25 +401,10 @@ ret:
 static PyObject*
 multidict_repr(MultiDictObject* self)
 {
-    int tmp = Py_ReprEnter((PyObject*)self);
-    if (tmp < 0) {
-        return NULL;
-    }
-    if (tmp > 0) {
-        return PyUnicode_FromString("...");
-    }
-    PyObject* name =
-        PyObject_GetAttr((PyObject*)Py_TYPE(self), self->state->str_name);
-    if (name == NULL) {
-        Py_ReprLeave((PyObject*)self);
-        return NULL;
-    }
     PyObject* ret;
     Py_BEGIN_CRITICAL_SECTION(self);
-    ret = md_repr(self, name, true, true);
+    ret = md_repr(self, (PyObject*)self, true, true);
     Py_END_CRITICAL_SECTION();
-    Py_ReprLeave((PyObject*)self);
-    Py_CLEAR(name);
     return ret;
 }
 
@@ -1264,25 +1249,10 @@ multidict_proxy_tp_clear(MultiDictProxyObject* self)
 static PyObject*
 multidict_proxy_repr(MultiDictProxyObject* self)
 {
-    int tmp = Py_ReprEnter((PyObject*)self);
-    if (tmp < 0) {
-        return NULL;
-    }
-    if (tmp > 0) {
-        return PyUnicode_FromString("...");
-    }
-    PyObject* name =
-        PyObject_GetAttr((PyObject*)Py_TYPE(self), self->md->state->str_name);
-    if (name == NULL) {
-        Py_ReprLeave((PyObject*)self);
-        return NULL;
-    }
     PyObject* ret;
     Py_BEGIN_CRITICAL_SECTION(self->md);
-    ret = md_repr(self->md, name, true, true);
+    ret = md_repr(self->md, (PyObject*)self, true, true);
     Py_END_CRITICAL_SECTION();
-    Py_ReprLeave((PyObject*)self);
-    Py_CLEAR(name);
     return ret;
 }
 

--- a/multidict/_multidict_py.py
+++ b/multidict/_multidict_py.py
@@ -319,6 +319,7 @@ class _KeysView(_ViewBase[_V], KeysView[str]):
                 raise RuntimeError("Dictionary changed during iteration")
             yield self._md._key(e.key)
 
+    @reprlib.recursive_repr()
     def __repr__(self) -> str:
         lst = []
         for e in self._md._keys.iter_entries():

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -1861,8 +1861,20 @@ md_eq_to_mapping(MultiDictObject* md, PyObject* other)
 }
 
 static inline PyObject*
-md_repr(MultiDictObject* md, PyObject* name, bool show_keys, bool show_values)
+md_repr(MultiDictObject* md, PyObject* obj, bool show_keys, bool show_values)
 {
+    int reprenter = Py_ReprEnter(obj);
+    if (reprenter != 0) {
+        return reprenter > 0 ? PyUnicode_FromString("...") : NULL;
+    }
+
+    PyObject* name =
+        PyObject_GetAttr((PyObject*)Py_TYPE(obj), md->state->str_name);
+    if (name == NULL) {
+        Py_ReprLeave(obj);
+        return NULL;
+    }
+
     PyObject* key = NULL;
     PyObject* value = NULL;
 
@@ -1870,7 +1882,11 @@ md_repr(MultiDictObject* md, PyObject* name, bool show_keys, bool show_values)
     uint64_t version = md->version;
 
     PyUnicodeWriter* writer = PyUnicodeWriter_Create(1024);
-    if (writer == NULL) return NULL;
+    if (writer == NULL) {
+        Py_CLEAR(name);
+        Py_ReprLeave(obj);
+        return NULL;
+    }
 
     if (PyUnicodeWriter_WriteChar(writer, '<') < 0) {
         goto fail;
@@ -1966,11 +1982,15 @@ md_repr(MultiDictObject* md, PyObject* name, bool show_keys, bool show_values)
     if (PyUnicodeWriter_WriteChar(writer, '>') < 0) {
         goto fail;
     }
+    Py_CLEAR(name);
+    Py_ReprLeave(obj);
     return PyUnicodeWriter_Finish(writer);
 fail:
     Py_CLEAR(key);
     Py_CLEAR(value);
+    Py_CLEAR(name);
     PyUnicodeWriter_Discard(writer);
+    Py_ReprLeave(obj);
     return NULL;
 }
 

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -1125,15 +1125,24 @@ multidict_keysview_iter(_Multidict_ViewObject* self)
 static inline PyObject*
 multidict_keysview_repr(_Multidict_ViewObject* self)
 {
+    int tmp = Py_ReprEnter((PyObject*)self);
+    if (tmp < 0) {
+        return NULL;
+    }
+    if (tmp > 0) {
+        return PyUnicode_FromString("...");
+    }
     PyObject* name =
         PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__name__");
     if (name == NULL) {
+        Py_ReprLeave((PyObject*)self);
         return NULL;
     }
     PyObject* ret;
     Py_BEGIN_CRITICAL_SECTION(self->md);
     ret = md_repr(self->md, name, true, false);
     Py_END_CRITICAL_SECTION();
+    Py_ReprLeave((PyObject*)self);
     Py_CLEAR(name);
     return ret;
 }

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -178,25 +178,10 @@ multidict_itemsview_iter(_Multidict_ViewObject* self)
 static inline PyObject*
 multidict_itemsview_repr(_Multidict_ViewObject* self)
 {
-    int tmp = Py_ReprEnter((PyObject*)self);
-    if (tmp < 0) {
-        return NULL;
-    }
-    if (tmp > 0) {
-        return PyUnicode_FromString("...");
-    }
-    PyObject* name =
-        PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__name__");
-    if (name == NULL) {
-        Py_ReprLeave((PyObject*)self);
-        return NULL;
-    }
     PyObject* ret;
     Py_BEGIN_CRITICAL_SECTION(self->md);
-    ret = md_repr(self->md, name, true, true);
+    ret = md_repr(self->md, (PyObject*)self, true, true);
     Py_END_CRITICAL_SECTION();
-    Py_ReprLeave((PyObject*)self);
-    Py_CLEAR(name);
     return ret;
 }
 
@@ -1125,25 +1110,10 @@ multidict_keysview_iter(_Multidict_ViewObject* self)
 static inline PyObject*
 multidict_keysview_repr(_Multidict_ViewObject* self)
 {
-    int tmp = Py_ReprEnter((PyObject*)self);
-    if (tmp < 0) {
-        return NULL;
-    }
-    if (tmp > 0) {
-        return PyUnicode_FromString("...");
-    }
-    PyObject* name =
-        PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__name__");
-    if (name == NULL) {
-        Py_ReprLeave((PyObject*)self);
-        return NULL;
-    }
     PyObject* ret;
     Py_BEGIN_CRITICAL_SECTION(self->md);
-    ret = md_repr(self->md, name, true, false);
+    ret = md_repr(self->md, (PyObject*)self, true, false);
     Py_END_CRITICAL_SECTION();
-    Py_ReprLeave((PyObject*)self);
-    Py_CLEAR(name);
     return ret;
 }
 
@@ -1704,25 +1674,10 @@ multidict_valuesview_iter(_Multidict_ViewObject* self)
 static inline PyObject*
 multidict_valuesview_repr(_Multidict_ViewObject* self)
 {
-    int tmp = Py_ReprEnter((PyObject*)self);
-    if (tmp < 0) {
-        return NULL;
-    }
-    if (tmp > 0) {
-        return PyUnicode_FromString("...");
-    }
-    PyObject* name =
-        PyObject_GetAttrString((PyObject*)Py_TYPE(self), "__name__");
-    if (name == NULL) {
-        Py_ReprLeave((PyObject*)self);
-        return NULL;
-    }
     PyObject* ret;
     Py_BEGIN_CRITICAL_SECTION(self->md);
-    ret = md_repr(self->md, name, false, true);
+    ret = md_repr(self->md, (PyObject*)self, false, true);
     Py_END_CRITICAL_SECTION();
-    Py_ReprLeave((PyObject*)self);
-    Py_CLEAR(name);
     return ret;
 }
 

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -191,7 +191,10 @@ multidict_itemsview_repr(_Multidict_ViewObject* self)
         Py_ReprLeave((PyObject*)self);
         return NULL;
     }
-    PyObject* ret = md_repr(self->md, name, true, true);
+    PyObject* ret;
+    Py_BEGIN_CRITICAL_SECTION(self->md);
+    ret = md_repr(self->md, name, true, true);
+    Py_END_CRITICAL_SECTION();
     Py_ReprLeave((PyObject*)self);
     Py_CLEAR(name);
     return ret;
@@ -1127,7 +1130,10 @@ multidict_keysview_repr(_Multidict_ViewObject* self)
     if (name == NULL) {
         return NULL;
     }
-    PyObject* ret = md_repr(self->md, name, true, false);
+    PyObject* ret;
+    Py_BEGIN_CRITICAL_SECTION(self->md);
+    ret = md_repr(self->md, name, true, false);
+    Py_END_CRITICAL_SECTION();
     Py_CLEAR(name);
     return ret;
 }
@@ -1702,7 +1708,10 @@ multidict_valuesview_repr(_Multidict_ViewObject* self)
         Py_ReprLeave((PyObject*)self);
         return NULL;
     }
-    PyObject* ret = md_repr(self->md, name, false, true);
+    PyObject* ret;
+    Py_BEGIN_CRITICAL_SECTION(self->md);
+    ret = md_repr(self->md, name, false, true);
+    Py_END_CRITICAL_SECTION();
     Py_ReprLeave((PyObject*)self);
     Py_CLEAR(name);
     return ret;

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -834,6 +834,19 @@ class TestMultiDict(BaseMultiDictTest):
 
         assert str(d) == f"<{_cls.__name__}('key': ...)>"
 
+    def test_proxy__repr___recursive(
+        self,
+        any_multidict_class: type[MultiDict[object]],
+        any_multidict_proxy_class: type[MultiDictProxy[object]],
+    ) -> None:
+        d = any_multidict_class()
+        d["key"] = any_multidict_proxy_class(d)
+        proxy = any_multidict_proxy_class(d)
+        _cls = type(proxy)
+
+        expected = f"<{_cls.__name__}('key': <{_cls.__name__}('key': ...)>)>"
+        assert str(proxy) == expected
+
     def test_getall(self, cls: type[MultiDict[str]]) -> None:
         d = cls([("key", "value1")], key="value2")
 
@@ -877,6 +890,23 @@ class TestMultiDict(BaseMultiDictTest):
     def test_keys__repr__(self, cls: type[MultiDict[str]]) -> None:
         d = cls([("key", "value1")], key="value2")
         assert repr(d.keys()) == "<_KeysView('key', 'key')>"
+
+    def test_keys__repr__recursive(
+        self, case_sensitive_multidict_class: type[MultiDict[object]]
+    ) -> None:
+        d = case_sensitive_multidict_class()
+        kv = d.keys()
+
+        class Key(str):
+            def __repr__(self) -> str:
+                return repr(kv)
+
+        # a quote forces md_repr() to call repr() on the key instead of
+        # writing its characters directly, so the custom __repr__() above
+        # is exercised and can recurse back into the keys view.
+        d[Key("a'b")] = "value"
+
+        assert repr(kv) == "<_KeysView(...)>"
 
     def test_values__repr__(self, cls: type[MultiDict[str]]) -> None:
         d = cls([("key", "value1")], key="value2")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Protects `repr()` of `MultiDict`, `MultiDictProxy`, and their items/keys/values
views in the C extension with `Py_BEGIN_CRITICAL_SECTION`, avoiding data races
when another thread mutates the multidict during iteration on the
free-threaded build of CPython. Also adds the missing `Py_ReprEnter`/
`Py_ReprLeave` recursion guard to `MultiDictProxy` and `KeysView` repr in the
C extension (already present on `MultiDict`, `ItemsView`, and `ValuesView`),
consolidates that guard plus the `__name__` lookup into the shared
`md_repr()` helper, and adds the same missing guard to the pure-Python
`_KeysView.__repr__`, which never had it either.

## Are there changes in behavior for the user?

Yes: a self-referential `MultiDictProxy` or `KeysView` now prints `...` for
the cyclic reference instead of recursing until `RecursionError`, matching
the existing behavior of `MultiDict`, `ItemsView`, and `ValuesView`, on both
the C extension and the pure-Python implementation.

## Is it a substantial burden for the maintainers to support this?

No, it only touches the `repr()` implementations and uses the critical
section macros already vendored via `pythoncapi_compat.h`.

## Related issue number

#1432 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
- [x] `make doc-spelling` passes and any new technical words are added to `docs/spelling_wordlist.txt`

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: `pytest -q` (1808 passed, C extension + pure-Python legs) and
`MULTIDICT_NO_EXTENSIONS=1 pytest -q --no-c-extensions` (917 passed,
pure-Python-only leg)
Lint: `make lint` (ruff, clang-format, mypy, yamllint, etc.) all passed
Spelling: `make doc-spelling` passes for the new fragments; one pre-existing,
unrelated failure in already-released `CHANGES.rst` ("fallbacks" not in the
wordlist) predates this branch and was left untouched

Drafted with Claude Code (Sonnet 5); reviewed by asvetlov.
</details>
