### PR TITLE
Implement tp_vectorcall for MultiDict, CIMultiDict and their proxies

### DIFF
--- a/CHANGES/1436.feature.rst
+++ b/CHANGES/1436.feature.rst
@@ -1,5 +1,5 @@
 ``MultiDict``, ``CIMultiDict``, ``MultiDictProxy`` and ``CIMultiDictProxy`` in the
-C extension now implement the vectorcall calling convention for construction,
-speeding up ``MultiDict(...)``-style calls by avoiding an intermediate
+C extension implemented the vectorcall calling convention for construction.
+This sped up ``MultiDict(...)``-style calls by avoiding an intermediate
 positional-arguments tuple and keyword-arguments dictionary in the common case
 -- by :user:`asvetlov`.

--- a/CHANGES/1436.feature.rst
+++ b/CHANGES/1436.feature.rst
@@ -1,0 +1,5 @@
+``MultiDict``, ``CIMultiDict``, ``MultiDictProxy`` and ``CIMultiDictProxy`` in the
+C extension now implement the vectorcall calling convention for construction,
+speeding up ``MultiDict(...)``-style calls by avoiding an intermediate
+positional-arguments tuple and keyword-arguments dictionary in the common case
+-- by :user:`asvetlov`.

--- a/CHANGES/1436.feature.rst
+++ b/CHANGES/1436.feature.rst
@@ -1,5 +1,5 @@
 ``MultiDict``, ``CIMultiDict``, ``MultiDictProxy`` and ``CIMultiDictProxy`` in the
 C extension implemented the vectorcall calling convention for construction.
 This sped up ``MultiDict(...)``-style calls by avoiding an intermediate
-positional-arguments tuple and keyword-arguments dictionary in the common case
+positional-arguments tuple and keyword-arguments dictionary in the common case; the gained burst is ~10.
 -- by :user:`asvetlov`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -125,6 +125,7 @@ url
 urlencoded
 urls
 utf
+vectorcall
 websocket
 websockets
 Websockets

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -175,45 +175,6 @@ done:
     return ret;
 }
 
-/* ---- tp_vectorcall-based fast construction ----
-
-   Unlike multidict_tp_init()/cimultidict_tp_init(), the object under
-   construction here (``self``) has just been allocated and has not been
-   returned to Python yet, so it cannot be observed by any other thread.
-   There is therefore no need for a critical section on ``self``, only on
-   ``other`` (an existing multidict/proxy argument) or on a plain dict
-   argument, same as the read side of the classic constructors. */
-
-static inline Py_ssize_t
-_multidict_ctor_size_hint(mod_state* state, PyObject* arg, Py_ssize_t nkwargs)
-{
-    Py_ssize_t size = nkwargs;
-    if (arg != NULL) {
-        if (PyTuple_CheckExact(arg)) {
-            size += PyTuple_GET_SIZE(arg);
-        } else if (PyList_CheckExact(arg)) {
-            size += PyList_GET_SIZE(arg);
-        } else if (PyDict_CheckExact(arg)) {
-            size += PyDict_GET_SIZE(arg);
-        } else if (MultiDict_CheckExact(state, arg) ||
-                   CIMultiDict_CheckExact(state, arg)) {
-            size += md_len((MultiDictObject*)arg);
-        } else if (MultiDictProxy_CheckExact(state, arg) ||
-                   CIMultiDictProxy_CheckExact(state, arg)) {
-            size += md_len(((MultiDictProxyObject*)arg)->md);
-        } else {
-            Py_ssize_t s = PyObject_LengthHint(arg, 0);
-            if (s < 0) {
-                // e.g. cannot calc size of generator object
-                PyErr_Clear();
-            } else {
-                size += s;
-            }
-        }
-    }
-    return size;
-}
-
 static inline int
 _multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
                            PyObject* arg, PyObject* const* args,

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -185,9 +185,9 @@ done:
    argument, same as the read side of the classic constructors. */
 
 static inline Py_ssize_t
-_multidict_ctor_size_hint(mod_state* state, PyObject* arg, PyObject* kwds)
+_multidict_ctor_size_hint(mod_state* state, PyObject* arg, Py_ssize_t nkwargs)
 {
-    Py_ssize_t size = 0;
+    Py_ssize_t size = nkwargs;
     if (arg != NULL) {
         if (PyTuple_CheckExact(arg)) {
             size += PyTuple_GET_SIZE(arg);
@@ -211,42 +211,34 @@ _multidict_ctor_size_hint(mod_state* state, PyObject* arg, PyObject* kwds)
             }
         }
     }
-    if (kwds != NULL) {
-        size += PyDict_GET_SIZE(kwds);
-    }
     return size;
 }
 
