### PR TITLE
Add fallbacks to spelling wordlist

### DIFF
--- a/CHANGES/1439.doc.rst
+++ b/CHANGES/1439.doc.rst
@@ -1,0 +1,2 @@
+Added the plural form "fallbacks" to the docs spell checker's allowed
+word list so :file:`CHANGES.rst` builds cleanly -- by :user:`asvetlov`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -41,6 +41,7 @@ docstrings
 downstreams
 eof
 fallback
+fallbacks
 fastpath
 filename
 formatters


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds the plural "fallbacks" to `docs/spelling_wordlist.txt`. The word
"fallback" was already allowed, but `sphinxcontrib.spelling` does not
stem plurals, so `make doc-spelling` currently fails on `CHANGES.rst`
line 79, which uses "fallbacks".

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No, it is a one-line addition to a word list.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A, wordlist entry only)
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A)
- [x] Add a new news fragment into the `CHANGES/` folder
- [x] `make doc-spelling` passes and any new technical words are added to `docs/spelling_wordlist.txt`

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: `make doc-spelling` run locally; failed before this change on
the pre-existing "fallbacks" typo, passes after.

</details>

Drafted with Claude Code (Sonnet 5); reviewed by andrew.svetlov@gmail.com.