-static inline PyObject*
-_multidict_kwnames_as_dict(PyObject* const* args, Py_ssize_t nargs,
-                           PyObject* kwnames)
+static inline int
+_multidict_validate_kwnames(PyObject* kwnames)
 {
-    Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
-    PyObject* kwds = PyDict_New();
-    if (kwds == NULL) {
-        return NULL;
+    if (kwnames == NULL) {
+        return 0;
     }
+    Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
     for (Py_ssize_t i = 0; i < nkwargs; i++) {
-        PyObject* key = PyTuple_GET_ITEM(kwnames, i);
-        if (PyDict_SetItem(kwds, key, args[nargs + i]) < 0) {
-            Py_DECREF(kwds);
-            return NULL;
+        if (!PyUnicode_Check(PyTuple_GET_ITEM(kwnames, i))) {
+            PyErr_SetString(PyExc_TypeError, "keywords must be strings");
+            return -1;
         }
     }
-    if (!PyArg_ValidateKeywordArguments(kwds)) {
-        Py_DECREF(kwds);
-        return NULL;
-    }
-    return kwds;
+    return 0;
 }
 
 static inline int
 _multidict_ctor_do_init(mod_state* state, MultiDictObject* self, bool is_ci,
-                        PyObject* arg, PyObject* kwds)
+                        PyObject* arg, PyObject* const* args, Py_ssize_t nargs,
+                        PyObject* kwnames)
 {
-    Py_ssize_t size = _multidict_ctor_size_hint(state, arg, kwds);
+    Py_ssize_t nkwargs = kwnames == NULL ? 0 : PyTuple_GET_SIZE(kwnames);
+    Py_ssize_t size = _multidict_ctor_size_hint(state, arg, nkwargs);
 
-    if (arg != NULL && kwds == NULL) {
+    if (arg != NULL && nkwargs == 0) {
         MultiDictObject* clone_other = NULL;
         if (AnyMultiDict_Check(state, arg)) {
             clone_other = (MultiDictObject*)arg;
@@ -270,8 +262,8 @@ _multidict_ctor_do_init(mod_state* state, MultiDictObject* self, bool is_ci,
         ret = md_init(self, state, is_ci, size);
         if (ret == 0) {
             ret = md_update_from_ht(self, other, Extend);
-            if (ret == 0 && kwds != NULL) {
-                ret = md_update_from_dict(self, kwds, Extend);
+            if (ret == 0 && nkwargs > 0) {
+                ret = md_update_from_kwnames(self, args, nargs, kwnames);
             }
             ASSERT_CONSISTENT(self, false);
         }
@@ -281,8 +273,8 @@ _multidict_ctor_do_init(mod_state* state, MultiDictObject* self, bool is_ci,
         ret = md_init(self, state, is_ci, size);
         if (ret == 0) {
             ret = md_update_from_dict(self, arg, Extend);
-            if (ret == 0 && kwds != NULL) {
-                ret = md_update_from_dict(self, kwds, Extend);
+            if (ret == 0 && nkwargs > 0) {
+                ret = md_update_from_kwnames(self, args, nargs, kwnames);
             }
             ASSERT_CONSISTENT(self, false);
         }
@@ -293,8 +285,8 @@ _multidict_ctor_do_init(mod_state* state, MultiDictObject* self, bool is_ci,
             if (arg != NULL) {
                 ret = md_update_from_seq(self, arg, Extend);
             }
-            if (ret == 0 && kwds != NULL) {
-                ret = md_update_from_dict(self, kwds, Extend);
+            if (ret == 0 && nkwargs > 0) {
+                ret = md_update_from_kwnames(self, args, nargs, kwnames);
             }
             ASSERT_CONSISTENT(self, false);
         }
@@ -318,6 +310,9 @@ _multidict_ctor_vectorcall(PyObject* type, PyObject* const* args,
             nargs + 1);
         return NULL;
     }
+    if (_multidict_validate_kwnames(kwnames) < 0) {
+        return NULL;
+    }
 
     PyObject* mod = PyType_GetModuleByDef(tp, &multidict_module);
     if (mod == NULL) {
@@ -325,25 +320,17 @@ _multidict_ctor_vectorcall(PyObject* type, PyObject* const* args,
     }
     mod_state* state = get_mod_state(mod);
 
-    PyObject* kwds = NULL;
-    if (kwnames != NULL && PyTuple_GET_SIZE(kwnames) > 0) {
-        kwds = _multidict_kwnames_as_dict(args, nargs, kwnames);
-        if (kwds == NULL) {
-            return NULL;
-        }
-    }
     PyObject* arg = nargs == 1 ? Py_NewRef(args[0]) : NULL;
 
     MultiDictObject* self = (MultiDictObject*)tp->tp_alloc(tp, 0);
     if (self == NULL) {
         Py_XDECREF(arg);
-        Py_XDECREF(kwds);
         return NULL;
     }
 
-    int ret = _multidict_ctor_do_init(state, self, is_ci, arg, kwds);
+    int ret =
+        _multidict_ctor_do_init(state, self, is_ci, arg, args, nargs, kwnames);
     Py_XDECREF(arg);
-    Py_XDECREF(kwds);
     if (ret < 0) {
         Py_DECREF(self);
         return NULL;

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -180,7 +180,6 @@ _multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
                            PyObject* arg, PyObject* const* args,
                            Py_ssize_t nargs, PyObject* kwnames)
 {
-    // the self is allocated and NULL-ed
     int ret;
     Py_ssize_t nkwargs = kwnames == NULL ? 0 : PyTuple_GET_SIZE(kwnames);
 
@@ -267,8 +266,6 @@ _multidict_ctor_vectorcall(PyObject* type, PyObject* const* args,
     }
     mod_state* state = get_mod_state(mod);
 
-    // Borrowed: the vectorcall args array is kept alive by the caller for
-    // the duration of this call, same as any other borrowed argument.
     PyObject* arg = nargs == 1 ? args[0] : NULL;
 
     MultiDictObject* self = (MultiDictObject*)tp->tp_alloc(tp, 0);

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -193,7 +193,7 @@ _multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
         }
         if (other != NULL) {
             if (other->is_ci == is_ci) {
-                Py_BEGIN_CRITICAL_SECTION(clone_other);
+                Py_BEGIN_CRITICAL_SECTION(other);
                 ret = md_clone_from_ht(self, other);
                 ASSERT_CONSISTENT(self, false);
                 Py_END_CRITICAL_SECTION();

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -221,6 +221,7 @@ _multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
 {
     // the self is allocated and NULL-ed
     int ret;
+    Py_ssize_t nkwargs = kwnames == NULL ? 0 : PyTuple_GET_SIZE(kwnames);
 
     if (arg != NULL) {
         MultiDictObject* other = NULL;
@@ -237,7 +238,7 @@ _multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
                 Py_END_CRITICAL_SECTION();
             } else {
                 Py_BEGIN_CRITICAL_SECTION(other);
-                ret = md_init(self, state, is_ci, md_len(other));
+                ret = md_init(self, state, is_ci, md_len(other) + nkwargs);
                 if (ret == 0) {
                     ret = md_update_from_ht(self, other, Extend);
                     ASSERT_CONSISTENT(self, false);
@@ -253,7 +254,7 @@ _multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
             }
             Py_END_CRITICAL_SECTION();
         } else {
-            ret = md_init(self, state, is_ci, 0);
+            ret = md_init(self, state, is_ci, nkwargs);
             if (ret == 0) {
                 if (arg != NULL) {
                     ret = md_update_from_seq(self, arg, Extend);
@@ -262,11 +263,10 @@ _multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
             }
         }
     } else {
-        ret = md_init(self, state, is_ci, 0);
+        ret = md_init(self, state, is_ci, nkwargs);
     }
 
     if (ret == 0) {
-        Py_ssize_t nkwargs = kwnames == NULL ? 0 : PyTuple_GET_SIZE(kwnames);
         if (nkwargs > 0) {
             ret = md_update_from_kwnames(self, args, nargs, kwnames);
         }

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -215,22 +215,6 @@ _multidict_ctor_size_hint(mod_state* state, PyObject* arg, Py_ssize_t nkwargs)
 }
 
 static inline int
-_multidict_validate_kwnames(PyObject* kwnames)
-{
-    if (kwnames == NULL) {
-        return 0;
-    }
-    Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
-    for (Py_ssize_t i = 0; i < nkwargs; i++) {
-        if (!PyUnicode_Check(PyTuple_GET_ITEM(kwnames, i))) {
-            PyErr_SetString(PyExc_TypeError, "keywords must be strings");
-            return -1;
-        }
-    }
-    return 0;
-}
-
-static inline int
 _multidict_ctor_do_init(mod_state* state, MultiDictObject* self, bool is_ci,
                         PyObject* arg, PyObject* const* args, Py_ssize_t nargs,
                         PyObject* kwnames)
@@ -308,9 +292,6 @@ _multidict_ctor_vectorcall(PyObject* type, PyObject* const* args,
             "%s takes from 1 to 2 positional arguments but %zd were given",
             name,
             nargs + 1);
-        return NULL;
-    }
-    if (_multidict_validate_kwnames(kwnames) < 0) {
         return NULL;
     }
 

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -239,7 +239,6 @@ _multidict_ctor_do_init(mod_state* state, MultiDictObject* self, bool is_ci,
     }
 
     MultiDictObject* other = _multidict_resolve_other(state, arg);
-    bool arg_is_dict = arg != NULL && PyDict_CheckExact(arg);
     int ret;
     if (other != NULL) {
         Py_BEGIN_CRITICAL_SECTION(other);
@@ -252,7 +251,7 @@ _multidict_ctor_do_init(mod_state* state, MultiDictObject* self, bool is_ci,
             ASSERT_CONSISTENT(self, false);
         }
         Py_END_CRITICAL_SECTION();
-    } else if (arg_is_dict) {
+    } else if (arg != NULL && PyDict_CheckExact(arg)) {
         Py_BEGIN_CRITICAL_SECTION(arg);
         ret = md_init(self, state, is_ci, size);
         if (ret == 0) {

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -208,14 +208,24 @@ _multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
             }
         } else if (PyDict_CheckExact(arg)) {
             Py_BEGIN_CRITICAL_SECTION(arg);
-            ret = md_init(self, state, is_ci, PyDict_GET_SIZE(arg));
+            ret = md_init(self, state, is_ci, PyDict_GET_SIZE(arg) + nkwargs);
             if (ret == 0) {
                 ret = md_update_from_dict(self, arg, Extend);
                 ASSERT_CONSISTENT(self, false);
             }
             Py_END_CRITICAL_SECTION();
         } else {
-            ret = md_init(self, state, is_ci, nkwargs);
+            Py_ssize_t extra;
+            if (PyTuple_CheckExact(arg)) {
+                extra = PyTuple_GET_SIZE(arg);
+            } else if (PyList_CheckExact(arg) {
+                extra = PyList_GET_SIZE(arg);
+            }
+            else {
+                extra = 0;
+	    }
+       
+            ret = md_init(self, state, is_ci, nkwargs + extra);
             if (ret == 0) {
                 if (arg != NULL) {
                     ret = md_update_from_seq(self, arg, Extend);

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -218,13 +218,12 @@ _multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
             Py_ssize_t extra;
             if (PyTuple_CheckExact(arg)) {
                 extra = PyTuple_GET_SIZE(arg);
-            } else if (PyList_CheckExact(arg) {
+            } else if (PyList_CheckExact(arg)) {
                 extra = PyList_GET_SIZE(arg);
-            }
-            else {
+            } else {
                 extra = 0;
-	    }
-       
+            }
+
             ret = md_init(self, state, is_ci, nkwargs + extra);
             if (ret == 0) {
                 if (arg != NULL) {

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -175,6 +175,282 @@ done:
     return ret;
 }
 
+/* ---- tp_vectorcall-based fast construction ----
+
+   Unlike multidict_tp_init()/cimultidict_tp_init(), the object under
+   construction here (``self``) has just been allocated and has not been
+   returned to Python yet, so it cannot be observed by any other thread.
+   There is therefore no need for a critical section on ``self``, only on
+   ``other`` (an existing multidict/proxy argument) or on a plain dict
+   argument, same as the read side of the classic constructors. */
+
+static inline Py_ssize_t
+_multidict_ctor_size_hint(mod_state* state, PyObject* arg, PyObject* kwds)
+{
+    Py_ssize_t size = 0;
+    if (arg != NULL) {
+        if (PyTuple_CheckExact(arg)) {
+            size += PyTuple_GET_SIZE(arg);
+        } else if (PyList_CheckExact(arg)) {
+            size += PyList_GET_SIZE(arg);
+        } else if (PyDict_CheckExact(arg)) {
+            size += PyDict_GET_SIZE(arg);
+        } else if (MultiDict_CheckExact(state, arg) ||
+                   CIMultiDict_CheckExact(state, arg)) {
+            size += md_len((MultiDictObject*)arg);
+        } else if (MultiDictProxy_CheckExact(state, arg) ||
+                   CIMultiDictProxy_CheckExact(state, arg)) {
+            size += md_len(((MultiDictProxyObject*)arg)->md);
+        } else {
+            Py_ssize_t s = PyObject_LengthHint(arg, 0);
+            if (s < 0) {
+                // e.g. cannot calc size of generator object
+                PyErr_Clear();
+            } else {
+                size += s;
+            }
+        }
+    }
+    if (kwds != NULL) {
+        size += PyDict_GET_SIZE(kwds);
+    }
+    return size;
+}
+
+static inline PyObject*
+_multidict_kwnames_as_dict(PyObject* const* args, Py_ssize_t nargs,
+                           PyObject* kwnames)
+{
+    Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
+    PyObject* kwds = PyDict_New();
+    if (kwds == NULL) {
+        return NULL;
+    }
+    for (Py_ssize_t i = 0; i < nkwargs; i++) {
+        PyObject* key = PyTuple_GET_ITEM(kwnames, i);
+        if (PyDict_SetItem(kwds, key, args[nargs + i]) < 0) {
+            Py_DECREF(kwds);
+            return NULL;
+        }
+    }
+    if (!PyArg_ValidateKeywordArguments(kwds)) {
+        Py_DECREF(kwds);
+        return NULL;
+    }
+    return kwds;
+}
+
+static inline int
+_multidict_ctor_do_init(mod_state* state, MultiDictObject* self, bool is_ci,
+                        PyObject* arg, PyObject* kwds)
+{
+    Py_ssize_t size = _multidict_ctor_size_hint(state, arg, kwds);
+
+    if (arg != NULL && kwds == NULL) {
+        MultiDictObject* clone_other = NULL;
+        if (AnyMultiDict_Check(state, arg)) {
+            clone_other = (MultiDictObject*)arg;
+        } else if (AnyMultiDictProxy_Check(state, arg)) {
+            clone_other = ((MultiDictProxyObject*)arg)->md;
+        }
+        if (clone_other != NULL && clone_other->is_ci == is_ci) {
+            int ret;
+            Py_BEGIN_CRITICAL_SECTION(clone_other);
+            ret = md_clone_from_ht(self, clone_other);
+            Py_END_CRITICAL_SECTION();
+            return ret;
+        }
+    }
+
+    MultiDictObject* other = _multidict_resolve_other(state, arg);
+    bool arg_is_dict = arg != NULL && PyDict_CheckExact(arg);
+    int ret;
+    if (other != NULL) {
+        Py_BEGIN_CRITICAL_SECTION(other);
+        ret = md_init(self, state, is_ci, size);
+        if (ret == 0) {
+            ret = md_update_from_ht(self, other, Extend);
+            if (ret == 0 && kwds != NULL) {
+                ret = md_update_from_dict(self, kwds, Extend);
+            }
+            ASSERT_CONSISTENT(self, false);
+        }
+        Py_END_CRITICAL_SECTION();
+    } else if (arg_is_dict) {
+        Py_BEGIN_CRITICAL_SECTION(arg);
+        ret = md_init(self, state, is_ci, size);
+        if (ret == 0) {
+            ret = md_update_from_dict(self, arg, Extend);
+            if (ret == 0 && kwds != NULL) {
+                ret = md_update_from_dict(self, kwds, Extend);
+            }
+            ASSERT_CONSISTENT(self, false);
+        }
+        Py_END_CRITICAL_SECTION();
+    } else {
+        ret = md_init(self, state, is_ci, size);
+        if (ret == 0) {
+            if (arg != NULL) {
+                ret = md_update_from_seq(self, arg, Extend);
+            }
+            if (ret == 0 && kwds != NULL) {
+                ret = md_update_from_dict(self, kwds, Extend);
+            }
+            ASSERT_CONSISTENT(self, false);
+        }
+    }
+    return ret;
+}
+
+static PyObject*
+_multidict_ctor_vectorcall(PyObject* type, PyObject* const* args,
+                           size_t nargsf, PyObject* kwnames, bool is_ci)
+{
+    PyTypeObject* tp = (PyTypeObject*)type;
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    const char* name = is_ci ? "CIMultiDict" : "MultiDict";
+
+    if (nargs > 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "%s takes from 1 to 2 positional arguments but %zd were given",
+            name,
+            nargs + 1);
+        return NULL;
+    }
+
+    PyObject* mod = PyType_GetModuleByDef(tp, &multidict_module);
+    if (mod == NULL) {
+        return NULL;
+    }
+    mod_state* state = get_mod_state(mod);
+
+    PyObject* kwds = NULL;
+    if (kwnames != NULL && PyTuple_GET_SIZE(kwnames) > 0) {
+        kwds = _multidict_kwnames_as_dict(args, nargs, kwnames);
+        if (kwds == NULL) {
+            return NULL;
+        }
+    }
+    PyObject* arg = nargs == 1 ? Py_NewRef(args[0]) : NULL;
+
+    MultiDictObject* self = (MultiDictObject*)tp->tp_alloc(tp, 0);
+    if (self == NULL) {
+        Py_XDECREF(arg);
+        Py_XDECREF(kwds);
+        return NULL;
+    }
+
+    int ret = _multidict_ctor_do_init(state, self, is_ci, arg, kwds);
+    Py_XDECREF(arg);
+    Py_XDECREF(kwds);
+    if (ret < 0) {
+        Py_DECREF(self);
+        return NULL;
+    }
+    return (PyObject*)self;
+}
+
+static PyObject*
+multidict_vectorcall(PyObject* type, PyObject* const* args, size_t nargsf,
+                     PyObject* kwnames)
+{
+    return _multidict_ctor_vectorcall(type, args, nargsf, kwnames, false);
+}
+
+static PyObject*
+cimultidict_vectorcall(PyObject* type, PyObject* const* args, size_t nargsf,
+                       PyObject* kwnames)
+{
+    return _multidict_ctor_vectorcall(type, args, nargsf, kwnames, true);
+}
+
+/* ---- MultiDictProxy/CIMultiDictProxy tp_vectorcall ---- */
+
+static inline int
+_multidict_proxy_ctor_do_init(mod_state* state, MultiDictProxyObject* self,
+                              bool is_ci, PyObject* arg)
+{
+    bool ok = is_ci ? (CIMultiDictProxy_Check(state, arg) ||
+                       CIMultiDict_Check(state, arg))
+                    : (AnyMultiDictProxy_Check(state, arg) ||
+                       AnyMultiDict_Check(state, arg));
+    if (!ok) {
+        PyErr_Format(PyExc_TypeError,
+                     "ctor requires %s or %s instance, not <class '%s'>",
+                     is_ci ? "CIMultiDict" : "MultiDict",
+                     is_ci ? "CIMultiDictProxy" : "MultiDictProxy",
+                     Py_TYPE(arg)->tp_name);
+        return -1;
+    }
+    bool arg_is_proxy = is_ci ? CIMultiDictProxy_Check(state, arg)
+                              : AnyMultiDictProxy_Check(state, arg);
+    MultiDictObject* md = arg_is_proxy ? ((MultiDictProxyObject*)arg)->md
+                                       : (MultiDictObject*)arg;
+    self->md = (MultiDictObject*)Py_NewRef(md);
+    return 0;
+}
+
+static PyObject*
+_multidict_proxy_ctor_vectorcall(PyObject* type, PyObject* const* args,
+                                 size_t nargsf, PyObject* kwnames, bool is_ci)
+{
+    PyTypeObject* tp = (PyTypeObject*)type;
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    const char* clsname = is_ci ? "multidict._multidict.CIMultiDictProxy"
+                                : "multidict._multidict.MultiDictProxy";
+
+    if (kwnames != NULL && PyTuple_GET_SIZE(kwnames) > 0) {
+        PyErr_Format(
+            PyExc_TypeError, "%s() doesn't accept keyword arguments", clsname);
+        return NULL;
+    }
+    if (nargs == 0) {
+        PyErr_Format(PyExc_TypeError,
+                     "%s() missing 1 required positional argument: 'arg'",
+                     clsname);
+        return NULL;
+    }
+    if (nargs > 1) {
+        PyErr_Format(PyExc_TypeError,
+                     "%s() takes 1 positional argument but %zd were given",
+                     clsname,
+                     nargs);
+        return NULL;
+    }
+
+    PyObject* mod = PyType_GetModuleByDef(tp, &multidict_module);
+    if (mod == NULL) {
+        return NULL;
+    }
+    mod_state* state = get_mod_state(mod);
+
+    MultiDictProxyObject* self = (MultiDictProxyObject*)tp->tp_alloc(tp, 0);
+    if (self == NULL) {
+        return NULL;
+    }
+    if (_multidict_proxy_ctor_do_init(state, self, is_ci, args[0]) < 0) {
+        Py_DECREF(self);
+        return NULL;
+    }
+    return (PyObject*)self;
+}
+
+static PyObject*
+multidict_proxy_vectorcall(PyObject* type, PyObject* const* args,
+                           size_t nargsf, PyObject* kwnames)
+{
+    return _multidict_proxy_ctor_vectorcall(
+        type, args, nargsf, kwnames, false);
+}
+
+static PyObject*
+cimultidict_proxy_vectorcall(PyObject* type, PyObject* const* args,
+                             size_t nargsf, PyObject* kwnames)
+{
+    return _multidict_proxy_ctor_vectorcall(type, args, nargsf, kwnames, true);
+}
+
 static inline PyObject*
 multidict_copy(MultiDictObject* self)
 {
@@ -1701,6 +1977,11 @@ module_exec(PyObject* mod)
         goto fail;
     }
     state->MultiDictType = (PyTypeObject*)tmp;
+    /* MultiDict(...) construction: behaves like tp_new + tp_init, but
+       reads its arguments directly off the vectorcall stack instead of
+       requiring type_call() to first pack them into an args tuple and a
+       kwargs dict. */
+    state->MultiDictType->tp_vectorcall = multidict_vectorcall;
 
     tpl = PyTuple_Pack(1, (PyObject*)state->MultiDictType);
     if (tpl == NULL) {
@@ -1711,6 +1992,7 @@ module_exec(PyObject* mod)
         goto fail;
     }
     state->CIMultiDictType = (PyTypeObject*)tmp;
+    state->CIMultiDictType->tp_vectorcall = cimultidict_vectorcall;
     Py_CLEAR(tpl);
 
     tmp = PyType_FromModuleAndSpec(mod, &multidict_proxy_spec, NULL);
@@ -1718,6 +2000,7 @@ module_exec(PyObject* mod)
         goto fail;
     }
     state->MultiDictProxyType = (PyTypeObject*)tmp;
+    state->MultiDictProxyType->tp_vectorcall = multidict_proxy_vectorcall;
 
     tpl = PyTuple_Pack(1, (PyObject*)state->MultiDictProxyType);
     if (tpl == NULL) {
@@ -1728,6 +2011,7 @@ module_exec(PyObject* mod)
         goto fail;
     }
     state->CIMultiDictProxyType = (PyTypeObject*)tmp;
+    state->CIMultiDictProxyType->tp_vectorcall = cimultidict_proxy_vectorcall;
     Py_CLEAR(tpl);
 
     if (PyModule_AddType(mod, state->IStrType) < 0) {

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -1359,6 +1359,9 @@ static PyType_Slot multidict_slots[] = {
     {Py_tp_new, multidict_tp_new},
     {Py_tp_free, PyObject_GC_Del},
 
+#if PY_VERSION_HEX >= 0x030e00f0
+    {Py_tp_vectorcall, multidict_vectorcall},
+#endif
 #ifndef MANAGED_WEAKREFS
     {Py_tp_members, multidict_members},
 #endif
@@ -1472,6 +1475,9 @@ static PyType_Slot cimultidict_slots[] = {
     {Py_tp_doc, (void*)CIMultDict_doc},
     {Py_tp_init, cimultidict_tp_init},
     {Py_tp_new, cimultidict_tp_new},
+#if PY_VERSION_HEX >= 0x030e00f0
+    {Py_tp_vectorcall, cimultidict_vectorcall},
+#endif
     {0, NULL},
 };
 
@@ -1721,6 +1727,9 @@ static PyType_Slot multidict_proxy_slots[] = {
     {Py_tp_new, PyType_GenericNew},
     {Py_tp_free, PyObject_GC_Del},
 
+#if PY_VERSION_HEX >= 0x030e00f0
+    {Py_tp_vectorcall, multidict_proxy_vectorcall},
+#endif
 #ifndef MANAGED_WEAKREFS
     {Py_tp_members, multidict_proxy_members},
 #endif
@@ -1808,6 +1817,9 @@ static PyType_Slot cimultidict_proxy_slots[] = {
     {Py_tp_doc, (void*)CIMultDictProxy_doc},
     {Py_tp_methods, cimultidict_proxy_methods},
     {Py_tp_init, cimultidict_proxy_tp_init},
+#if PY_VERSION_HEX >= 0x030e00f0
+    {Py_tp_vectorcall, cimultidict_proxy_vectorcall},
+#endif
     {0, NULL},
 };
 
@@ -1944,11 +1956,13 @@ module_exec(PyObject* mod)
         goto fail;
     }
     state->MultiDictType = (PyTypeObject*)tmp;
-    /* MultiDict(...) construction: behaves like tp_new + tp_init, but
-       reads its arguments directly off the vectorcall stack instead of
-       requiring type_call() to first pack them into an args tuple and a
-       kwargs dict. */
+#if PY_VERSION_HEX < 0x030e00f0
+    /* 3.14+ sets this via the Py_tp_vectorcall slot instead: MultiDict(...)
+       construction behaves like tp_new + tp_init, but reads its arguments
+       directly off the vectorcall stack instead of requiring type_call()
+       to first pack them into an args tuple and a kwargs dict. */
     state->MultiDictType->tp_vectorcall = multidict_vectorcall;
+#endif
 
     tpl = PyTuple_Pack(1, (PyObject*)state->MultiDictType);
     if (tpl == NULL) {
@@ -1959,7 +1973,9 @@ module_exec(PyObject* mod)
         goto fail;
     }
     state->CIMultiDictType = (PyTypeObject*)tmp;
+#if PY_VERSION_HEX < 0x030e00f0
     state->CIMultiDictType->tp_vectorcall = cimultidict_vectorcall;
+#endif
     Py_CLEAR(tpl);
 
     tmp = PyType_FromModuleAndSpec(mod, &multidict_proxy_spec, NULL);
@@ -1967,7 +1983,9 @@ module_exec(PyObject* mod)
         goto fail;
     }
     state->MultiDictProxyType = (PyTypeObject*)tmp;
+#if PY_VERSION_HEX < 0x030e00f0
     state->MultiDictProxyType->tp_vectorcall = multidict_proxy_vectorcall;
+#endif
 
     tpl = PyTuple_Pack(1, (PyObject*)state->MultiDictProxyType);
     if (tpl == NULL) {
@@ -1978,7 +1996,9 @@ module_exec(PyObject* mod)
         goto fail;
     }
     state->CIMultiDictProxyType = (PyTypeObject*)tmp;
+#if PY_VERSION_HEX < 0x030e00f0
     state->CIMultiDictProxyType->tp_vectorcall = cimultidict_proxy_vectorcall;
+#endif
     Py_CLEAR(tpl);
 
     if (PyModule_AddType(mod, state->IStrType) < 0) {

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -300,17 +300,17 @@ _multidict_ctor_vectorcall(PyObject* type, PyObject* const* args,
     }
     mod_state* state = get_mod_state(mod);
 
-    PyObject* arg = nargs == 1 ? Py_NewRef(args[0]) : NULL;
+    // Borrowed: the vectorcall args array is kept alive by the caller for
+    // the duration of this call, same as any other borrowed argument.
+    PyObject* arg = nargs == 1 ? args[0] : NULL;
 
     MultiDictObject* self = (MultiDictObject*)tp->tp_alloc(tp, 0);
     if (self == NULL) {
-        Py_XDECREF(arg);
         return NULL;
     }
 
     int ret =
         _multidict_ctor_do_init(state, self, is_ci, arg, args, nargs, kwnames);
-    Py_XDECREF(arg);
     if (ret < 0) {
         Py_DECREF(self);
         return NULL;

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -215,63 +215,60 @@ _multidict_ctor_size_hint(mod_state* state, PyObject* arg, Py_ssize_t nkwargs)
 }
 
 static inline int
-_multidict_ctor_do_init(mod_state* state, MultiDictObject* self, bool is_ci,
-                        PyObject* arg, PyObject* const* args, Py_ssize_t nargs,
-                        PyObject* kwnames)
+_multidict_vectorcall_impl(mod_state* state, MultiDictObject* self, bool is_ci,
+                           PyObject* arg, PyObject* const* args,
+                           Py_ssize_t nargs, PyObject* kwnames)
 {
-    Py_ssize_t nkwargs = kwnames == NULL ? 0 : PyTuple_GET_SIZE(kwnames);
-    Py_ssize_t size = _multidict_ctor_size_hint(state, arg, nkwargs);
+    // the self is allocated and NULL-ed
+    int ret;
 
-    if (arg != NULL && nkwargs == 0) {
-        MultiDictObject* clone_other = NULL;
+    if (arg != NULL) {
+        MultiDictObject* other = NULL;
         if (AnyMultiDict_Check(state, arg)) {
-            clone_other = (MultiDictObject*)arg;
+            other = (MultiDictObject*)arg;
         } else if (AnyMultiDictProxy_Check(state, arg)) {
-            clone_other = ((MultiDictProxyObject*)arg)->md;
+            other = ((MultiDictProxyObject*)arg)->md;
         }
-        if (clone_other != NULL && clone_other->is_ci == is_ci) {
-            int ret;
-            Py_BEGIN_CRITICAL_SECTION(clone_other);
-            ret = md_clone_from_ht(self, clone_other);
+        if (other != NULL) {
+            if (other->is_ci == is_ci) {
+                Py_BEGIN_CRITICAL_SECTION(clone_other);
+                ret = md_clone_from_ht(self, other);
+                ASSERT_CONSISTENT(self, false);
+                Py_END_CRITICAL_SECTION();
+            } else {
+                Py_BEGIN_CRITICAL_SECTION(other);
+                ret = md_init(self, state, is_ci, md_len(other));
+                if (ret == 0) {
+                    ret = md_update_from_ht(self, other, Extend);
+                    ASSERT_CONSISTENT(self, false);
+                }
+                Py_END_CRITICAL_SECTION();
+            }
+        } else if (PyDict_CheckExact(arg)) {
+            Py_BEGIN_CRITICAL_SECTION(arg);
+            ret = md_init(self, state, is_ci, PyDict_GET_SIZE(arg));
+            if (ret == 0) {
+                ret = md_update_from_dict(self, arg, Extend);
+                ASSERT_CONSISTENT(self, false);
+            }
             Py_END_CRITICAL_SECTION();
-            return ret;
+        } else {
+            ret = md_init(self, state, is_ci, 0);
+            if (ret == 0) {
+                if (arg != NULL) {
+                    ret = md_update_from_seq(self, arg, Extend);
+                }
+                ASSERT_CONSISTENT(self, false);
+            }
         }
+    } else {
+        ret = md_init(self, state, is_ci, 0);
     }
 
-    MultiDictObject* other = _multidict_resolve_other(state, arg);
-    int ret;
-    if (other != NULL) {
-        Py_BEGIN_CRITICAL_SECTION(other);
-        ret = md_init(self, state, is_ci, size);
-        if (ret == 0) {
-            ret = md_update_from_ht(self, other, Extend);
-            if (ret == 0 && nkwargs > 0) {
-                ret = md_update_from_kwnames(self, args, nargs, kwnames);
-            }
-            ASSERT_CONSISTENT(self, false);
-        }
-        Py_END_CRITICAL_SECTION();
-    } else if (arg != NULL && PyDict_CheckExact(arg)) {
-        Py_BEGIN_CRITICAL_SECTION(arg);
-        ret = md_init(self, state, is_ci, size);
-        if (ret == 0) {
-            ret = md_update_from_dict(self, arg, Extend);
-            if (ret == 0 && nkwargs > 0) {
-                ret = md_update_from_kwnames(self, args, nargs, kwnames);
-            }
-            ASSERT_CONSISTENT(self, false);
-        }
-        Py_END_CRITICAL_SECTION();
-    } else {
-        ret = md_init(self, state, is_ci, size);
-        if (ret == 0) {
-            if (arg != NULL) {
-                ret = md_update_from_seq(self, arg, Extend);
-            }
-            if (ret == 0 && nkwargs > 0) {
-                ret = md_update_from_kwnames(self, args, nargs, kwnames);
-            }
-            ASSERT_CONSISTENT(self, false);
+    if (ret == 0) {
+        Py_ssize_t nkwargs = kwnames == NULL ? 0 : PyTuple_GET_SIZE(kwnames);
+        if (nkwargs > 0) {
+            ret = md_update_from_kwnames(self, args, nargs, kwnames);
         }
     }
     return ret;
@@ -309,8 +306,8 @@ _multidict_ctor_vectorcall(PyObject* type, PyObject* const* args,
         return NULL;
     }
 
-    int ret =
-        _multidict_ctor_do_init(state, self, is_ci, arg, args, nargs, kwnames);
+    int ret = _multidict_vectorcall_impl(
+        state, self, is_ci, arg, args, nargs, kwnames);
     if (ret < 0) {
         Py_DECREF(self);
         return NULL;

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -1541,10 +1541,6 @@ fail:
     return -1;
 }
 
-/* Extend `md` with the keyword arguments of a vectorcall, i.e. the
- * `nkwargs` trailing entries of `args` named by `kwnames`, without
- * materializing an intermediate dict.  Every name in `kwnames` must
- * already be known to be a `str` (checked once by the caller). */
 static inline int
 md_update_from_kwnames(MultiDictObject* md, PyObject* const* args,
                        Py_ssize_t nargs, PyObject* kwnames)

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -1550,6 +1550,9 @@ md_update_from_kwnames(MultiDictObject* md, PyObject* const* args,
                        Py_ssize_t nargs, PyObject* kwnames)
 {
     Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
+    if (md_reserve(md, nkwargs) < 0) {
+        return -1;
+    }
     for (Py_ssize_t i = 0; i < nkwargs; i++) {
         PyObject* key = PyTuple_GET_ITEM(kwnames, i);  // borrowed
         assert(PyUnicode_Check(key));

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -1541,6 +1541,42 @@ fail:
     return -1;
 }
 
+/* Extend `md` with the keyword arguments of a vectorcall, i.e. the
+ * `nkwargs` trailing entries of `args` named by `kwnames`, without
+ * materializing an intermediate dict.  Every name in `kwnames` must
+ * already be known to be a `str` (checked once by the caller). */
+static inline int
+md_update_from_kwnames(MultiDictObject* md, PyObject* const* args,
+                       Py_ssize_t nargs, PyObject* kwnames)
+{
+    Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
+    for (Py_ssize_t i = 0; i < nkwargs; i++) {
+        PyObject* key = PyTuple_GET_ITEM(kwnames, i);  // borrowed
+        assert(PyUnicode_Check(key));
+        Py_INCREF(key);
+        PyObject* identity = md_calc_identity(md, key);
+        if (identity == NULL) {
+            Py_DECREF(key);
+            return -1;
+        }
+        Py_hash_t hash = _unicode_hash(identity);
+        if (hash == -1) {
+            Py_DECREF(identity);
+            Py_DECREF(key);
+            return -1;
+        }
+        PyObject* value = args[nargs + i];  // borrowed
+        if (_md_add_with_hash_steal_refs(
+                md, hash, identity, key, Py_NewRef(value)) < 0) {
+            Py_DECREF(value);
+            Py_DECREF(identity);
+            Py_DECREF(key);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static inline void
 _err_not_sequence(Py_ssize_t i)
 {

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -117,6 +117,46 @@ def test_multidict_proxy_subclassing(
         pass
 
 
+def test_multidict_subclass_new_and_init_are_called(
+    any_multidict_class: type[MultiDict[str]],
+) -> None:
+    calls = []
+
+    class DummyMultidict(any_multidict_class):  # type: ignore[valid-type,misc]
+        def __new__(cls, *args: object, **kwargs: object) -> DummyMultidict:
+            calls.append("new")
+            return cast(DummyMultidict, super().__new__(cls))
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            calls.append("init")
+            super().__init__(*args, **kwargs)
+
+    d = DummyMultidict([("key", "value")], extra="1")
+
+    assert calls == ["new", "init"]
+    assert d == {"key": "value", "extra": "1"}
+
+
+def test_multidict_proxy_subclass_init_is_called(
+    any_multidict_class: type[MultiDict[str]],
+    any_multidict_proxy_class: type[MultiDictProxy[str]],
+) -> None:
+    calls = []
+
+    class DummyMultidictProxy(
+        any_multidict_proxy_class,  # type: ignore[valid-type,misc]
+    ):
+        def __init__(self, arg: object) -> None:
+            calls.append("init")
+            super().__init__(arg)
+
+    md = any_multidict_class(key="value")
+    p = DummyMultidictProxy(md)
+
+    assert calls == ["init"]
+    assert p == md
+
+
 class BaseMultiDictTest:
     def test_instantiate__empty(self, cls: type[MutableMultiMapping[str]]) -> None:
         d = cls()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,6 +4,8 @@ import types
 
 import pytest
 
+import multidict
+
 FREETHREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 
@@ -123,6 +125,40 @@ def test_create_ci_multidict_proxy_from_multidict(
         ),
     ):
         multidict_module.CIMultiDictProxy(d)
+
+
+@pytest.mark.parametrize("proxy_class_name", ("MultiDictProxy", "CIMultiDictProxy"))
+def test_create_multidict_proxy_missing_arg(
+    multidict_module: types.ModuleType,
+    proxy_class_name: str,
+) -> None:
+    proxy_class = getattr(multidict_module, proxy_class_name)
+    with pytest.raises(TypeError, match="missing 1 required positional argument"):
+        proxy_class()
+
+
+@pytest.mark.parametrize("proxy_class_name", ("MultiDictProxy", "CIMultiDictProxy"))
+def test_create_multidict_proxy_too_many_args(
+    multidict_module: types.ModuleType,
+    proxy_class_name: str,
+) -> None:
+    proxy_class = getattr(multidict_module, proxy_class_name)
+    dict_class_name = proxy_class_name.replace("Proxy", "")
+    d = getattr(multidict_module, dict_class_name)(key="val")
+    with pytest.raises(TypeError, match="positional argument"):
+        proxy_class(d, d)
+
+
+@pytest.mark.c_extension
+@pytest.mark.parametrize("proxy_class_name", ("MultiDictProxy", "CIMultiDictProxy"))
+def test_create_multidict_proxy_rejects_kwargs(proxy_class_name: str) -> None:
+    # Unlike the pure-Python implementation, the C extension's
+    # constructor does not accept its single argument by keyword.
+    proxy_class = getattr(multidict, proxy_class_name)
+    dict_class_name = proxy_class_name.replace("Proxy", "")
+    d = getattr(multidict, dict_class_name)(key="val")
+    with pytest.raises(TypeError, match="keyword arguments"):
+        proxy_class(arg=d)
 
 
 def test_generic_alias(multidict_module: types.ModuleType) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`MultiDict(...)`, `CIMultiDict(...)`, `MultiDictProxy(...)` and `CIMultiDictProxy(...)` now go through a dedicated `tp_vectorcall` function in the C extension instead of the classic `tp_new`/`tp_init` pair, avoiding the positional-args tuple and keyword-args dict that `type.__call__()` otherwise builds for every construction call. The new path reuses the same `md_init()`/`md_update_from_*()` primitives as the existing constructors, so behaviour is unchanged.

Since the object under construction is freshly allocated and not yet reachable from any other thread, only an existing multidict, proxy, or plain dict argument needs a critical section during construction, not `self`.

The pure-Python implementation is unaffected: there is no equivalent C-level calling protocol to opt into there, so no change was needed on that side.

## Are there changes in behavior for the user?

No. Construction is faster in the common case; results, error messages, and subclassing behaviour (a `__new__`/`__init__` override in a Python subclass still runs, since the fast path is not inherited by subclasses) are unchanged.

## Is it a substantial burden for the maintainers to support this?

No. The new code is a self-contained addition that shares its core logic with the existing constructors rather than duplicating it, and does not change any existing code paths.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
- [x] `make doc-spelling` passes and any new technical words are added to `docs/spelling_wordlist.txt`

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: `pytest -q` (1831 passed) against the default C-extension build; `MULTIDICT_NO_EXTENSIONS=1 pip install ...` + `pytest -q --no-c-extensions` (926 passed, 905 deselected) for the pure-Python leg; free-threaded debug build (3.13, `-O0 -g3`, `PYTHON_GIL=0`) via `pytest -q -k "not benchmark"` (1557 passed, 5 skipped).

Concurrency: a 16-thread stress test constructing `MultiDict`/`CIMultiDict`/`MultiDictProxy`/`CIMultiDictProxy` from a shared, concurrently-read source found no crashes or corruption. A separate stress test that also *mutates* the shared source concurrently does reproduce a segfault, but it reproduces identically on unmodified `master`; it's the already-tracked residual free-threading race, not a regression from this change.

Lint: `pre-commit run --all-files` passes (ruff check/format, clang-format, mypy for 3.11 and 3.13). `make doc-spelling` passes for the new content (the word `vectorcall` was added to `docs/spelling_wordlist.txt`); one pre-existing, unrelated spelling failure already exists on `master` in `CHANGES.rst` and is untouched by this PR.

Drafted with Claude Code (Sonnet 5); reviewed by asvetlov.
</details>