### PR TITLE
Make __contains__ lock-free with reader-counted table retirement

### DIFF
--- a/CHANGES/1441.bugfix.1.rst
+++ b/CHANGES/1441.bugfix.1.rst
@@ -1,5 +1,4 @@
-Fixed several pre-existing use-after-free races on the free-threaded build,
-uncovered while stress-testing the lock-free reads above: ``_md_resize()``
+Fixed several pre-existing use-after-free races on the free-threaded build: ``_md_resize()``
 and ``md_clone_from_ht()`` could allocate a new hash table, have their
 critical section transiently suspended during that allocation, and then use
 a keys-table pointer or size a concurrent operation had already invalidated;

--- a/CHANGES/1441.bugfix.1.rst
+++ b/CHANGES/1441.bugfix.1.rst
@@ -1,0 +1,7 @@
+Fixed several pre-existing use-after-free races on the free-threaded build,
+uncovered while stress-testing the lock-free reads above: ``_md_resize()``
+and ``md_clone_from_ht()`` could allocate a new hash table, have their
+critical section transiently suspended during that allocation, and then use
+a keys-table pointer or size a concurrent operation had already invalidated;
+``_md_del_at()`` (plain ``del``/``pop()``) could likewise leave ``self`` in
+an inconsistent state across a suspending decref -- by :user:`asvetlov`.

--- a/CHANGES/1441.bugfix.2.rst
+++ b/CHANGES/1441.bugfix.2.rst
@@ -1,0 +1,7 @@
+Fixed several more pre-existing use-after-free and data-corruption races on
+the free-threaded build, this time in the ``__setitem__()``/``update()``/
+``extend()``/``merge()`` replace path: a decref suspending the critical
+section mid-replace could leave a stale table pointer in use, misplace a
+temporarily-marked entry during a concurrent resize, or let one thread's
+duplicate-tracking mark get overwritten by an unrelated key's entry sharing
+the same hash bucket -- by :user:`asvetlov`.

--- a/CHANGES/1441.bugfix.3.rst
+++ b/CHANGES/1441.bugfix.3.rst
@@ -1,0 +1,5 @@
+Fixed a data race on the free-threaded build where ``md->keys`` was
+published with a plain store while lock-free readers loaded it
+atomically, and a false-negative race in ``get()``/``__contains__``
+where a hash temporarily marked by a concurrent replace could make a
+present key look absent -- by :user:`asvetlov`.

--- a/CHANGES/1441.bugfix.4.rst
+++ b/CHANGES/1441.bugfix.4.rst
@@ -1,0 +1,3 @@
+Fixed a data race on the free-threaded build where ``MultiDictObject.used``
+was written non-atomically while ``len()`` read it with a relaxed atomic
+load -- by :user:`asvetlov`.

--- a/CHANGES/1441.feature.rst
+++ b/CHANGES/1441.feature.rst
@@ -1,5 +1,8 @@
-Made ``MultiDict.__contains__()`` lock-free on the free-threaded build of
-CPython, instead of taking a critical section like the rest of the C
-extension's API. A resize/shrink/clear no longer frees the outgoing hash
-table immediately; it is deferred until no lock-free reader could still be
-walking it -- by :user:`asvetlov`.
+Made ``MultiDict.__contains__()``, ``.get()``, ``.getone()`` and
+``__getitem__()`` lock-free on CPython 3.14+'s free-threaded build, instead
+of taking a critical section like the rest of the C extension's API (on
+3.13, which lacks the public API these need to safely read an entry
+concurrently, they still take the critical section, exactly as before). A
+resize/shrink/clear no longer frees the outgoing hash table immediately; it
+is deferred until no lock-free reader could still be walking it -- by
+:user:`asvetlov`.

--- a/CHANGES/1441.feature.rst
+++ b/CHANGES/1441.feature.rst
@@ -1,0 +1,5 @@
+Made ``MultiDict.__contains__()`` lock-free on the free-threaded build of
+CPython, instead of taking a critical section like the rest of the C
+extension's API. A resize/shrink/clear no longer frees the outgoing hash
+table immediately; it is deferred until no lock-free reader could still be
+walking it -- by :user:`asvetlov`.

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -598,11 +598,10 @@ multidict_mp_as_subscript(MultiDictObject* self, PyObject* key, PyObject* val)
 static int
 multidict_sq_contains(MultiDictObject* self, PyObject* key)
 {
-    int ret;
-    Py_BEGIN_CRITICAL_SECTION(self);
-    ret = md_contains(self, key, NULL);
-    Py_END_CRITICAL_SECTION();
-    return ret;
+    /* md_contains() with pret == NULL is lock-free on its own (see the
+       comment on md_contains() in hashtable.h); no critical section
+       needed here. */
+    return md_contains(self, key, NULL);
 }
 
 static PyObject*

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -43,12 +43,6 @@
 static inline PyObject*
 _multidict_getone(MultiDictObject* self, PyObject* key, PyObject* _default)
 {
-    /* md_get_one() is lock-free on its own (falling back to a critical
-       section internally when it can't proceed safely); no critical
-       section needed here. ASSERT_CONSISTENT() is deliberately not
-       called: it walks the whole table and is only safe to run while
-       holding the critical section, which the lock-free fast path
-       does not. */
     PyObject* val = NULL;
     int tmp = md_get_one(self, key, &val);
 
@@ -505,11 +499,6 @@ multidict_get(MultiDictObject* self, PyObject* const* args, Py_ssize_t nargs,
         }
         decref_default = true;
     }
-    /* No ASSERT_CONSISTENT() here: _multidict_getone() below is
-       lock-free on its own fast path (see its comment), so nothing
-       above this point holds a critical section, and walking the
-       whole table without one is unsafe -- same reasoning as
-       _multidict_getone() itself. */
     PyObject* ret = _multidict_getone(self, key, _default);
     if (decref_default) {
         Py_CLEAR(_default);

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -43,13 +43,14 @@
 static inline PyObject*
 _multidict_getone(MultiDictObject* self, PyObject* key, PyObject* _default)
 {
+    /* md_get_one() is lock-free on its own (falling back to a critical
+       section internally when it can't proceed safely); no critical
+       section needed here. ASSERT_CONSISTENT() is deliberately not
+       called: it walks the whole table and is only safe to run while
+       holding the critical section, which the lock-free fast path
+       does not. */
     PyObject* val = NULL;
-    int tmp;
-
-    Py_BEGIN_CRITICAL_SECTION(self);
-    tmp = md_get_one(self, key, &val);
-    ASSERT_CONSISTENT(self, false);
-    Py_END_CRITICAL_SECTION();
+    int tmp = md_get_one(self, key, &val);
 
     if (tmp < 0) {
         return NULL;
@@ -504,7 +505,11 @@ multidict_get(MultiDictObject* self, PyObject* const* args, Py_ssize_t nargs,
         }
         decref_default = true;
     }
-    ASSERT_CONSISTENT(self, false);
+    /* No ASSERT_CONSISTENT() here: _multidict_getone() below is
+       lock-free on its own fast path (see its comment), so nothing
+       above this point holds a critical section, and walking the
+       whole table without one is unsafe -- same reasoning as
+       _multidict_getone() itself. */
     PyObject* ret = _multidict_getone(self, key, _default);
     if (decref_default) {
         Py_CLEAR(_default);

--- a/multidict/_multidict.c
+++ b/multidict/_multidict.c
@@ -598,9 +598,6 @@ multidict_mp_as_subscript(MultiDictObject* self, PyObject* key, PyObject* val)
 static int
 multidict_sq_contains(MultiDictObject* self, PyObject* key)
 {
-    /* md_contains() with pret == NULL is lock-free on its own (see the
-       comment on md_contains() in hashtable.h); no critical section
-       needed here. */
     return md_contains(self, key, NULL);
 }
 

--- a/multidict/_multilib/atomic_helpers.h
+++ b/multidict/_multilib/atomic_helpers.h
@@ -39,6 +39,12 @@ atomic_load_ssize(const Py_ssize_t* obj)
     return __atomic_load_n(obj, __ATOMIC_SEQ_CST);
 }
 
+static inline void
+atomic_store_ssize_relaxed(Py_ssize_t* obj, Py_ssize_t value)
+{
+    __atomic_store_n(obj, value, __ATOMIC_RELAXED);
+}
+
 static inline Py_ssize_t
 atomic_fetch_add_ssize_relaxed(Py_ssize_t* obj, Py_ssize_t value)
 {
@@ -80,6 +86,13 @@ atomic_load_ssize(const Py_ssize_t* obj)
 {
     return atomic_load_explicit((const _Atomic(Py_ssize_t)*)obj,
                                 memory_order_seq_cst);
+}
+
+static inline void
+atomic_store_ssize_relaxed(Py_ssize_t* obj, Py_ssize_t value)
+{
+    atomic_store_explicit(
+        (_Atomic(Py_ssize_t)*)obj, value, memory_order_relaxed);
 }
 
 static inline Py_ssize_t
@@ -142,6 +155,12 @@ static inline Py_ssize_t
 atomic_load_ssize(const Py_ssize_t* obj)
 {
     return *(volatile const Py_ssize_t*)obj;
+}
+
+static inline void
+atomic_store_ssize_relaxed(Py_ssize_t* obj, Py_ssize_t value)
+{
+    *(volatile Py_ssize_t*)obj = value;
 }
 
 static inline Py_ssize_t

--- a/multidict/_multilib/atomic_helpers.h
+++ b/multidict/_multilib/atomic_helpers.h
@@ -138,7 +138,7 @@ atomic_store_ptr(void** obj, void* value)
    is NOT just a volatile write, though: TSO explicitly allows a store
    to be reordered after a later, independent load (StoreLoad
    reordering) -- exactly the reordering this module's Dekker-style
-   md->keys / active_readers pair depends on being absent. CPython's
+   md->keys / num_active_readers pair depends on being absent. CPython's
    own _Py_atomic_store_ptr() avoids this the same way: route the
    store through _InterlockedExchange*, which carries a full fence on
    every architecture MSVC targets. */

--- a/multidict/_multilib/atomic_helpers.h
+++ b/multidict/_multilib/atomic_helpers.h
@@ -19,7 +19,7 @@ extern "C" {
    counters (htkeys_t.readers), and seq_cst load/store/fetch-add for
    the md->keys <-> active_readers pair, where anything weaker than a
    full fence leaves a real (if narrow, architecture-dependent) race --
-   see the reasoning in md_reader_enter()/md_reader_exit()/md_retire()
+   see the reasoning in _md_reader_enter()/_md_reader_exit()/_md_retire()
    in hashtable.h. */
 
 #ifndef _MULTIDICT_USE_GCC_BUILTIN_ATOMICS

--- a/multidict/_multilib/atomic_helpers.h
+++ b/multidict/_multilib/atomic_helpers.h
@@ -9,10 +9,18 @@ extern "C" {
 
 #ifdef Py_GIL_DISABLED
 
-/* Atomic load backend selection, mirroring CPython's own
+/* Atomic backend selection, mirroring CPython's own
    Include/cpython/pyatomic.h: prefer GCC/Clang builtins, fall back to
    C11 stdatomic.h, and use MSVC intrinsics only when neither is
-   available (plain cl.exe, which supports neither). */
+   available (plain cl.exe, which supports neither).
+
+   Only the operations the lock-free read path actually needs are
+   provided: relaxed load/fetch-add for advisory, non-load-bearing
+   counters (htkeys_t.readers), and seq_cst load/store/fetch-add for
+   the md->keys <-> active_readers pair, where anything weaker than a
+   full fence leaves a real (if narrow, architecture-dependent) race --
+   see the reasoning in md_reader_enter()/md_reader_exit()/md_retire()
+   in hashtable.h. */
 
 #ifndef _MULTIDICT_USE_GCC_BUILTIN_ATOMICS
 #if defined(__GNUC__) && \
@@ -33,6 +41,36 @@ atomic_load_ssize_relaxed(const Py_ssize_t* obj)
     return __atomic_load_n(obj, __ATOMIC_RELAXED);
 }
 
+static inline Py_ssize_t
+atomic_load_ssize(const Py_ssize_t* obj)
+{
+    return __atomic_load_n(obj, __ATOMIC_SEQ_CST);
+}
+
+static inline Py_ssize_t
+atomic_fetch_add_ssize_relaxed(Py_ssize_t* obj, Py_ssize_t value)
+{
+    return __atomic_fetch_add(obj, value, __ATOMIC_RELAXED);
+}
+
+static inline Py_ssize_t
+atomic_fetch_add_ssize(Py_ssize_t* obj, Py_ssize_t value)
+{
+    return __atomic_fetch_add(obj, value, __ATOMIC_SEQ_CST);
+}
+
+static inline void*
+atomic_load_ptr(void* const* obj)
+{
+    return __atomic_load_n(obj, __ATOMIC_SEQ_CST);
+}
+
+static inline void
+atomic_store_ptr(void** obj, void* value)
+{
+    __atomic_store_n(obj, value, __ATOMIC_SEQ_CST);
+}
+
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && \
     !defined(__STDC_NO_ATOMICS__)
 
@@ -45,6 +83,40 @@ atomic_load_ssize_relaxed(const Py_ssize_t* obj)
                                 memory_order_relaxed);
 }
 
+static inline Py_ssize_t
+atomic_load_ssize(const Py_ssize_t* obj)
+{
+    return atomic_load_explicit((const _Atomic(Py_ssize_t)*)obj,
+                                memory_order_seq_cst);
+}
+
+static inline Py_ssize_t
+atomic_fetch_add_ssize_relaxed(Py_ssize_t* obj, Py_ssize_t value)
+{
+    return atomic_fetch_add_explicit(
+        (_Atomic(Py_ssize_t)*)obj, value, memory_order_relaxed);
+}
+
+static inline Py_ssize_t
+atomic_fetch_add_ssize(Py_ssize_t* obj, Py_ssize_t value)
+{
+    return atomic_fetch_add_explicit(
+        (_Atomic(Py_ssize_t)*)obj, value, memory_order_seq_cst);
+}
+
+static inline void*
+atomic_load_ptr(void* const* obj)
+{
+    return atomic_load_explicit((void* const _Atomic*)obj,
+                                memory_order_seq_cst);
+}
+
+static inline void
+atomic_store_ptr(void** obj, void* value)
+{
+    atomic_store_explicit((void* _Atomic*)obj, value, memory_order_seq_cst);
+}
+
 #elif defined(_MSC_VER)
 
 /* MSVC has no __atomic_* builtins and (at least on the toolset multidict
@@ -52,7 +124,21 @@ atomic_load_ssize_relaxed(const Py_ssize_t* obj)
    relaxed semantics: on x86/x86_64 volatile accesses already have
    acquire-release ordering, and on ARM64 MSVC treats them as
    memory_order_relaxed -- exactly what's needed here. See the comment
-   at the top of CPython's Include/cpython/pyatomic_msc.h. */
+   at the top of CPython's Include/cpython/pyatomic_msc.h.
+
+   A seq_cst *load* is the same plain volatile read: x86/x86_64's TSO
+   already orders a load after any earlier store on the same thread,
+   and ARM64 MSVC volatile loads carry load-acquire semantics, which is
+   enough once the writer side is properly fenced. A seq_cst *store*
+   is NOT just a volatile write, though: TSO explicitly allows a store
+   to be reordered after a later, independent load (StoreLoad
+   reordering) -- exactly the reordering this module's Dekker-style
+   md->keys / active_readers pair depends on being absent. CPython's
+   own _Py_atomic_store_ptr() avoids this the same way: route the
+   store through _InterlockedExchange*, which carries a full fence on
+   every architecture MSVC targets. */
+
+#include <intrin.h>
 
 static inline Py_ssize_t
 atomic_load_ssize_relaxed(const Py_ssize_t* obj)
@@ -60,8 +146,45 @@ atomic_load_ssize_relaxed(const Py_ssize_t* obj)
     return *(volatile const Py_ssize_t*)obj;
 }
 
+static inline Py_ssize_t
+atomic_load_ssize(const Py_ssize_t* obj)
+{
+    return *(volatile const Py_ssize_t*)obj;
+}
+
+static inline Py_ssize_t
+atomic_fetch_add_ssize_relaxed(Py_ssize_t* obj, Py_ssize_t value)
+{
+#if SIZEOF_VOID_P == 8
+    return (Py_ssize_t)_InterlockedExchangeAdd64((volatile __int64*)obj,
+                                                 (__int64)value);
 #else
-#error "no available atomic load implementation for this platform/compiler"
+    return (Py_ssize_t)_InterlockedExchangeAdd((volatile long*)obj,
+                                               (long)value);
+#endif
+}
+
+static inline Py_ssize_t
+atomic_fetch_add_ssize(Py_ssize_t* obj, Py_ssize_t value)
+{
+    /* _InterlockedExchangeAdd* already carries a full fence. */
+    return atomic_fetch_add_ssize_relaxed(obj, value);
+}
+
+static inline void*
+atomic_load_ptr(void* const* obj)
+{
+    return *(void* const volatile*)obj;
+}
+
+static inline void
+atomic_store_ptr(void** obj, void* value)
+{
+    (void)_InterlockedExchangePointer((void* volatile*)obj, value);
+}
+
+#else
+#error "no available atomic implementation for this platform/compiler"
 #endif
 
 #else /* Py_GIL_DISABLED */

--- a/multidict/_multilib/atomic_helpers.h
+++ b/multidict/_multilib/atomic_helpers.h
@@ -12,15 +12,7 @@ extern "C" {
 /* Atomic backend selection, mirroring CPython's own
    Include/cpython/pyatomic.h: prefer GCC/Clang builtins, fall back to
    C11 stdatomic.h, and use MSVC intrinsics only when neither is
-   available (plain cl.exe, which supports neither).
-
-   Only the operations the lock-free read path actually needs are
-   provided: relaxed load/fetch-add for advisory, non-load-bearing
-   counters (htkeys_t.readers), and seq_cst load/store/fetch-add for
-   the md->keys <-> active_readers pair, where anything weaker than a
-   full fence leaves a real (if narrow, architecture-dependent) race --
-   see the reasoning in _md_reader_enter()/_md_reader_exit()/_md_retire()
-   in hashtable.h. */
+   available (plain cl.exe, which supports neither). */
 
 #ifndef _MULTIDICT_USE_GCC_BUILTIN_ATOMICS
 #if defined(__GNUC__) && \

--- a/multidict/_multilib/dict.h
+++ b/multidict/_multilib/dict.h
@@ -29,11 +29,6 @@ typedef struct {
 #ifdef Py_GIL_DISABLED
     Py_ssize_t active_readers;
 
-    /* Singly-linked list (via htkeys_t.retired_next) of tables retired
-       by a resize/shrink/clear while active_readers was nonzero.
-       Writer-only (always under this object's critical section), so a
-       plain pointer, not atomic. Drained opportunistically at the
-       start of the next resize/shrink/reserve/clear. */
     htkeys_t* retired;
 #endif
 } MultiDictObject;

--- a/multidict/_multilib/dict.h
+++ b/multidict/_multilib/dict.h
@@ -25,6 +25,24 @@ typedef struct {
     bool is_ci;
 
     htkeys_t* keys;
+
+#ifdef Py_GIL_DISABLED
+    /* Coarse gate for the lock-free read path (get()/contains()/
+       iteration): incremented before a reader ever dereferences
+       `keys`, decremented once it's done. A retired table is only
+       ever freed once this reads 0 at a point synchronized (seq_cst)
+       with the swap that retired it -- see md_reader_enter()/
+       md_reader_exit()/md_retire() in hashtable.h for the full
+       reasoning. Writers never touch this field themselves. */
+    Py_ssize_t active_readers;
+
+    /* Singly-linked list (via htkeys_t.retired_next) of tables retired
+       by a resize/shrink/clear while active_readers was nonzero.
+       Writer-only (always under this object's critical section), so a
+       plain pointer, not atomic. Drained opportunistically at the
+       start of the next resize/shrink/reserve/clear. */
+    htkeys_t* retired;
+#endif
 } MultiDictObject;
 
 typedef struct {

--- a/multidict/_multilib/dict.h
+++ b/multidict/_multilib/dict.h
@@ -31,8 +31,8 @@ typedef struct {
        iteration): incremented before a reader ever dereferences
        `keys`, decremented once it's done. A retired table is only
        ever freed once this reads 0 at a point synchronized (seq_cst)
-       with the swap that retired it -- see md_reader_enter()/
-       md_reader_exit()/md_retire() in hashtable.h for the full
+       with the swap that retired it -- see _md_reader_enter()/
+       _md_reader_exit()/_md_retire() in hashtable.h for the full
        reasoning. Writers never touch this field themselves. */
     Py_ssize_t active_readers;
 

--- a/multidict/_multilib/dict.h
+++ b/multidict/_multilib/dict.h
@@ -27,7 +27,7 @@ typedef struct {
     htkeys_t* keys;
 
 #ifdef Py_GIL_DISABLED
-    Py_ssize_t active_readers;
+    Py_ssize_t num_active_readers;
 
     htkeys_t* retired;
 #endif

--- a/multidict/_multilib/dict.h
+++ b/multidict/_multilib/dict.h
@@ -27,13 +27,6 @@ typedef struct {
     htkeys_t* keys;
 
 #ifdef Py_GIL_DISABLED
-    /* Coarse gate for the lock-free read path (get()/contains()/
-       iteration): incremented before a reader ever dereferences
-       `keys`, decremented once it's done. A retired table is only
-       ever freed once this reads 0 at a point synchronized (seq_cst)
-       with the swap that retired it -- see _md_reader_enter()/
-       _md_reader_exit()/_md_retire() in hashtable.h for the full
-       reasoning. Writers never touch this field themselves. */
     Py_ssize_t active_readers;
 
     /* Singly-linked list (via htkeys_t.retired_next) of tables retired

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -323,70 +323,257 @@ _md_retire(MultiDictObject* md, htkeys_t* keys)
     }
 }
 
+/* PyUnstable_TryIncRef()/PyUnstable_EnableTryIncRef() -- the only
+   public API letting a third-party extension safely try to incref an
+   object that might concurrently be reaching refcount zero on another
+   thread -- were added in CPython 3.14 (gh-128844) and do not exist
+   on 3.13, the free-threaded build's first (and, as of this writing,
+   most widely deployed) release: checked directly against the CPython
+   3.13 branch's Include/cpython/object.h, which has no equivalent.
+   CPython's own dict has had this capability since 3.13
+   (_Py_TryIncrefCompare, Include/internal/pycore_object.h), but that's
+   an internal, non-exported symbol -- the same situation as
+   _PyMem_FreeDelayed elsewhere in this file, not something a
+   separately-built, separately-linked extension can call. Below 3.14,
+   dereferencing an entry's identity/value contents without holding
+   md's critical section is not safe by any means available here, so
+   md_get_one() and the pret == NULL path of md_contains() fall back
+   to always taking the critical section there, exactly as they were
+   before this file added any lock-free reading at all. */
+#if PY_VERSION_HEX >= 0x030e0000
+#define _MD_HAVE_TRYINCREF 1
+#else
+#define _MD_HAVE_TRYINCREF 0
+#endif
+
+/*
+Lock-free-safe access to individual entry fields.
+
+The table-retirement scheme above only protects an htkeys_t blob's own
+memory. It says nothing about a single entry's identity/value fields
+*within* a table that is still md->keys, still published, still being
+mutated in the ordinary way by add()/__setitem__/pop()/update() -- all
+of which run under md's critical section, which does not exclude a
+lock-free reader at all.
+
+entry->identity doubles as the "is this slot populated" signal a
+lock-free walk checks first (mirroring CPython's own me_key in
+compare_unicode_unicode_threadsafe): insertion publishes every other
+field an entry needs (hash, key, value) before publishing identity,
+last, and deletion clears identity. entry->identity is never replaced
+with a *different* non-NULL identity while an entry stays populated
+(only key/value change on replace/update), so the only transitions a
+reader can race are NULL -> real (insertion) and real -> NULL
+(deletion) -- never real -> different-real.
+
+That ordering alone is not enough to safely dereference the identity
+or value object's *contents* (_str_cmp, PyUnstable_TryIncRef's own
+caller), though: a concurrent delete's Py_CLEAR() is an ordinary
+decref with no deferred reclamation, so it can free the object
+immediately. Every lock-free read of entry->identity or entry->value
+therefore needs PyUnstable_TryIncRef() (safe even if the object is
+mid-teardown on another thread; fails cleanly instead of racing it)
+followed by re-reading the field to confirm it still holds what was
+just incref'd -- if either step fails, the field changed or is
+changing under us and the caller must fall back to the critical
+section, exactly like CPython's DKIX_KEY_CHANGED retry.
+*/
+
+static inline PyObject*
+_md_entry_load_identity(entry_t* entry)
+{
+    return (PyObject*)atomic_load_ptr((void* const*)&entry->identity);
+}
+
+static inline void
+_md_entry_publish_identity(entry_t* entry, PyObject* identity)
+{
+#if _MD_HAVE_TRYINCREF
+    PyUnstable_EnableTryIncRef(identity);
+#endif
+    atomic_store_ptr((void**)&entry->identity, identity);
+}
+
+static inline void
+_md_entry_clear_identity(entry_t* entry)
+{
+    PyObject* old = _md_entry_load_identity(entry);
+    atomic_store_ptr((void**)&entry->identity, NULL);
+    Py_XDECREF(old);
+}
+
+static inline PyObject*
+_md_entry_load_value(entry_t* entry)
+{
+    return (PyObject*)atomic_load_ptr((void* const*)&entry->value);
+}
+
+/* Publishes a new value, enabling PyUnstable_TryIncRef() for lock-free
+   readers, and decrefs whatever was there before only after the new
+   value is already visible, so a concurrent reader can never observe
+   entry->value mid-transition. */
+static inline void
+_md_entry_store_value(entry_t* entry, PyObject* value)
+{
+#if _MD_HAVE_TRYINCREF
+    PyUnstable_EnableTryIncRef(value);
+#endif
+    PyObject* old = _md_entry_load_value(entry);
+    atomic_store_ptr((void**)&entry->value, value);
+    Py_XDECREF(old);
+}
+
+static inline void
+_md_entry_clear_value(entry_t* entry)
+{
+    PyObject* old = _md_entry_load_value(entry);
+    atomic_store_ptr((void**)&entry->value, NULL);
+    Py_XDECREF(old);
+}
+
+/* entry->hash also needs an atomic accessor once a lock-free reader
+   compares against it: _md_replace()/_md_update() overwrite it in
+   place on an already-populated entry (a plain write racing the
+   reader's plain read is still a data race even though Py_hash_t
+   isn't a pointer and can't crash on a torn value). Relaxed is enough
+   -- it's read only after the identity check above already
+   established happens-before for everything else in the entry;
+   nothing else depends on this specific field's ordering. */
+static inline Py_hash_t
+_md_entry_load_hash(entry_t* entry)
+{
+    return (Py_hash_t)atomic_load_ssize_relaxed((Py_ssize_t*)&entry->hash);
+}
+
+static inline void
+_md_entry_store_hash(entry_t* entry, Py_hash_t hash)
+{
+    atomic_store_ssize_relaxed((Py_ssize_t*)&entry->hash, (Py_ssize_t)hash);
+}
+
+#if _MD_HAVE_TRYINCREF
+/* Tries to safely grab a strong reference to *addr's current value for
+   a lock-free reader: PyUnstable_TryIncRef() (fails cleanly if the
+   object is concurrently being torn down) followed by re-reading
+   *addr to confirm it is still what was just incref'd. Returns NULL
+   (with no reference held) if either step fails, meaning the caller
+   must fall back to the critical section; the field may be NULL
+   legitimately (not populated / deleted), which is reported the same
+   way, since either way the caller cannot proceed lock-free. Only
+   defined where PyUnstable_TryIncRef() exists at all (see the
+   _MD_HAVE_TRYINCREF comment above); callers must be equally
+   guarded. */
+static inline PyObject*
+_md_entry_try_get_ref(PyObject** addr)
+{
+    PyObject* value = (PyObject*)atomic_load_ptr((void* const*)addr);
+    if (value == NULL) {
+        return NULL;
+    }
+    if (!PyUnstable_TryIncRef(value)) {
+        return NULL;
+    }
+    if ((PyObject*)atomic_load_ptr((void* const*)addr) != value) {
+        Py_DECREF(value);
+        return NULL;
+    }
+    return value;
+}
+#endif /* _MD_HAVE_TRYINCREF */
+
 #endif /* Py_GIL_DISABLED */
 
 static inline int
 _md_resize(MultiDictObject* md, uint8_t log2_newsize, bool update)
 {
-    htkeys_t *oldkeys, *newkeys;
+    for (;;) {
+        if (log2_newsize >= SIZEOF_SIZE_T * 8) {
+            PyErr_NoMemory();
+            return -1;
+        }
+        assert(log2_newsize >= HT_LOG_MINSIZE);
 
-    if (log2_newsize >= SIZEOF_SIZE_T * 8) {
-        PyErr_NoMemory();
-        return -1;
-    }
-    assert(log2_newsize >= HT_LOG_MINSIZE);
+        /* Allocating the new table can transiently suspend our critical
+           section on md: PyMem_Malloc() may block acquiring an internal
+           allocator lock, and CPython suspends critical sections around
+           blocking lock acquisitions on the free-threaded build (see
+           Include/cpython/critical_section.h). While suspended, another
+           thread that also locks md can run an entire add()/pop()/
+           update()/extend()/merge() to completion, mutating or replacing
+           md->keys. Therefore nothing read from md before this call may
+           be trusted afterward: oldkeys and numentries are (re-)read only
+           below, once the critical section is guaranteed to be held
+           again. */
+        htkeys_t* newkeys = htkeys_new(log2_newsize);
+        assert(newkeys);
+        if (newkeys == NULL) {
+            return -1;
+        }
 
-    oldkeys = md->keys;
+        htkeys_t* oldkeys = md->keys;
+        Py_ssize_t numentries = md->used;
+        if (newkeys->usable < numentries) {
+            /* A concurrent operation grew md while our critical section
+               was suspended during the allocation above, so the table we
+               just built is already too small. Discard it and retry with
+               a fresh estimate based on the current size. newkeys was
+               never published, so freeing it directly (not via
+               _md_retire()) is safe even under Py_GIL_DISABLED. */
+            htkeys_free(newkeys);
+            log2_newsize = estimate_log2_keysize(numentries);
+            continue;
+        }
 
-    /* Allocate a new table. */
-    newkeys = htkeys_new(log2_newsize);
-    assert(newkeys);
-    if (newkeys == NULL) {
-        return -1;
-    }
-    // New table must be large enough.
-    assert(newkeys->usable >= md->used);
-
-    Py_ssize_t numentries = md->used;
-    entry_t* oldentries = htkeys_entries(oldkeys);
-    entry_t* newentries = htkeys_entries(newkeys);
-    if (oldkeys->nentries == numentries) {
-        memcpy(newentries, oldentries, numentries * sizeof(entry_t));
-    } else {
-        entry_t* new_ep = newentries;
-        entry_t* old_ep = oldentries;
-        Py_ssize_t oldnumentries = oldkeys->nentries;
-        for (Py_ssize_t i = 0; i < oldnumentries; ++i, ++old_ep) {
-            if (old_ep->identity != NULL) {
-                *new_ep++ = *old_ep;
+        entry_t* oldentries = htkeys_entries(oldkeys);
+        entry_t* newentries = htkeys_entries(newkeys);
+        if (oldkeys->nentries == numentries) {
+            memcpy(newentries, oldentries, numentries * sizeof(entry_t));
+        } else {
+            entry_t* new_ep = newentries;
+            entry_t* old_ep = oldentries;
+            Py_ssize_t oldnumentries = oldkeys->nentries;
+            for (Py_ssize_t i = 0; i < oldnumentries; ++i, ++old_ep) {
+                if (old_ep->identity != NULL) {
+                    *new_ep++ = *old_ep;
+                }
             }
         }
-    }
 
-    if (htkeys_build_indices(newkeys, newentries, numentries, update) < 0) {
-        return -1;
-    }
+        if (htkeys_build_indices(newkeys, newentries, numentries, update) <
+            0) {
+            return -1;
+        }
 
-    md->keys = newkeys;
+        /* Finalize newkeys's usable/nentries before publishing it to
+           md->keys and before _md_retire() below, which can also suspend
+           this thread's critical section (same mechanism as the alloc
+           above, this time around freeing oldkeys). Otherwise a
+           concurrent insert could observe newkeys published with its
+           stale, fresh-from-htkeys_new() values during that window and
+           corrupt already-copied entries. */
+        newkeys->usable = newkeys->usable - numentries;
+        newkeys->nentries = numentries;
+
+        md->keys = newkeys;
 
 #ifdef Py_GIL_DISABLED
-    /* Ownership of oldkeys's entries has already moved to newkeys via
-       the memcpy/copy loop above; zeroing nentries tells _md_retire()'s
-       cleanup there is nothing left to decref, only memory to free. */
-    if (oldkeys != &empty_htkeys) {
-        oldkeys->nentries = 0;
-    }
-    _md_retire(md, oldkeys);
+        /* Ownership of oldkeys's entries has already moved to newkeys via
+           the memcpy/copy loop above; zeroing nentries tells
+           _md_retire()'s cleanup there is nothing left to decref, only
+           memory to free. */
+        if (oldkeys != &empty_htkeys) {
+            oldkeys->nentries = 0;
+        }
+        _md_retire(md, oldkeys);
 #else
-    if (oldkeys != &empty_htkeys) {
-        htkeys_free(oldkeys);
-    }
+        if (oldkeys != &empty_htkeys) {
+            htkeys_free(oldkeys);
+        }
 #endif
 
-    md->keys->usable = md->keys->usable - numentries;
-    md->keys->nentries = numentries;
-    ASSERT_CONSISTENT(md, update);
-    return 0;
+        ASSERT_CONSISTENT(md, update);
+        return 0;
+    }
 }
 
 static inline int
@@ -509,19 +696,37 @@ static inline int
 md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
 {
     ASSERT_CONSISTENT(other, false);
-    mod_state* state = other->state;
-    Py_ssize_t used = other->used;
-    uint64_t version = other->version;
-    bool is_ci = other->is_ci;
+
     htkeys_t* keys = (htkeys_t*)&empty_htkeys;
-    if (other->keys != &empty_htkeys) {
-        size_t size = htkeys_sizeof(other->keys);
+    htkeys_t* src = other->keys;
+    while (src != &empty_htkeys) {
+        size_t size = htkeys_sizeof(src);
+
+        /* Allocating can transiently suspend our critical section on
+           `other`, for the same reason explained in _md_resize(): a
+           blocking PyMem_Malloc() may release the lock, letting another
+           thread that also locks `other` run to completion (e.g. resizing
+           other->keys and freeing this exact buffer) before we resume.
+           `size` and `src` were computed before the call and cannot be
+           trusted afterward, so re-read other->keys and retry if it no
+           longer matches what we sized the allocation for, instead of
+           copying `size` bytes from a possibly different (or freed)
+           buffer. */
         keys = PyMem_Malloc(size);
         if (keys == NULL) {
             PyErr_NoMemory();
             return -1;
         }
-        memcpy(keys, other->keys, size);
+
+        htkeys_t* fresh_src = other->keys;
+        if (fresh_src != src) {
+            PyMem_Free(keys);
+            keys = (htkeys_t*)&empty_htkeys;
+            src = fresh_src;
+            continue;
+        }
+
+        memcpy(keys, fresh_src, size);
 #ifdef Py_GIL_DISABLED
         /* keys is a brand-new, independent allocation: the memcpy just
            copied other->keys's live reader count and retirement link
@@ -537,7 +742,17 @@ md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
             Py_XINCREF(entry->key);
             Py_XINCREF(entry->value);
         }
+        break;
     }
+
+    /* No allocation happens between here and the writes to md below, so
+       this snapshot of other's remaining fields is consistent with the
+       keys buffer just copied above. */
+    mod_state* state = other->state;
+    Py_ssize_t used = other->used;
+    uint64_t version = other->version;
+    bool is_ci = other->is_ci;
+
     md_clear(md);
     md->state = state;
     md->used = used;
@@ -604,10 +819,21 @@ _md_add_with_hash_steal_refs(MultiDictObject* md, Py_hash_t hash,
 
     entry_t* entry = htkeys_entries(keys) + keys->nentries;
 
+#ifdef Py_GIL_DISABLED
+    /* identity is published last: it's the field a lock-free reader
+       checks first (before ever touching hash/key/value), treating
+       NULL as "not populated yet, keep probing". See the comment
+       above _md_entry_load_identity(). */
+    entry->key = key;
+    _md_entry_store_hash(entry, hash);
+    _md_entry_store_value(entry, value);
+    _md_entry_publish_identity(entry, identity);
+#else
     entry->identity = identity;
     entry->key = key;
     entry->value = value;
     entry->hash = hash;
+#endif
 
     md->version = NEXT_VERSION(md->state);
     md->used += 1;
@@ -643,10 +869,17 @@ _md_add_for_upd_steal_refs(MultiDictObject* md, Py_hash_t hash,
 
     entry_t* entry = htkeys_entries(keys) + keys->nentries;
 
+#ifdef Py_GIL_DISABLED
+    entry->key = key;
+    _md_entry_store_hash(entry, hash | MD_HASH_MARK);
+    _md_entry_store_value(entry, value);
+    _md_entry_publish_identity(entry, identity);
+#else
     entry->identity = identity;
     entry->key = key;
     entry->value = value;
     entry->hash = hash | MD_HASH_MARK;
+#endif
 
     md->version = NEXT_VERSION(md->state);
     md->used += 1;
@@ -690,11 +923,42 @@ _md_del_at(MultiDictObject* md, size_t slot, entry_t* entry)
 {
     htkeys_t* keys = md->keys;
     assert(keys != &empty_htkeys);
+#ifdef Py_GIL_DISABLED
+    /* Null out every field and finish md's bookkeeping (index, used)
+       before dropping any reference. A decref below can transiently
+       suspend this thread's critical section -- freeing an object can
+       contend the same allocator lock as PyMem_Malloc(), see the
+       comment above _md_resize() -- letting a concurrent resize run
+       in between. If that resize caught this entry with some fields
+       already NULL and others (or md->used, or the index) not yet
+       updated, it would see md in a state that is neither "entry
+       still there" nor "entry gone" and corrupt itself. Saving the
+       objects locally and decref'ing them only once md is already
+       fully self-consistent means a concurrent resize -- however far
+       into this function it catches us -- always sees a coherent
+       view. entry->key is read/written as a plain pointer: unlike
+       identity/value, no lock-free reader ever touches it (see the
+       comment above _md_entry_load_identity()). */
+    PyObject* identity = _md_entry_load_identity(entry);
+    PyObject* key = entry->key;
+    PyObject* value = _md_entry_load_value(entry);
+
+    atomic_store_ptr((void**)&entry->identity, NULL);
+    entry->key = NULL;
+    atomic_store_ptr((void**)&entry->value, NULL);
+    htkeys_set_index(keys, slot, DKIX_DUMMY);
+    md->used -= 1;
+
+    Py_XDECREF(identity);
+    Py_XDECREF(key);
+    Py_XDECREF(value);
+#else
     Py_CLEAR(entry->identity);
     Py_CLEAR(entry->key);
     Py_CLEAR(entry->value);
     htkeys_set_index(keys, slot, DKIX_DUMMY);
     md->used -= 1;
+#endif
 }
 
 static inline void
@@ -708,7 +972,11 @@ _md_del_at_for_upd(MultiDictObject* md, size_t slot, entry_t* entry)
     */
     assert(md->keys != &empty_htkeys);
     Py_CLEAR(entry->key);
+#ifdef Py_GIL_DISABLED
+    _md_entry_clear_value(entry);
+#else
     Py_CLEAR(entry->value);
+#endif
 }
 
 static inline int
@@ -1016,100 +1284,17 @@ md_finder_cleanup(md_finder_t* finder)
     finder->md = NULL;
 }
 
+/* Used for pret != NULL (every caller already holds md's critical
+   section -- the view set-algebra helpers, not a hot path) and as the
+   whole implementation / lock-free fallback for pret == NULL
+   (__contains__'s actual hot path). _md_ensure_key()'s entry->key
+   mutation is safe here exactly as it always was: this function is
+   only ever invoked either already under the critical section, or by
+   md_contains() itself while holding it. */
 static inline int
-md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
+_md_contains_locked(MultiDictObject* md, PyObject* identity, Py_hash_t hash,
+                    PyObject** pret)
 {
-    if (!PyUnicode_Check(key)) {
-        return 0;
-    }
-
-    PyObject* identity = md_calc_identity(md, key);
-    if (identity == NULL) {
-        goto fail;
-    }
-
-    Py_hash_t hash = _unicode_hash(identity);
-    if (hash == -1) {
-        goto fail;
-    }
-
-    /* entry->identity and entry->hash are write-once-at-insertion and
-       never mutated again (aside from getall()'s temporary MD_HASH_MARK
-       toggling, still critical-section-only -- a concurrent contains()
-       can transiently race that into a false negative, which is a
-       logical staleness in the same family as the version-check
-       RuntimeError elsewhere, not a memory-safety concern). That means
-       this walk needs no per-entry synchronization beyond the table's
-       own lifetime, which _md_reader_enter()/_md_reader_exit() provide:
-       no atomic entry-field stores or TryIncRef dance needed here,
-       unlike md_get_one()'s value read. When pret != NULL every caller
-       already holds md's critical section (the pret == NULL path is
-       __contains__'s hot path and the only lock-free one; pret != NULL
-       is only reached from the still-locked view set-algebra helpers),
-       so _md_ensure_key()'s entry->key mutation below remains exactly
-       as safe as it always was; the reader bookkeeping is just
-       harmless extra accounting in that case. */
-#ifdef Py_GIL_DISABLED
-    htkeys_t* keys = _md_reader_enter(md);
-#else
-    htkeys_t* keys = md->keys;
-#endif
-
-    htkeysiter_t iter;
-    htkeysiter_init(&iter, keys, hash);
-    entry_t* entries = htkeys_entries(keys);
-
-    int found = 0;
-    for (; iter.index != DKIX_EMPTY; htkeysiter_next(&iter)) {
-        if (iter.index < 0) {
-            continue;
-        }
-        entry_t* entry = entries + iter.index;
-        if (hash != entry->hash) {
-            continue;
-        }
-        if (_str_cmp(identity, entry->identity)) {
-            found = 1;
-            if (pret != NULL) {
-                *pret = _md_ensure_key(md, entry);
-                if (*pret == NULL) {
-                    found = -1;
-                }
-            }
-            break;
-        }
-    }
-
-#ifdef Py_GIL_DISABLED
-    _md_reader_exit(md, keys);
-#endif
-
-    Py_DECREF(identity);
-    if (found <= 0 && pret != NULL) {
-        *pret = NULL;
-    }
-    return found;
-fail:
-    Py_XDECREF(identity);
-    if (pret != NULL) {
-        *pret = NULL;
-    }
-    return -1;
-}
-
-static inline int
-md_get_one(MultiDictObject* md, PyObject* key, PyObject** ret)
-{
-    PyObject* identity = md_calc_identity(md, key);
-    if (identity == NULL) {
-        goto fail;
-    }
-
-    Py_hash_t hash = _unicode_hash(identity);
-    if (hash == -1) {
-        goto fail;
-    }
-
     htkeysiter_t iter;
     htkeysiter_init(&iter, md->keys, hash);
     entry_t* entries = htkeys_entries(md->keys);
@@ -1123,18 +1308,295 @@ md_get_one(MultiDictObject* md, PyObject* key, PyObject** ret)
             continue;
         }
         if (_str_cmp(identity, entry->identity)) {
+            if (pret != NULL) {
+                *pret = _md_ensure_key(md, entry);
+                if (*pret == NULL) {
+                    return -1;
+                }
+            }
+            return 1;
+        }
+    }
+    if (pret != NULL) {
+        *pret = NULL;
+    }
+    return 0;
+}
+
+#if defined(Py_GIL_DISABLED) && _MD_HAVE_TRYINCREF
+
+/* Lock-free fast path for __contains__ (pret == NULL only: pret !=
+   NULL needs _md_ensure_key()'s entry->key mutation, which stays
+   critical-section-only). Same shape as _md_get_one_lockfree(): check
+   identity (safely referenced via _md_entry_try_get_ref()) before
+   ever touching hash, for every candidate the walk examines, not just
+   an eventual match -- _str_cmp() needs to safely read the
+   candidate's contents to know whether it even matches. Returns
+   _MD_NEED_LOCK (shared with _md_get_one_lockfree's sentinel value)
+   when it can't complete safely. */
+static inline int
+_md_contains_lockfree(MultiDictObject* md, PyObject* identity, Py_hash_t hash)
+{
+    htkeys_t* keys = _md_reader_enter(md);
+    htkeysiter_t iter;
+    htkeysiter_init(&iter, keys, hash);
+    entry_t* entries = htkeys_entries(keys);
+
+    int result = 0;
+    for (; iter.index != DKIX_EMPTY; htkeysiter_next(&iter)) {
+        if (iter.index < 0) {
+            continue;
+        }
+        entry_t* entry = entries + iter.index;
+
+        PyObject* entry_identity = _md_entry_try_get_ref(&entry->identity);
+        if (entry_identity == NULL) {
+            if (_md_entry_load_identity(entry) == NULL) {
+                continue;  // not populated (or deleted); keep probing
+            }
+            result = 2;  // _MD_NEED_LOCK
+            break;
+        }
+
+        if (_md_entry_load_hash(entry) != hash) {
+            Py_DECREF(entry_identity);
+            continue;
+        }
+
+        bool matched = _str_cmp(identity, entry_identity);
+        Py_DECREF(entry_identity);
+        if (matched) {
+            result = 1;
+            break;
+        }
+    }
+
+    _md_reader_exit(md, keys);
+    return result;
+}
+
+#endif /* Py_GIL_DISABLED && _MD_HAVE_TRYINCREF */
+
+static inline int
+md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
+{
+    if (!PyUnicode_Check(key)) {
+        return 0;
+    }
+
+    PyObject* identity = md_calc_identity(md, key);
+    if (identity == NULL) {
+        if (pret != NULL) {
+            *pret = NULL;
+        }
+        return -1;
+    }
+
+    Py_hash_t hash = _unicode_hash(identity);
+    if (hash == -1) {
+        Py_DECREF(identity);
+        if (pret != NULL) {
+            *pret = NULL;
+        }
+        return -1;
+    }
+
+    int result;
+#if defined(Py_GIL_DISABLED) && _MD_HAVE_TRYINCREF
+    if (pret == NULL) {
+        result = _md_contains_lockfree(md, identity, hash);
+        if (result != 2 /* _MD_NEED_LOCK */) {
             Py_DECREF(identity);
+            return result;
+        }
+    }
+    Py_BEGIN_CRITICAL_SECTION(md);
+    result = _md_contains_locked(md, identity, hash, pret);
+    Py_END_CRITICAL_SECTION();
+#elif defined(Py_GIL_DISABLED)
+    /* No PyUnstable_TryIncRef() available (pre-3.14, see the
+       _MD_HAVE_TRYINCREF comment above): always take the critical
+       section, exactly as before this file added any lock-free
+       reading. */
+    Py_BEGIN_CRITICAL_SECTION(md);
+    result = _md_contains_locked(md, identity, hash, pret);
+    Py_END_CRITICAL_SECTION();
+#else
+    result = _md_contains_locked(md, identity, hash, pret);
+#endif
+    Py_DECREF(identity);
+    return result;
+}
+
+/* Definitive, always-correct implementation: used as the entire
+   md_get_one() on the GIL build, and as the Py_GIL_DISABLED fallback
+   once a lock-free attempt below reports it cannot proceed safely.
+   Callers already hold md's critical section on Py_GIL_DISABLED (the
+   GIL build needs none). */
+static inline int
+_md_get_one_locked(MultiDictObject* md, PyObject* identity, Py_hash_t hash,
+                   PyObject** ret)
+{
+    htkeysiter_t iter;
+    htkeysiter_init(&iter, md->keys, hash);
+    entry_t* entries = htkeys_entries(md->keys);
+
+    for (; iter.index != DKIX_EMPTY; htkeysiter_next(&iter)) {
+        if (iter.index < 0) {
+            continue;
+        }
+        entry_t* entry = entries + iter.index;
+        if (hash != entry->hash) {
+            continue;
+        }
+        if (_str_cmp(identity, entry->identity)) {
             *ret = Py_NewRef(entry->value);
             return 1;
         }
     }
-
-    Py_DECREF(identity);
     return 0;
-fail:
-    Py_XDECREF(identity);
-    return -1;
 }
+
+#if defined(Py_GIL_DISABLED) && _MD_HAVE_TRYINCREF
+
+/* Sentinel meaning "could not complete lock-free"; never returned to
+   md_get_one()'s own caller, only used between the two functions
+   below. Distinct from 1 (found) / 0 (not found) / -1 (error). */
+#define _MD_NEED_LOCK 2
+
+/* Lock-free fast path. entry->identity is checked (and, via
+   PyUnstable_TryIncRef(), safely referenced) before entry->hash or
+   entry->value is ever touched -- see the comment on
+   _md_entry_load_identity() in the Py_GIL_DISABLED block above for
+   why that order, and why TryIncRef is required at all rather than a
+   raw dereference, for *every* candidate this walk examines, not just
+   an eventual match: _str_cmp() needs to safely read the candidate's
+   contents to know whether it even matches. */
+static inline int
+_md_get_one_lockfree(MultiDictObject* md, PyObject* identity, Py_hash_t hash,
+                     PyObject** ret)
+{
+    htkeys_t* keys = _md_reader_enter(md);
+    htkeysiter_t iter;
+    htkeysiter_init(&iter, keys, hash);
+    entry_t* entries = htkeys_entries(keys);
+
+    int result = 0;
+    for (; iter.index != DKIX_EMPTY; htkeysiter_next(&iter)) {
+        if (iter.index < 0) {
+            continue;
+        }
+        entry_t* entry = entries + iter.index;
+
+        PyObject* entry_identity = _md_entry_try_get_ref(&entry->identity);
+        if (entry_identity == NULL) {
+            if (_md_entry_load_identity(entry) == NULL) {
+                continue;  // not populated (or deleted); keep probing
+            }
+            result = _MD_NEED_LOCK;  // racing a concurrent change
+            break;
+        }
+
+        if (_md_entry_load_hash(entry) != hash) {
+            Py_DECREF(entry_identity);
+            continue;
+        }
+
+        bool matched = _str_cmp(identity, entry_identity);
+        Py_DECREF(entry_identity);
+        if (!matched) {
+            continue;
+        }
+
+        PyObject* value = _md_entry_try_get_ref(&entry->value);
+        if (value == NULL) {
+            result = _MD_NEED_LOCK;
+            break;
+        }
+        *ret = value;
+        result = 1;
+        break;
+    }
+
+    _md_reader_exit(md, keys);
+    return result;
+}
+
+static inline int
+md_get_one(MultiDictObject* md, PyObject* key, PyObject** ret)
+{
+    PyObject* identity = md_calc_identity(md, key);
+    if (identity == NULL) {
+        return -1;
+    }
+    Py_hash_t hash = _unicode_hash(identity);
+    if (hash == -1) {
+        Py_DECREF(identity);
+        return -1;
+    }
+
+    int result = _md_get_one_lockfree(md, identity, hash, ret);
+    if (result != _MD_NEED_LOCK) {
+        Py_DECREF(identity);
+        return result;
+    }
+
+    Py_BEGIN_CRITICAL_SECTION(md);
+    result = _md_get_one_locked(md, identity, hash, ret);
+    Py_END_CRITICAL_SECTION();
+    Py_DECREF(identity);
+    return result;
+}
+
+#undef _MD_NEED_LOCK
+
+#elif defined(Py_GIL_DISABLED)
+
+/* No PyUnstable_TryIncRef() available (pre-3.14, see the
+   _MD_HAVE_TRYINCREF comment above): entry contents cannot be
+   dereferenced safely without md's critical section at all, so fall
+   back to always taking it, exactly as before this file added any
+   lock-free reading. */
+static inline int
+md_get_one(MultiDictObject* md, PyObject* key, PyObject** ret)
+{
+    PyObject* identity = md_calc_identity(md, key);
+    if (identity == NULL) {
+        return -1;
+    }
+    Py_hash_t hash = _unicode_hash(identity);
+    if (hash == -1) {
+        Py_DECREF(identity);
+        return -1;
+    }
+    int result;
+    Py_BEGIN_CRITICAL_SECTION(md);
+    result = _md_get_one_locked(md, identity, hash, ret);
+    Py_END_CRITICAL_SECTION();
+    Py_DECREF(identity);
+    return result;
+}
+
+#else /* !Py_GIL_DISABLED */
+
+static inline int
+md_get_one(MultiDictObject* md, PyObject* key, PyObject** ret)
+{
+    PyObject* identity = md_calc_identity(md, key);
+    if (identity == NULL) {
+        return -1;
+    }
+    Py_hash_t hash = _unicode_hash(identity);
+    if (hash == -1) {
+        Py_DECREF(identity);
+        return -1;
+    }
+    int result = _md_get_one_locked(md, identity, hash, ret);
+    Py_DECREF(identity);
+    return result;
+}
+
+#endif /* Py_GIL_DISABLED */
 
 static inline int
 md_get_all(MultiDictObject* md, PyObject* key, PyObject** ret)
@@ -1403,8 +1865,13 @@ _md_replace(MultiDictObject* md, PyObject* key, PyObject* value,
         if (!found) {
             found = 1;
             Py_SETREF(entry->key, Py_NewRef(key));
+#ifdef Py_GIL_DISABLED
+            _md_entry_store_value(entry, Py_NewRef(value));
+            _md_entry_store_hash(entry, finder.hash | MD_HASH_MARK);
+#else
             Py_SETREF(entry->value, Py_NewRef(value));
             entry->hash = finder.hash | MD_HASH_MARK;
+#endif
         } else {
             _md_del_at(md, md_finder_slot(&finder), entry);
         }
@@ -1476,12 +1943,24 @@ _md_update(MultiDictObject* md, Py_hash_t hash, PyObject* identity,
                        in md_update_from* functions. */
                     assert(entry->value == NULL);
                     entry->key = Py_NewRef(key);
+#ifdef Py_GIL_DISABLED
+                    _md_entry_store_value(entry, Py_NewRef(value));
+#else
                     entry->value = Py_NewRef(value);
+#endif
                 } else {
                     Py_SETREF(entry->key, Py_NewRef(key));
+#ifdef Py_GIL_DISABLED
+                    _md_entry_store_value(entry, Py_NewRef(value));
+#else
                     Py_SETREF(entry->value, Py_NewRef(value));
+#endif
                 }
+#ifdef Py_GIL_DISABLED
+                _md_entry_store_hash(entry, hash | MD_HASH_MARK);
+#else
                 entry->hash = hash | MD_HASH_MARK;
+#endif
             } else {
                 _md_del_at_for_upd(md, iter.slot, entry);
             }

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -289,11 +289,6 @@ _md_free_retired(htkeys_t* keys)
     htkeys_free(keys);
 }
 
-/* Frees whatever is currently on md->retired, if active_readers reads
-   0 at this (seq_cst) checkpoint. Called at the start of every
-   resize-triggering operation (shrink, resize, reserve, clear), so a
-   table that couldn't be freed immediately at retirement time gets
-   another chance each time the object is next mutated. */
 static inline void
 _md_drain_retired(MultiDictObject* md)
 {
@@ -313,10 +308,6 @@ _md_drain_retired(MultiDictObject* md)
     }
 }
 
-/* Replaces md_clear()'s and _md_resize()'s direct htkeys_free(): frees
-   `keys` immediately if provably unreferenced by any in-flight
-   lock-free reader, otherwise defers it to md->retired for a later
-   _md_drain_retired() to pick up. */
 static inline void
 _md_retire(MultiDictObject* md, htkeys_t* keys)
 {

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -1433,14 +1433,6 @@ _md_get_one_locked(MultiDictObject* md, PyObject* identity, Py_hash_t hash,
    below. Distinct from 1 (found) / 0 (not found) / -1 (error). */
 #define _MD_NEED_LOCK 2
 
-/* Lock-free fast path. entry->identity is checked (and, via
-   PyUnstable_TryIncRef(), safely referenced) before entry->hash or
-   entry->value is ever touched -- see the comment on
-   _md_entry_load_identity() in the Py_GIL_DISABLED block above for
-   why that order, and why TryIncRef is required at all rather than a
-   raw dereference, for *every* candidate this walk examines, not just
-   an eventual match: _str_cmp() needs to safely read the candidate's
-   contents to know whether it even matches. */
 static inline int
 _md_get_one_lockfree(MultiDictObject* md, PyObject* identity, Py_hash_t hash,
                      PyObject** ret)

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -271,16 +271,15 @@ _md_reader_exit(MultiDictObject* md, htkeys_t* keys)
     atomic_fetch_add_ssize(&md->active_readers, -1);
 }
 
-/* Releases any entries a retired table still owns, then frees it.
-   Only md_clear()'s retired tables have live entries to release here:
-   _md_resize()'s old table has its ownership already transferred to
-   the new table via memcpy (see _md_retire_resized()), so its
-   nentries is reset to 0 before retirement, making this loop a
-   no-op for that case. */
 static inline void
 _md_free_retired(htkeys_t* keys)
 {
     entry_t* entries = htkeys_entries(keys);
+    /* Only md_clear()'s retired tables have live entries to release here:
+   _md_resize()'s old table has its ownership already transferred to
+   the new table via memcpy (see _md_retire_resized()), so its
+   nentries is reset to 0 before retirement, making this loop a
+   no-op for that case. */
     for (Py_ssize_t i = 0; i < keys->nentries; i++) {
         Py_CLEAR(entries[i].identity);
         Py_CLEAR(entries[i].key);
@@ -728,11 +727,6 @@ md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
 
         memcpy(keys, fresh_src, size);
 #ifdef Py_GIL_DISABLED
-        /* keys is a brand-new, independent allocation: the memcpy just
-           copied other->keys's live reader count and retirement link
-           along with everything else, neither of which describes this
-           new blob's own (so-far nonexistent) readers or retirement
-           state. */
         keys->readers = 0;
         keys->retired_next = NULL;
 #endif
@@ -1284,13 +1278,6 @@ md_finder_cleanup(md_finder_t* finder)
     finder->md = NULL;
 }
 
-/* Used for pret != NULL (every caller already holds md's critical
-   section -- the view set-algebra helpers, not a hot path) and as the
-   whole implementation / lock-free fallback for pret == NULL
-   (__contains__'s actual hot path). _md_ensure_key()'s entry->key
-   mutation is safe here exactly as it always was: this function is
-   only ever invoked either already under the critical section, or by
-   md_contains() itself while holding it. */
 static inline int
 _md_contains_locked(MultiDictObject* md, PyObject* identity, Py_hash_t hash,
                     PyObject** pret)
@@ -1325,15 +1312,6 @@ _md_contains_locked(MultiDictObject* md, PyObject* identity, Py_hash_t hash,
 
 #if defined(Py_GIL_DISABLED) && _MD_HAVE_TRYINCREF
 
-/* Lock-free fast path for __contains__ (pret == NULL only: pret !=
-   NULL needs _md_ensure_key()'s entry->key mutation, which stays
-   critical-section-only). Same shape as _md_get_one_lockfree(): check
-   identity (safely referenced via _md_entry_try_get_ref()) before
-   ever touching hash, for every candidate the walk examines, not just
-   an eventual match -- _str_cmp() needs to safely read the
-   candidate's contents to know whether it even matches. Returns
-   _MD_NEED_LOCK (shared with _md_get_one_lockfree's sentinel value)
-   when it can't complete safely. */
 static inline int
 _md_contains_lockfree(MultiDictObject* md, PyObject* identity, Py_hash_t hash)
 {
@@ -1414,10 +1392,6 @@ md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
     result = _md_contains_locked(md, identity, hash, pret);
     Py_END_CRITICAL_SECTION();
 #elif defined(Py_GIL_DISABLED)
-    /* No PyUnstable_TryIncRef() available (pre-3.14, see the
-       _MD_HAVE_TRYINCREF comment above): always take the critical
-       section, exactly as before this file added any lock-free
-       reading. */
     Py_BEGIN_CRITICAL_SECTION(md);
     result = _md_contains_locked(md, identity, hash, pret);
     Py_END_CRITICAL_SECTION();
@@ -1428,11 +1402,6 @@ md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
     return result;
 }
 
-/* Definitive, always-correct implementation: used as the entire
-   md_get_one() on the GIL build, and as the Py_GIL_DISABLED fallback
-   once a lock-free attempt below reports it cannot proceed safely.
-   Callers already hold md's critical section on Py_GIL_DISABLED (the
-   GIL build needs none). */
 static inline int
 _md_get_one_locked(MultiDictObject* md, PyObject* identity, Py_hash_t hash,
                    PyObject** ret)
@@ -1552,11 +1521,6 @@ md_get_one(MultiDictObject* md, PyObject* key, PyObject** ret)
 
 #elif defined(Py_GIL_DISABLED)
 
-/* No PyUnstable_TryIncRef() available (pre-3.14, see the
-   _MD_HAVE_TRYINCREF comment above): entry contents cannot be
-   dereferenced safely without md's critical section at all, so fall
-   back to always taking it, exactly as before this file added any
-   lock-free reading. */
 static inline int
 md_get_one(MultiDictObject* md, PyObject* key, PyObject** ret)
 {
@@ -2753,16 +2717,6 @@ md_clear(MultiDictObject* md)
     md->keys = (htkeys_t*)&empty_htkeys;
 
 #ifdef Py_GIL_DISABLED
-    /* Unlike the critical-section-only world PR #1433 was written for,
-       a lock-free reader can now be genuinely concurrent with this
-       function, not just suspended by an arbitrary-code callback: it
-       does not take md's critical section at all. Releasing entries'
-       references here, immediately, would race such a reader's own
-       (unsynchronized) reads of those same identity/key/value fields.
-       So the entire cleanup -- decref loop included, not just the
-       final free -- is deferred to _md_retire()'s drain, which only
-       ever runs at a point already proven to have no reader near this
-       table. */
     _md_retire(md, old_keys);
 #else
     entry_t* entries = htkeys_entries(old_keys);

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -207,57 +207,70 @@ _ci_arg_to_key(mod_state* state, PyObject* key, PyObject* identity)
 /*
 Lock-free read support.
 
-md->active_readers is a coarse "some lock-free reader is in flight on
+md->num_active_readers is a coarse "some lock-free reader is in flight on
 this object" gate: incremented before a reader ever dereferences a
 keys table, decremented once it's done. A table is only ever freed
 once this reads 0 at a point synchronized (seq_cst on both sides, see
 atomic_helpers.h) with the swap that retired it. That ordering is the
 safety argument in full:
 
-  reader:  active_readers += 1        (A, seq_cst)
+  reader:  num_active_readers += 1        (A, seq_cst)
            keys = load(md->keys)      (B, seq_cst)
-           keys->readers += 1         (C, relaxed; skipped for
+           keys->num_readers += 1         (C, relaxed; skipped for
                                         &empty_htkeys, which is never
                                         retired or freed)
            ... walk keys ...
-           keys->readers -= 1         (D, relaxed)
-           active_readers -= 1        (E, seq_cst)
+           keys->num_readers -= 1         (D, relaxed)
+           num_active_readers -= 1        (E, seq_cst)
 
   writer:  store(md->keys, new)       (seq_cst)
-           if load(active_readers) == 0 (seq_cst): free old immediately
+           if load(num_active_readers) == 0 (seq_cst): free old immediately
            else: move old onto md->retired, freed by a later drain
 
 A is always sequenced-before B on the reader's own thread, so if the
-writer's check observes active_readers == 0, no reader can be between
+writer's check observes num_active_readers == 0, no reader can be between
 A and E for *any* table -- in particular none can be between B and C
 for the table being freed. Anything weaker than seq_cst here (plain
 acquire/release, or relaxed) is not enough: the writer's store to
-md->keys and its read of active_readers, versus the reader's write to
-active_readers and its read of md->keys, is a criss-cross on two
+md->keys and its read of num_active_readers, versus the reader's write to
+num_active_readers and its read of md->keys, is a criss-cross on two
 independent atomics (the same shape as Dekker's algorithm), and only a
 single global seq_cst order over all four operations closes it -- see
 the design discussion that produced this file for the specific
 interleaving that a weaker order permits.
 
-keys->readers (C/D) does not participate in that ordering and stays
+keys->num_readers (C/D) does not participate in that ordering and stays
 relaxed: it is only ever inspected in _md_drain_retired(), which never
-runs except at a point already known -- via the active_readers check
+runs except at a point already known -- via the num_active_readers check
 above -- to have no reader anywhere near it. It exists purely as a
 cheap defensive assertion that the coarse gate actually worked, not as
 an independent freeing trigger; freeing a specific retired table ahead
-of the whole object's active_readers reaching 0 would reintroduce the
+of the whole object's num_active_readers reaching 0 would reintroduce the
 same bootstrap race the coarse gate exists to close (see the design
 discussion; true per-table precision under sustained concurrent read
 load needs epoch tagging, which this does not attempt).
 */
 
+/* Every write to md->keys that a lock-free reader could observe must
+   use this, matching _md_reader_enter()'s atomic_load_ptr(): mixing a
+   plain store here with an atomic load there is a data race regardless
+   of what the surrounding critical section or num_active_readers protocol
+   otherwise guarantees, and on architectures weaker than x86 a plain
+   store carries no ordering guarantee at all relative to the
+   num_active_readers check the retiring code depends on. */
+static inline void
+_md_store_keys(MultiDictObject* md, htkeys_t* keys)
+{
+    atomic_store_ptr((void**)&md->keys, keys);
+}
+
 static inline htkeys_t*
 _md_reader_enter(MultiDictObject* md)
 {
-    atomic_fetch_add_ssize(&md->active_readers, 1);
+    atomic_fetch_add_ssize(&md->num_active_readers, 1);
     htkeys_t* keys = (htkeys_t*)atomic_load_ptr((void* const*)&md->keys);
     if (keys != &empty_htkeys) {
-        atomic_fetch_add_ssize_relaxed(&keys->readers, 1);
+        atomic_fetch_add_ssize_relaxed(&keys->num_readers, 1);
     }
     return keys;
 }
@@ -266,9 +279,9 @@ static inline void
 _md_reader_exit(MultiDictObject* md, htkeys_t* keys)
 {
     if (keys != &empty_htkeys) {
-        atomic_fetch_add_ssize_relaxed(&keys->readers, -1);
+        atomic_fetch_add_ssize_relaxed(&keys->num_readers, -1);
     }
-    atomic_fetch_add_ssize(&md->active_readers, -1);
+    atomic_fetch_add_ssize(&md->num_active_readers, -1);
 }
 
 static inline void
@@ -294,14 +307,14 @@ _md_drain_retired(MultiDictObject* md)
     if (md->retired == NULL) {
         return;
     }
-    if (atomic_load_ssize(&md->active_readers) != 0) {
+    if (atomic_load_ssize(&md->num_active_readers) != 0) {
         return;
     }
     htkeys_t* t = md->retired;
     md->retired = NULL;
     while (t != NULL) {
         htkeys_t* next = t->retired_next;
-        assert(atomic_load_ssize_relaxed(&t->readers) == 0);
+        assert(atomic_load_ssize_relaxed(&t->num_readers) == 0);
         _md_free_retired(t);
         t = next;
     }
@@ -314,7 +327,7 @@ _md_retire(MultiDictObject* md, htkeys_t* keys)
         return;
     }
     _md_drain_retired(md);
-    if (atomic_load_ssize(&md->active_readers) == 0) {
+    if (atomic_load_ssize(&md->num_active_readers) == 0) {
         _md_free_retired(keys);
     } else {
         keys->retired_next = md->retired;
@@ -322,23 +335,6 @@ _md_retire(MultiDictObject* md, htkeys_t* keys)
     }
 }
 
-/* PyUnstable_TryIncRef()/PyUnstable_EnableTryIncRef() -- the only
-   public API letting a third-party extension safely try to incref an
-   object that might concurrently be reaching refcount zero on another
-   thread -- were added in CPython 3.14 (gh-128844) and do not exist
-   on 3.13, the free-threaded build's first (and, as of this writing,
-   most widely deployed) release: checked directly against the CPython
-   3.13 branch's Include/cpython/object.h, which has no equivalent.
-   CPython's own dict has had this capability since 3.13
-   (_Py_TryIncrefCompare, Include/internal/pycore_object.h), but that's
-   an internal, non-exported symbol -- the same situation as
-   _PyMem_FreeDelayed elsewhere in this file, not something a
-   separately-built, separately-linked extension can call. Below 3.14,
-   dereferencing an entry's identity/value contents without holding
-   md's critical section is not safe by any means available here, so
-   md_get_one() and the pret == NULL path of md_contains() fall back
-   to always taking the critical section there, exactly as they were
-   before this file added any lock-free reading at all. */
 #if PY_VERSION_HEX >= 0x030e0000
 #define _MD_HAVE_TRYINCREF 1
 #else
@@ -407,12 +403,6 @@ _md_entry_load_value(entry_t* entry)
     return (PyObject*)atomic_load_ptr((void* const*)&entry->value);
 }
 
-/* Publishes a new value, enabling PyUnstable_TryIncRef() for lock-free
-   readers. Does not touch whatever reference was there before: callers
-   that replace an already-populated entry (as opposed to filling a
-   fresh one) must drop that reference themselves, and are free to do
-   so after other suspension-risky work -- see _md_replace()/
-   _md_update() for why deferring it can matter. */
 static inline void
 _md_entry_publish_value(entry_t* entry, PyObject* value)
 {
@@ -422,11 +412,6 @@ _md_entry_publish_value(entry_t* entry, PyObject* value)
     atomic_store_ptr((void**)&entry->value, value);
 }
 
-/* Publishes a new value and decrefs whatever was there before only
-   after the new value is already visible, so a concurrent reader can
-   never observe entry->value mid-transition. Only safe when nothing
-   else needs to happen between the two -- see _md_entry_publish_value()
-   above when the caller must defer the decref. */
 static inline void
 _md_entry_store_value(entry_t* entry, PyObject* value)
 {
@@ -566,7 +551,11 @@ _md_resize(MultiDictObject* md, uint8_t log2_newsize, bool update)
         newkeys->usable = newkeys->usable - numentries;
         newkeys->nentries = numentries;
 
+#ifdef Py_GIL_DISABLED
+        _md_store_keys(md, newkeys);
+#else
         md->keys = newkeys;
+#endif
 
 #ifdef Py_GIL_DISABLED
         /* Bump the version on every resize, not just when a caller's
@@ -709,7 +698,11 @@ md_init(MultiDictObject* md, mod_state* state, bool is_ci, Py_ssize_t minused)
     md->is_ci = is_ci;
     md->used = 0;
     md->version = NEXT_VERSION(md->state);
+#ifdef Py_GIL_DISABLED
+    _md_store_keys(md, new_keys);
+#else
     md->keys = new_keys;
+#endif
     ASSERT_CONSISTENT(md, false);
     return 0;
 }
@@ -750,7 +743,7 @@ md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
 
         memcpy(keys, fresh_src, size);
 #ifdef Py_GIL_DISABLED
-        keys->readers = 0;
+        keys->num_readers = 0;
         keys->retired_next = NULL;
 #endif
         entry_t* entry = htkeys_entries(keys);
@@ -775,7 +768,11 @@ md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
     md->used = used;
     md->version = version;
     md->is_ci = is_ci;
+#ifdef Py_GIL_DISABLED
+    _md_store_keys(md, keys);
+#else
     md->keys = keys;
+#endif
     ASSERT_CONSISTENT(md, false);
     return 0;
 }
@@ -1305,18 +1302,6 @@ md_finder_cleanup(md_finder_t* finder)
             continue;
         }
         entry_t* entry = entries + finder->iter.index;
-        /* Restore only entries this exact finder marked, not any
-           marked entry the probe chain happens to pass through: under
-           free threading, that chain can also hold an entry a
-           different, concurrently-suspended finder (scanning some
-           other key whose hash shares this bucket -- easy with a
-           small table) marked with *its own* hash. Blindly restoring
-           by matching only the sign bit would overwrite that entry's
-           real hash with this finder's, corrupting it. A mark this
-           finder made is always exactly finder->hash | MD_HASH_MARK;
-           nothing else can coincidentally equal that unless the two
-           keys' hashes were equal to begin with, in which case
-           restoring to finder->hash is correct anyway. */
         if (entry->hash == (finder->hash | MD_HASH_MARK)) {
             entry->hash = finder->hash;
         }
@@ -1383,7 +1368,14 @@ _md_contains_lockfree(MultiDictObject* md, PyObject* identity, Py_hash_t hash)
             break;
         }
 
-        if (_md_entry_load_hash(entry) != hash) {
+        /* Masked, not a raw comparison: entry->hash can legitimately
+           carry MD_HASH_MARK right now if a different, concurrently-
+           suspended _md_replace()/_md_update() call has this exact
+           entry marked (see the comment above MD_HASH_MARK). A raw
+           comparison would treat that as "wrong hash, not a match" and
+           skip a key that is genuinely present both before and after
+           that operation -- a false miss, not just a stale read. */
+        if ((_md_entry_load_hash(entry) & PY_SSIZE_T_MAX) != hash) {
             Py_DECREF(entry_identity);
             continue;
         }
@@ -1505,7 +1497,12 @@ _md_get_one_lockfree(MultiDictObject* md, PyObject* identity, Py_hash_t hash,
             break;
         }
 
-        if (_md_entry_load_hash(entry) != hash) {
+        /* Masked, not a raw comparison -- see the identical comment in
+           _md_contains_lockfree(): entry->hash can be legitimately
+           MD_HASH_MARK-ed by a different, concurrently-suspended
+           _md_replace()/_md_update() call right now, and a raw
+           comparison would wrongly treat a present key as absent. */
+        if ((_md_entry_load_hash(entry) & PY_SSIZE_T_MAX) != hash) {
             Py_DECREF(entry_identity);
             continue;
         }
@@ -2871,7 +2868,11 @@ md_clear(MultiDictObject* md)
     // either the fully-populated old table or the fully-empty one.
     htkeys_t* old_keys = md->keys;
     md->used = 0;
+#ifdef Py_GIL_DISABLED
+    _md_store_keys(md, (htkeys_t*)&empty_htkeys);
+#else
     md->keys = (htkeys_t*)&empty_htkeys;
+#endif
 
 #ifdef Py_GIL_DISABLED
     _md_retire(md, old_keys);

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -240,7 +240,7 @@ the design discussion that produced this file for the specific
 interleaving that a weaker order permits.
 
 keys->readers (C/D) does not participate in that ordering and stays
-relaxed: it is only ever inspected in md_drain_retired(), which never
+relaxed: it is only ever inspected in _md_drain_retired(), which never
 runs except at a point already known -- via the active_readers check
 above -- to have no reader anywhere near it. It exists purely as a
 cheap defensive assertion that the coarse gate actually worked, not as
@@ -252,7 +252,7 @@ load needs epoch tagging, which this does not attempt).
 */
 
 static inline htkeys_t*
-md_reader_enter(MultiDictObject* md)
+_md_reader_enter(MultiDictObject* md)
 {
     atomic_fetch_add_ssize(&md->active_readers, 1);
     htkeys_t* keys = (htkeys_t*)atomic_load_ptr((void* const*)&md->keys);
@@ -263,7 +263,7 @@ md_reader_enter(MultiDictObject* md)
 }
 
 static inline void
-md_reader_exit(MultiDictObject* md, htkeys_t* keys)
+_md_reader_exit(MultiDictObject* md, htkeys_t* keys)
 {
     if (keys != &empty_htkeys) {
         atomic_fetch_add_ssize_relaxed(&keys->readers, -1);
@@ -295,7 +295,7 @@ _md_free_retired(htkeys_t* keys)
    table that couldn't be freed immediately at retirement time gets
    another chance each time the object is next mutated. */
 static inline void
-md_drain_retired(MultiDictObject* md)
+_md_drain_retired(MultiDictObject* md)
 {
     if (md->retired == NULL) {
         return;
@@ -316,14 +316,14 @@ md_drain_retired(MultiDictObject* md)
 /* Replaces md_clear()'s and _md_resize()'s direct htkeys_free(): frees
    `keys` immediately if provably unreferenced by any in-flight
    lock-free reader, otherwise defers it to md->retired for a later
-   md_drain_retired() to pick up. */
+   _md_drain_retired() to pick up. */
 static inline void
-md_retire(MultiDictObject* md, htkeys_t* keys)
+_md_retire(MultiDictObject* md, htkeys_t* keys)
 {
     if (keys == &empty_htkeys) {
         return;
     }
-    md_drain_retired(md);
+    _md_drain_retired(md);
     if (atomic_load_ssize(&md->active_readers) == 0) {
         _md_free_retired(keys);
     } else {
@@ -380,12 +380,12 @@ _md_resize(MultiDictObject* md, uint8_t log2_newsize, bool update)
 
 #ifdef Py_GIL_DISABLED
     /* Ownership of oldkeys's entries has already moved to newkeys via
-       the memcpy/copy loop above; zeroing nentries tells md_retire()'s
+       the memcpy/copy loop above; zeroing nentries tells _md_retire()'s
        cleanup there is nothing left to decref, only memory to free. */
     if (oldkeys != &empty_htkeys) {
         oldkeys->nentries = 0;
     }
-    md_retire(md, oldkeys);
+    _md_retire(md, oldkeys);
 #else
     if (oldkeys != &empty_htkeys) {
         htkeys_free(oldkeys);
@@ -565,7 +565,7 @@ md_calc_identity(MultiDictObject* md, PyObject* key)
 }
 
 static inline PyObject*
-md_calc_key(MultiDictObject* md, PyObject* key, PyObject* identity)
+_md_calc_key(MultiDictObject* md, PyObject* key, PyObject* identity)
 {
     if (md->is_ci) return _ci_arg_to_key(md->state, key, identity);
     return _arg_to_key(md->state, key, identity);
@@ -582,7 +582,7 @@ _md_ensure_key(MultiDictObject* md, entry_t* entry)
 {
     assert(entry >= htkeys_entries(md->keys));
     assert(entry < htkeys_entries(md->keys) + md->keys->nentries);
-    PyObject* key = md_calc_key(md, entry->key, entry->identity);
+    PyObject* key = _md_calc_key(md, entry->key, entry->identity);
     if (key == NULL) {
         return NULL;
     }
@@ -936,14 +936,14 @@ md_init_finder(MultiDictObject* md, PyObject* identity, md_finder_t* finder)
 }
 
 static inline Py_ssize_t
-md_finder_slot(md_finder_t* finder)
+_md_finder_slot(md_finder_t* finder)
 {
     assert(finder->md != NULL);
     return finder->iter.slot;
 }
 
 static inline Py_ssize_t
-md_finder_index(md_finder_t* finder)
+_md_finder_index(md_finder_t* finder)
 {
     assert(finder->md != NULL);
     assert(finder->iter.index >= 0);
@@ -1049,7 +1049,7 @@ md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
        logical staleness in the same family as the version-check
        RuntimeError elsewhere, not a memory-safety concern). That means
        this walk needs no per-entry synchronization beyond the table's
-       own lifetime, which md_reader_enter()/md_reader_exit() provide:
+       own lifetime, which _md_reader_enter()/_md_reader_exit() provide:
        no atomic entry-field stores or TryIncRef dance needed here,
        unlike md_get_one()'s value read. When pret != NULL every caller
        already holds md's critical section (the pret == NULL path is
@@ -1059,7 +1059,7 @@ md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
        as safe as it always was; the reader bookkeeping is just
        harmless extra accounting in that case. */
 #ifdef Py_GIL_DISABLED
-    htkeys_t* keys = md_reader_enter(md);
+    htkeys_t* keys = _md_reader_enter(md);
 #else
     htkeys_t* keys = md->keys;
 #endif
@@ -1090,7 +1090,7 @@ md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
     }
 
 #ifdef Py_GIL_DISABLED
-    md_reader_exit(md, keys);
+    _md_reader_exit(md, keys);
 #endif
 
     Py_DECREF(identity);
@@ -1371,7 +1371,7 @@ md_pop_item(MultiDictObject* md)
     }
     assert(pos >= 0);
 
-    PyObject* key = md_calc_key(md, entry->key, entry->identity);
+    PyObject* key = _md_calc_key(md, entry->key, entry->identity);
     if (key == NULL) {
         return NULL;
     }
@@ -1408,14 +1408,14 @@ _md_replace(MultiDictObject* md, PyObject* key, PyObject* value,
 
     // don't grab neither key nor value but use the calculated index
     while ((tmp = md_find_next(&finder, NULL, NULL)) > 0) {
-        entry_t* entry = entries + md_finder_index(&finder);
+        entry_t* entry = entries + _md_finder_index(&finder);
         if (!found) {
             found = 1;
             Py_SETREF(entry->key, Py_NewRef(key));
             Py_SETREF(entry->value, Py_NewRef(value));
             entry->hash = finder.hash | MD_HASH_MARK;
         } else {
-            _md_del_at(md, md_finder_slot(&finder), entry);
+            _md_del_at(md, _md_finder_slot(&finder), entry);
         }
     }
     if (tmp < 0) {
@@ -1609,7 +1609,7 @@ md_update_from_ht(MultiDictObject* md, MultiDictObject* other, UpdateOp op)
                 goto fail;
             }
             /* materialize key */
-            key = md_calc_key(other, entry->key, identity);
+            key = _md_calc_key(other, entry->key, identity);
             if (key == NULL) {
                 goto fail;
             }
@@ -2290,10 +2290,10 @@ md_clear(MultiDictObject* md)
        references here, immediately, would race such a reader's own
        (unsynchronized) reads of those same identity/key/value fields.
        So the entire cleanup -- decref loop included, not just the
-       final free -- is deferred to md_retire()'s drain, which only
+       final free -- is deferred to _md_retire()'s drain, which only
        ever runs at a point already proven to have no reader near this
        table. */
-    md_retire(md, old_keys);
+    _md_retire(md, old_keys);
 #else
     entry_t* entries = htkeys_entries(old_keys);
     Py_ssize_t nentries = old_keys->nentries;

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -927,14 +927,14 @@ md_init_finder(MultiDictObject* md, PyObject* identity, md_finder_t* finder)
 }
 
 static inline Py_ssize_t
-_md_finder_slot(md_finder_t* finder)
+md_finder_slot(md_finder_t* finder)
 {
     assert(finder->md != NULL);
     return finder->iter.slot;
 }
 
 static inline Py_ssize_t
-_md_finder_index(md_finder_t* finder)
+md_finder_index(md_finder_t* finder)
 {
     assert(finder->md != NULL);
     assert(finder->iter.index >= 0);
@@ -1399,14 +1399,14 @@ _md_replace(MultiDictObject* md, PyObject* key, PyObject* value,
 
     // don't grab neither key nor value but use the calculated index
     while ((tmp = md_find_next(&finder, NULL, NULL)) > 0) {
-        entry_t* entry = entries + _md_finder_index(&finder);
+        entry_t* entry = entries + md_finder_index(&finder);
         if (!found) {
             found = 1;
             Py_SETREF(entry->key, Py_NewRef(key));
             Py_SETREF(entry->value, Py_NewRef(value));
             entry->hash = finder.hash | MD_HASH_MARK;
         } else {
-            _md_del_at(md, _md_finder_slot(&finder), entry);
+            _md_del_at(md, md_finder_slot(&finder), entry);
         }
     }
     if (tmp < 0) {

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -202,6 +202,138 @@ _ci_arg_to_key(mod_state* state, PyObject* key, PyObject* identity)
     return NULL;
 }
 
+#ifdef Py_GIL_DISABLED
+
+/*
+Lock-free read support.
+
+md->active_readers is a coarse "some lock-free reader is in flight on
+this object" gate: incremented before a reader ever dereferences a
+keys table, decremented once it's done. A table is only ever freed
+once this reads 0 at a point synchronized (seq_cst on both sides, see
+atomic_helpers.h) with the swap that retired it. That ordering is the
+safety argument in full:
+
+  reader:  active_readers += 1        (A, seq_cst)
+           keys = load(md->keys)      (B, seq_cst)
+           keys->readers += 1         (C, relaxed; skipped for
+                                        &empty_htkeys, which is never
+                                        retired or freed)
+           ... walk keys ...
+           keys->readers -= 1         (D, relaxed)
+           active_readers -= 1        (E, seq_cst)
+
+  writer:  store(md->keys, new)       (seq_cst)
+           if load(active_readers) == 0 (seq_cst): free old immediately
+           else: move old onto md->retired, freed by a later drain
+
+A is always sequenced-before B on the reader's own thread, so if the
+writer's check observes active_readers == 0, no reader can be between
+A and E for *any* table -- in particular none can be between B and C
+for the table being freed. Anything weaker than seq_cst here (plain
+acquire/release, or relaxed) is not enough: the writer's store to
+md->keys and its read of active_readers, versus the reader's write to
+active_readers and its read of md->keys, is a criss-cross on two
+independent atomics (the same shape as Dekker's algorithm), and only a
+single global seq_cst order over all four operations closes it -- see
+the design discussion that produced this file for the specific
+interleaving that a weaker order permits.
+
+keys->readers (C/D) does not participate in that ordering and stays
+relaxed: it is only ever inspected in md_drain_retired(), which never
+runs except at a point already known -- via the active_readers check
+above -- to have no reader anywhere near it. It exists purely as a
+cheap defensive assertion that the coarse gate actually worked, not as
+an independent freeing trigger; freeing a specific retired table ahead
+of the whole object's active_readers reaching 0 would reintroduce the
+same bootstrap race the coarse gate exists to close (see the design
+discussion; true per-table precision under sustained concurrent read
+load needs epoch tagging, which this does not attempt).
+*/
+
+static inline htkeys_t*
+md_reader_enter(MultiDictObject* md)
+{
+    atomic_fetch_add_ssize(&md->active_readers, 1);
+    htkeys_t* keys = (htkeys_t*)atomic_load_ptr((void* const*)&md->keys);
+    if (keys != &empty_htkeys) {
+        atomic_fetch_add_ssize_relaxed(&keys->readers, 1);
+    }
+    return keys;
+}
+
+static inline void
+md_reader_exit(MultiDictObject* md, htkeys_t* keys)
+{
+    if (keys != &empty_htkeys) {
+        atomic_fetch_add_ssize_relaxed(&keys->readers, -1);
+    }
+    atomic_fetch_add_ssize(&md->active_readers, -1);
+}
+
+/* Releases any entries a retired table still owns, then frees it.
+   Only md_clear()'s retired tables have live entries to release here:
+   _md_resize()'s old table has its ownership already transferred to
+   the new table via memcpy (see _md_retire_resized()), so its
+   nentries is reset to 0 before retirement, making this loop a
+   no-op for that case. */
+static inline void
+_md_free_retired(htkeys_t* keys)
+{
+    entry_t* entries = htkeys_entries(keys);
+    for (Py_ssize_t i = 0; i < keys->nentries; i++) {
+        Py_CLEAR(entries[i].identity);
+        Py_CLEAR(entries[i].key);
+        Py_CLEAR(entries[i].value);
+    }
+    htkeys_free(keys);
+}
+
+/* Frees whatever is currently on md->retired, if active_readers reads
+   0 at this (seq_cst) checkpoint. Called at the start of every
+   resize-triggering operation (shrink, resize, reserve, clear), so a
+   table that couldn't be freed immediately at retirement time gets
+   another chance each time the object is next mutated. */
+static inline void
+md_drain_retired(MultiDictObject* md)
+{
+    if (md->retired == NULL) {
+        return;
+    }
+    if (atomic_load_ssize(&md->active_readers) != 0) {
+        return;
+    }
+    htkeys_t* t = md->retired;
+    md->retired = NULL;
+    while (t != NULL) {
+        htkeys_t* next = t->retired_next;
+        assert(atomic_load_ssize_relaxed(&t->readers) == 0);
+        _md_free_retired(t);
+        t = next;
+    }
+}
+
+/* Replaces md_clear()'s and _md_resize()'s direct htkeys_free(): frees
+   `keys` immediately if provably unreferenced by any in-flight
+   lock-free reader, otherwise defers it to md->retired for a later
+   md_drain_retired() to pick up. */
+static inline void
+md_retire(MultiDictObject* md, htkeys_t* keys)
+{
+    if (keys == &empty_htkeys) {
+        return;
+    }
+    md_drain_retired(md);
+    if (atomic_load_ssize(&md->active_readers) == 0) {
+        _md_free_retired(keys);
+    } else {
+        keys->retired_next = md->retired;
+        md->retired = keys;
+    }
+}
+
+#endif /* Py_GIL_DISABLED */
+
 static inline int
 _md_resize(MultiDictObject* md, uint8_t log2_newsize, bool update)
 {
@@ -246,9 +378,19 @@ _md_resize(MultiDictObject* md, uint8_t log2_newsize, bool update)
 
     md->keys = newkeys;
 
+#ifdef Py_GIL_DISABLED
+    /* Ownership of oldkeys's entries has already moved to newkeys via
+       the memcpy/copy loop above; zeroing nentries tells md_retire()'s
+       cleanup there is nothing left to decref, only memory to free. */
+    if (oldkeys != &empty_htkeys) {
+        oldkeys->nentries = 0;
+    }
+    md_retire(md, oldkeys);
+#else
     if (oldkeys != &empty_htkeys) {
         htkeys_free(oldkeys);
     }
+#endif
 
     md->keys->usable = md->keys->usable - numentries;
     md->keys->nentries = numentries;
@@ -259,6 +401,19 @@ _md_resize(MultiDictObject* md, uint8_t log2_newsize, bool update)
 static inline int
 _md_shrink(MultiDictObject* md, bool update)
 {
+#ifdef Py_GIL_DISABLED
+    /* The in-place compaction below rewrites the currently-published
+       table's entries and indices while md->keys keeps pointing at it
+       the whole time -- safe when every reader holds the critical
+       section (mutually exclusive with this function), not safe
+       against a lock-free reader concurrently walking the very memory
+       being rewritten. _md_resize() already has the build-a-new-table,
+       swap, retire-the-old-one shape lock-free reads need; reusing it
+       at the *current* size does exactly what shrinking means here
+       (drop the dummy-slot gaps) without a second, duplicate
+       implementation of that shape. */
+    return _md_resize(md, md->keys->log2_size, update);
+#else
     htkeys_t* keys = md->keys;
     Py_ssize_t nentries = keys->nentries;
     entry_t* entries = htkeys_entries(keys);
@@ -284,6 +439,7 @@ _md_shrink(MultiDictObject* md, bool update)
     }
     ASSERT_CONSISTENT(md, update);
     return 0;
+#endif
 }
 
 static inline int
@@ -375,6 +531,15 @@ md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
             return -1;
         }
         memcpy(keys, other->keys, size);
+#ifdef Py_GIL_DISABLED
+        /* keys is a brand-new, independent allocation: the memcpy just
+           copied other->keys's live reader count and retirement link
+           along with everything else, neither of which describes this
+           new blob's own (so-far nonexistent) readers or retirement
+           state. */
+        keys->readers = 0;
+        keys->retired_next = NULL;
+#endif
         entry_t* entry = htkeys_entries(keys);
         for (Py_ssize_t idx = 0; idx < keys->nentries; idx++, entry++) {
             Py_XINCREF(entry->identity);
@@ -877,10 +1042,33 @@ md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
         goto fail;
     }
 
-    htkeysiter_t iter;
-    htkeysiter_init(&iter, md->keys, hash);
-    entry_t* entries = htkeys_entries(md->keys);
+    /* entry->identity and entry->hash are write-once-at-insertion and
+       never mutated again (aside from getall()'s temporary MD_HASH_MARK
+       toggling, still critical-section-only -- a concurrent contains()
+       can transiently race that into a false negative, which is a
+       logical staleness in the same family as the version-check
+       RuntimeError elsewhere, not a memory-safety concern). That means
+       this walk needs no per-entry synchronization beyond the table's
+       own lifetime, which md_reader_enter()/md_reader_exit() provide:
+       no atomic entry-field stores or TryIncRef dance needed here,
+       unlike md_get_one()'s value read. When pret != NULL every caller
+       already holds md's critical section (the pret == NULL path is
+       __contains__'s hot path and the only lock-free one; pret != NULL
+       is only reached from the still-locked view set-algebra helpers),
+       so _md_ensure_key()'s entry->key mutation below remains exactly
+       as safe as it always was; the reader bookkeeping is just
+       harmless extra accounting in that case. */
+#ifdef Py_GIL_DISABLED
+    htkeys_t* keys = md_reader_enter(md);
+#else
+    htkeys_t* keys = md->keys;
+#endif
 
+    htkeysiter_t iter;
+    htkeysiter_init(&iter, keys, hash);
+    entry_t* entries = htkeys_entries(keys);
+
+    int found = 0;
     for (; iter.index != DKIX_EMPTY; htkeysiter_next(&iter)) {
         if (iter.index < 0) {
             continue;
@@ -890,22 +1078,26 @@ md_contains(MultiDictObject* md, PyObject* key, PyObject** pret)
             continue;
         }
         if (_str_cmp(identity, entry->identity)) {
-            Py_DECREF(identity);
+            found = 1;
             if (pret != NULL) {
                 *pret = _md_ensure_key(md, entry);
                 if (*pret == NULL) {
-                    goto fail;
+                    found = -1;
                 }
             }
-            return 1;
+            break;
         }
     }
 
+#ifdef Py_GIL_DISABLED
+    md_reader_exit(md, keys);
+#endif
+
     Py_DECREF(identity);
-    if (pret != NULL) {
+    if (found <= 0 && pret != NULL) {
         *pret = NULL;
     }
-    return 0;
+    return found;
 fail:
     Py_XDECREF(identity);
     if (pret != NULL) {
@@ -2087,11 +2279,24 @@ md_clear(MultiDictObject* md)
     // not yet). Swapping first means a suspended thread only ever sees
     // either the fully-populated old table or the fully-empty one.
     htkeys_t* old_keys = md->keys;
-    entry_t* entries = htkeys_entries(old_keys);
-    Py_ssize_t nentries = old_keys->nentries;
     md->used = 0;
     md->keys = (htkeys_t*)&empty_htkeys;
 
+#ifdef Py_GIL_DISABLED
+    /* Unlike the critical-section-only world PR #1433 was written for,
+       a lock-free reader can now be genuinely concurrent with this
+       function, not just suspended by an arbitrary-code callback: it
+       does not take md's critical section at all. Releasing entries'
+       references here, immediately, would race such a reader's own
+       (unsynchronized) reads of those same identity/key/value fields.
+       So the entire cleanup -- decref loop included, not just the
+       final free -- is deferred to md_retire()'s drain, which only
+       ever runs at a point already proven to have no reader near this
+       table. */
+    md_retire(md, old_keys);
+#else
+    entry_t* entries = htkeys_entries(old_keys);
+    Py_ssize_t nentries = old_keys->nentries;
     for (Py_ssize_t pos = 0; pos < nentries; pos++) {
         entry_t* entry = entries + pos;
         if (entry->identity != NULL) {
@@ -2100,8 +2305,8 @@ md_clear(MultiDictObject* md)
             Py_CLEAR(entry->value);
         }
     }
-
     htkeys_free(old_keys);
+#endif
     ASSERT_CONSISTENT(md, false);
     return 0;
 }

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -264,6 +264,21 @@ _md_store_keys(MultiDictObject* md, htkeys_t* keys)
     atomic_store_ptr((void**)&md->keys, keys);
 }
 
+/* md_len() reads md->used lock-free via atomic_load_ssize_relaxed(); every
+   write to it needs the matching relaxed atomic op for the same reason
+   _md_store_keys() exists above. */
+static inline void
+_md_store_used(MultiDictObject* md, Py_ssize_t used)
+{
+    atomic_store_ssize_relaxed(&md->used, used);
+}
+
+static inline void
+_md_add_used(MultiDictObject* md, Py_ssize_t delta)
+{
+    atomic_fetch_add_ssize_relaxed(&md->used, delta);
+}
+
 static inline htkeys_t*
 _md_reader_enter(MultiDictObject* md)
 {
@@ -290,9 +305,8 @@ _md_free_retired(htkeys_t* keys)
     entry_t* entries = htkeys_entries(keys);
     /* Only md_clear()'s retired tables have live entries to release here:
    _md_resize()'s old table has its ownership already transferred to
-   the new table via memcpy (see _md_retire_resized()), so its
-   nentries is reset to 0 before retirement, making this loop a
-   no-op for that case. */
+   the new table via memcpy, so its nentries is reset to 0 before
+   retirement, making this loop a no-op for that case. */
     for (Py_ssize_t i = 0; i < keys->nentries; i++) {
         Py_CLEAR(entries[i].identity);
         Py_CLEAR(entries[i].key);
@@ -696,7 +710,11 @@ md_init(MultiDictObject* md, mod_state* state, bool is_ci, Py_ssize_t minused)
     md_clear(md);
     md->state = state;
     md->is_ci = is_ci;
+#ifdef Py_GIL_DISABLED
+    _md_store_used(md, 0);
+#else
     md->used = 0;
+#endif
     md->version = NEXT_VERSION(md->state);
 #ifdef Py_GIL_DISABLED
     _md_store_keys(md, new_keys);
@@ -765,7 +783,11 @@ md_clone_from_ht(MultiDictObject* md, MultiDictObject* other)
 
     md_clear(md);
     md->state = state;
+#ifdef Py_GIL_DISABLED
+    _md_store_used(md, used);
+#else
     md->used = used;
+#endif
     md->version = version;
     md->is_ci = is_ci;
 #ifdef Py_GIL_DISABLED
@@ -850,7 +872,11 @@ _md_add_with_hash_steal_refs(MultiDictObject* md, Py_hash_t hash,
 #endif
 
     md->version = NEXT_VERSION(md->state);
+#ifdef Py_GIL_DISABLED
+    _md_add_used(md, 1);
+#else
     md->used += 1;
+#endif
     keys->usable -= 1;
     keys->nentries += 1;
     return 0;
@@ -896,7 +922,11 @@ _md_add_for_upd_steal_refs(MultiDictObject* md, Py_hash_t hash,
 #endif
 
     md->version = NEXT_VERSION(md->state);
+#ifdef Py_GIL_DISABLED
+    _md_add_used(md, 1);
+#else
     md->used += 1;
+#endif
     keys->usable -= 1;
     keys->nentries += 1;
     return 0;
@@ -961,7 +991,7 @@ _md_del_at(MultiDictObject* md, size_t slot, entry_t* entry)
     entry->key = NULL;
     atomic_store_ptr((void**)&entry->value, NULL);
     htkeys_set_index(keys, slot, DKIX_DUMMY);
-    md->used -= 1;
+    _md_add_used(md, -1);
 
     Py_XDECREF(identity);
     Py_XDECREF(key);
@@ -2123,7 +2153,7 @@ md_post_update(MultiDictObject* md)
                     PyObject* old_identity = _md_entry_load_identity(entry);
                     atomic_store_ptr((void**)&entry->identity, NULL);
                     htkeys_set_index(keys, slot, DKIX_DUMMY);
-                    md->used -= 1;
+                    _md_add_used(md, -1);
                     Py_XDECREF(old_identity);
                     /* See _md_replace()'s comment on why both the
                        pointer and the version are checked. */
@@ -2867,10 +2897,11 @@ md_clear(MultiDictObject* md)
     // not yet). Swapping first means a suspended thread only ever sees
     // either the fully-populated old table or the fully-empty one.
     htkeys_t* old_keys = md->keys;
-    md->used = 0;
 #ifdef Py_GIL_DISABLED
+    _md_store_used(md, 0);
     _md_store_keys(md, (htkeys_t*)&empty_htkeys);
 #else
+    md->used = 0;
     md->keys = (htkeys_t*)&empty_htkeys;
 #endif
 
@@ -2907,8 +2938,6 @@ _md_check_consistency(MultiDictObject* md, bool update)
     CHECK(keys != NULL);
     Py_ssize_t calc_usable = USABLE_FRACTION(htkeys_nslots(keys));
 
-    // In the free-threaded build, shared keys may be concurrently modified,
-    // so use atomic loads.
     Py_ssize_t usable = keys->usable;
     Py_ssize_t nentries = keys->nentries;
 

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -408,17 +408,30 @@ _md_entry_load_value(entry_t* entry)
 }
 
 /* Publishes a new value, enabling PyUnstable_TryIncRef() for lock-free
-   readers, and decrefs whatever was there before only after the new
-   value is already visible, so a concurrent reader can never observe
-   entry->value mid-transition. */
+   readers. Does not touch whatever reference was there before: callers
+   that replace an already-populated entry (as opposed to filling a
+   fresh one) must drop that reference themselves, and are free to do
+   so after other suspension-risky work -- see _md_replace()/
+   _md_update() for why deferring it can matter. */
 static inline void
-_md_entry_store_value(entry_t* entry, PyObject* value)
+_md_entry_publish_value(entry_t* entry, PyObject* value)
 {
 #if _MD_HAVE_TRYINCREF
     PyUnstable_EnableTryIncRef(value);
 #endif
-    PyObject* old = _md_entry_load_value(entry);
     atomic_store_ptr((void**)&entry->value, value);
+}
+
+/* Publishes a new value and decrefs whatever was there before only
+   after the new value is already visible, so a concurrent reader can
+   never observe entry->value mid-transition. Only safe when nothing
+   else needs to happen between the two -- see _md_entry_publish_value()
+   above when the caller must defer the decref. */
+static inline void
+_md_entry_store_value(entry_t* entry, PyObject* value)
+{
+    PyObject* old = _md_entry_load_value(entry);
+    _md_entry_publish_value(entry, value);
     Py_XDECREF(old);
 }
 
@@ -556,6 +569,16 @@ _md_resize(MultiDictObject* md, uint8_t log2_newsize, bool update)
         md->keys = newkeys;
 
 #ifdef Py_GIL_DISABLED
+        /* Bump the version on every resize, not just when a caller's
+           own insert/delete/replace would bump it anyway: a freed
+           htkeys_t can get reallocated at the very same address by a
+           later resize (same size class, common in practice), so code
+           elsewhere that detects "did md->keys change under me" by
+           comparing the raw pointer alone (see _md_replace()'s and
+           _md_update()'s comments) needs a companion signal that can't
+           coincidentally repeat. */
+        md->version = NEXT_VERSION(md->state);
+
         /* Ownership of oldkeys's entries has already moved to newkeys via
            the memcpy/copy loop above; zeroing nentries tells
            _md_retire()'s cleanup there is nothing left to decref, only
@@ -965,10 +988,22 @@ _md_del_at_for_upd(MultiDictObject* md, size_t slot, entry_t* entry)
        in md_post_update()
     */
     assert(md->keys != &empty_htkeys);
-    Py_CLEAR(entry->key);
 #ifdef Py_GIL_DISABLED
-    _md_entry_clear_value(entry);
+    /* Null out both fields before dropping either reference: a decref
+       between the two can transiently suspend the critical section
+       (same allocator-lock mechanism as _md_resize()'s PyMem_Malloc(),
+       see its comment) and let a concurrent resize free the table
+       `entry` lives in, in which case the *second* field access below
+       would be a use-after-free rather than just an inconsistency a
+       caller could later detect. */
+    PyObject* old_key = entry->key;
+    PyObject* old_value = _md_entry_load_value(entry);
+    entry->key = NULL;
+    atomic_store_ptr((void**)&entry->value, NULL);
+    Py_XDECREF(old_key);
+    Py_XDECREF(old_value);
 #else
+    Py_CLEAR(entry->key);
     Py_CLEAR(entry->value);
 #endif
 }
@@ -1270,7 +1305,19 @@ md_finder_cleanup(md_finder_t* finder)
             continue;
         }
         entry_t* entry = entries + finder->iter.index;
-        if (entry->hash < 0) {
+        /* Restore only entries this exact finder marked, not any
+           marked entry the probe chain happens to pass through: under
+           free threading, that chain can also hold an entry a
+           different, concurrently-suspended finder (scanning some
+           other key whose hash shares this bucket -- easy with a
+           small table) marked with *its own* hash. Blindly restoring
+           by matching only the sign bit would overwrite that entry's
+           real hash with this finder's, corrupting it. A mark this
+           finder made is always exactly finder->hash | MD_HASH_MARK;
+           nothing else can coincidentally equal that unless the two
+           keys' hashes were equal to begin with, in which case
+           restoring to finder->hash is correct anyway. */
+        if (entry->hash == (finder->hash | MD_HASH_MARK)) {
             entry->hash = finder->hash;
         }
     }
@@ -1806,49 +1853,100 @@ _md_replace(MultiDictObject* md, PyObject* key, PyObject* value,
             PyObject* identity, Py_hash_t hash)
 {
     int found = 0;
-    md_finder_t finder = {0};
-    if (md_init_finder(md, identity, &finder) < 0) {
-        assert(PyErr_Occurred());
-        goto fail;
-    }
-    entry_t* entries = htkeys_entries(md->keys);
 
-    int tmp;
+    /* Loops at most once per concurrent resize this scan actually
+       collides with (see the Py_GIL_DISABLED branch below); a fresh
+       finder each pass means a retry costs nothing beyond redoing the
+       scan. */
+    for (;;) {
+        md_finder_t finder = {0};
+        if (md_init_finder(md, identity, &finder) < 0) {
+            assert(PyErr_Occurred());
+            return -1;
+        }
 
-    // don't grab neither key nor value but use the calculated index
-    while ((tmp = md_find_next(&finder, NULL, NULL)) > 0) {
-        entry_t* entry = entries + md_finder_index(&finder);
-        if (!found) {
-            found = 1;
-            Py_SETREF(entry->key, Py_NewRef(key));
+        int tmp;
+        bool stale = false;
+
+        // don't grab neither key nor value but use the calculated index
+        while ((tmp = md_find_next(&finder, NULL, NULL)) > 0) {
 #ifdef Py_GIL_DISABLED
-            _md_entry_store_value(entry, Py_NewRef(value));
-            _md_entry_store_hash(entry, finder.hash | MD_HASH_MARK);
-#else
-            Py_SETREF(entry->value, Py_NewRef(value));
-            entry->hash = finder.hash | MD_HASH_MARK;
+            htkeys_t* keys_before = md->keys;
+            uint64_t version_before = md->version;
 #endif
-        } else {
-            _md_del_at(md, md_finder_slot(&finder), entry);
+            entry_t* entries = htkeys_entries(md->keys);
+            entry_t* entry = entries + md_finder_index(&finder);
+            if (!found) {
+                found = 1;
+#ifdef Py_GIL_DISABLED
+                /* Finish every store to this slot before dropping the
+                   old key/value: a decref can transiently suspend the
+                   critical section (same allocator-lock mechanism as
+                   _md_resize()'s PyMem_Malloc(), see its comment),
+                   letting a concurrent resize free the table `entry`
+                   lives in. Deferring the decref to locally-saved
+                   pointers, once entry is already in its final form,
+                   means a concurrent resize's copy always sees this
+                   slot correctly replaced, whether or not it caught us
+                   mid-decref. If it did, this finder's iterator is now
+                   walking a table md->keys has moved past -- restart
+                   the scan below with a fresh one. The rescan finds
+                   this very entry again (still marked, from the store
+                   below) and correctly treats it as invisible rather
+                   than a second occurrence to replace. */
+                PyObject* old_key = entry->key;
+                PyObject* old_value = _md_entry_load_value(entry);
+                entry->key = Py_NewRef(key);
+                _md_entry_publish_value(entry, Py_NewRef(value));
+                _md_entry_store_hash(entry, finder.hash | MD_HASH_MARK);
+                Py_DECREF(old_key);
+                Py_DECREF(old_value);
+#else
+                Py_SETREF(entry->key, Py_NewRef(key));
+                Py_SETREF(entry->value, Py_NewRef(value));
+                entry->hash = finder.hash | MD_HASH_MARK;
+#endif
+            } else {
+                _md_del_at(md, md_finder_slot(&finder), entry);
+            }
+#ifdef Py_GIL_DISABLED
+            /* Checking the pointer alone isn't enough: a freed table
+               can get reallocated at the very same address by a later
+               resize (same size class, common in practice), which
+               would make a pointer-only check miss the change. Every
+               mutation bumps md->version, including ones that don't
+               otherwise touch md->keys, so compare both. */
+            if (md->keys != keys_before || md->version != version_before) {
+                stale = true;
+                break;
+            }
+#endif
         }
-    }
-    if (tmp < 0) {
-        goto fail;
-    }
+        if (stale) {
+            /* Deliberately not calling md_finder_cleanup() here: it
+               would unmark the entry the block above just replaced,
+               making the rescan below treat it as a second occurrence
+               instead of skipping it. The eventual, non-stale finder's
+               own cleanup unmarks everything this hash's chain still
+               has marked, from every attempt, not just its own. */
+            continue;
+        }
+        if (tmp < 0) {
+            md_finder_cleanup(&finder);
+            return -1;
+        }
 
-    md_finder_cleanup(&finder);
-    if (!found) {
-        if (_md_add_with_hash(md, hash, identity, key, value) < 0) {
-            goto fail;
+        md_finder_cleanup(&finder);
+        if (!found) {
+            if (_md_add_with_hash(md, hash, identity, key, value) < 0) {
+                return -1;
+            }
+            return 0;
+        } else {
+            md->version = NEXT_VERSION(md->state);
+            return 0;
         }
-        return 0;
-    } else {
-        md->version = NEXT_VERSION(md->state);
-        return 0;
     }
-fail:
-    md_finder_cleanup(&finder);
-    return -1;
 }
 
 static inline int
@@ -1877,50 +1975,86 @@ static inline int
 _md_update(MultiDictObject* md, Py_hash_t hash, PyObject* identity,
            PyObject* key, PyObject* value)
 {
-    htkeysiter_t iter;
-    htkeysiter_init(&iter, md->keys, hash);
-    entry_t* entries = htkeys_entries(md->keys);
     bool found = false;
 
-    for (; iter.index != DKIX_EMPTY; htkeysiter_next(&iter)) {
-        if (iter.index < 0) {
-            continue;
-        }
-        entry_t* entry = entries + iter.index;
-        if (hash != entry->hash) {
-            continue;
-        }
-        if (_str_cmp(identity, entry->identity)) {
-            if (!found) {
-                found = true;
-                if (entry->key == NULL) {
-                    /* entry->key could be NULL if it was deleted
-                       by the previous _md_update call during the iteration
-                       in md_update_from* functions. */
-                    assert(entry->value == NULL);
-                    entry->key = Py_NewRef(key);
-#ifdef Py_GIL_DISABLED
-                    _md_entry_store_value(entry, Py_NewRef(value));
-#else
-                    entry->value = Py_NewRef(value);
-#endif
-                } else {
-                    Py_SETREF(entry->key, Py_NewRef(key));
-#ifdef Py_GIL_DISABLED
-                    _md_entry_store_value(entry, Py_NewRef(value));
-#else
-                    Py_SETREF(entry->value, Py_NewRef(value));
-#endif
-                }
-#ifdef Py_GIL_DISABLED
-                _md_entry_store_hash(entry, hash | MD_HASH_MARK);
-#else
-                entry->hash = hash | MD_HASH_MARK;
-#endif
-            } else {
-                _md_del_at_for_upd(md, iter.slot, entry);
+    /* See _md_replace()'s comment for why this can loop: a decref
+       below can transiently suspend the critical section and let a
+       concurrent resize replace md->keys out from under this scan. */
+    for (;;) {
+        htkeysiter_t iter;
+        htkeysiter_init(&iter, md->keys, hash);
+        bool stale = false;
+
+        for (; iter.index != DKIX_EMPTY; htkeysiter_next(&iter)) {
+            if (iter.index < 0) {
+                continue;
             }
+#ifdef Py_GIL_DISABLED
+            htkeys_t* keys_before = md->keys;
+            uint64_t version_before = md->version;
+#endif
+            entry_t* entries = htkeys_entries(md->keys);
+            entry_t* entry = entries + iter.index;
+            if (hash != entry->hash) {
+                continue;
+            }
+            if (_str_cmp(identity, entry->identity)) {
+                if (!found) {
+                    found = true;
+                    if (entry->key == NULL) {
+                        /* entry->key could be NULL if it was deleted
+                           by the previous _md_update call during the iteration
+                           in md_update_from* functions. */
+                        assert(entry->value == NULL);
+                        entry->key = Py_NewRef(key);
+#ifdef Py_GIL_DISABLED
+                        _md_entry_publish_value(entry, Py_NewRef(value));
+                        _md_entry_store_hash(entry, hash | MD_HASH_MARK);
+#else
+                        entry->value = Py_NewRef(value);
+                        entry->hash = hash | MD_HASH_MARK;
+#endif
+                    } else {
+#ifdef Py_GIL_DISABLED
+                        /* Defer the old key/value's decref until entry
+                           is already in its final form -- see
+                           _md_replace()'s comment on the identical
+                           pattern above. */
+                        PyObject* old_key = entry->key;
+                        PyObject* old_value = _md_entry_load_value(entry);
+                        entry->key = Py_NewRef(key);
+                        _md_entry_publish_value(entry, Py_NewRef(value));
+                        _md_entry_store_hash(entry, hash | MD_HASH_MARK);
+                        Py_DECREF(old_key);
+                        Py_DECREF(old_value);
+#else
+                        Py_SETREF(entry->key, Py_NewRef(key));
+                        Py_SETREF(entry->value, Py_NewRef(value));
+                        entry->hash = hash | MD_HASH_MARK;
+#endif
+                    }
+                } else {
+                    _md_del_at_for_upd(md, iter.slot, entry);
+                }
+            }
+#ifdef Py_GIL_DISABLED
+            /* See _md_replace()'s comment on why both the pointer and
+               the version are checked. */
+            if (md->keys != keys_before || md->version != version_before) {
+                stale = true;
+                break;
+            }
+#endif
         }
+        if (stale) {
+            /* No cleanup to skip here (unlike _md_replace()'s finder):
+               md_post_update() unmarks everything once, for the whole
+               batch, at the very end -- so the marks this attempt
+               already made simply need to survive into the rescan,
+               which they do since nothing above touches them. */
+            continue;
+        }
+        break;
     }
 
     if (!found) {
@@ -1965,23 +2099,54 @@ fail:
 static inline void
 md_post_update(MultiDictObject* md)
 {
-    htkeys_t* keys = md->keys;
-    size_t num_slots = htkeys_nslots(keys);
-    entry_t* entries = htkeys_entries(keys);
-    for (size_t slot = 0; slot < num_slots; slot++) {
-        Py_ssize_t index = htkeys_get_index(keys, slot);
-        if (index >= 0) {
-            entry_t* entry = entries + index;
-            if (entry->key == NULL) {
-                /* the entry is marked for deletion during .update() call
-                   and not replaced with a new value */
-                Py_CLEAR(entry->identity);
-                htkeys_set_index(keys, slot, DKIX_DUMMY);
-                md->used -= 1;
+    /* See _md_replace()'s comment for why this can loop: a decref
+       below can transiently suspend the critical section and let a
+       concurrent resize replace md->keys mid-sweep. Restarting from
+       slot 0 against the current table is safe either way: an entry
+       this function already finished (identity cleared) is exactly
+       the kind _md_resize()'s copy already drops, so it simply isn't
+       there to revisit; anything not yet finished still has its
+       original identity and is copied over unchanged. */
+    for (;;) {
+        htkeys_t* keys = md->keys;
+#ifdef Py_GIL_DISABLED
+        uint64_t version_before = md->version;
+#endif
+        size_t num_slots = htkeys_nslots(keys);
+        entry_t* entries = htkeys_entries(keys);
+        bool stale = false;
+        for (size_t slot = 0; slot < num_slots; slot++) {
+            Py_ssize_t index = htkeys_get_index(keys, slot);
+            if (index >= 0) {
+                entry_t* entry = entries + index;
+                if (entry->key == NULL) {
+                    /* the entry is marked for deletion during .update() call
+                       and not replaced with a new value */
+#ifdef Py_GIL_DISABLED
+                    PyObject* old_identity = _md_entry_load_identity(entry);
+                    atomic_store_ptr((void**)&entry->identity, NULL);
+                    htkeys_set_index(keys, slot, DKIX_DUMMY);
+                    md->used -= 1;
+                    Py_XDECREF(old_identity);
+                    /* See _md_replace()'s comment on why both the
+                       pointer and the version are checked. */
+                    if (md->keys != keys || md->version != version_before) {
+                        stale = true;
+                        break;
+                    }
+#else
+                    Py_CLEAR(entry->identity);
+                    htkeys_set_index(keys, slot, DKIX_DUMMY);
+                    md->used -= 1;
+#endif
+                }
+                if (entry->hash < 0) {
+                    entry->hash &= PY_SSIZE_T_MAX;
+                }
             }
-            if (entry->hash < 0) {
-                entry->hash &= PY_SSIZE_T_MAX;
-            }
+        }
+        if (!stale) {
+            break;
         }
     }
     ASSERT_CONSISTENT(md, false);
@@ -2762,6 +2927,24 @@ _md_check_consistency(MultiDictObject* md, bool update)
         PyObject* identity = entry->identity;
 
         if (identity != NULL) {
+#ifdef Py_GIL_DISABLED
+            /* `update` describes only this call's own operation, not
+               whether some entirely different, concurrently-suspended
+               thread's _md_replace()/_md_update() (on some other key)
+               currently has an entry of its own marked (hash < 0) or
+               half-deleted (key == NULL, identity kept) pending that
+               thread's own cleanup -- critical section suspension
+               means that can be true regardless of what this call's
+               update flag says. So always use the tolerant checks
+               here; the strict !update ones remain meaningful only
+               where nothing else can be concurrently mid-operation,
+               i.e. the GIL build below. */
+            if (entry->key == NULL) {
+                CHECK(entry->value == NULL);
+            } else {
+                CHECK(entry->value != NULL);
+            }
+#else
             if (!update) {
                 CHECK(entry->hash >= 0);
                 CHECK(entry->key != NULL);
@@ -2773,6 +2956,7 @@ _md_check_consistency(MultiDictObject* md, bool update)
                     CHECK(entry->value != NULL);
                 }
             }
+#endif
 
             CHECK(PyUnicode_CheckExact(identity));
             if (entry->hash >= 0) {

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -52,13 +52,6 @@ typedef struct _htkeys {
     Py_ssize_t nentries;
 
 #ifdef Py_GIL_DISABLED
-    /* Number of lock-free readers currently walking this specific table.
-       Advisory only: freeing is gated by MultiDictObject.active_readers
-       (see _md_reader_enter()/_md_reader_exit()/_md_retire() in
-       hashtable.h), this field is a defensive assertion that the gate
-       actually worked, not itself load-bearing for safety. Relaxed
-       ordering is enough because it is only ever inspected after that
-       gate has already been observed closed. */
     Py_ssize_t readers;
 
     /* Intrusive link for MultiDictObject.retired: a table moves here

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -260,8 +260,6 @@ static const htkeys_t empty_htkeys = {
     .usable = 0, /* immutable */
     .nentries = 0,
 #ifdef Py_GIL_DISABLED
-    /* Never retired or freed (every resize path special-cases
-       `keys != &empty_htkeys`), so these are never touched. */
     .readers = 0,
     .retired_next = NULL,
 #endif

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -54,12 +54,6 @@ typedef struct _htkeys {
 #ifdef Py_GIL_DISABLED
     Py_ssize_t readers;
 
-    /* Intrusive link for MultiDictObject.retired: a table moves here
-       instead of being freed immediately if active_readers was nonzero
-       at retirement time, and is only actually freed once a later
-       resize observes the gate closed. Writer-only (always touched
-       under the owning MultiDict's critical section), so it is a plain
-       (non-atomic) field. */
     struct _htkeys* retired_next;
 #endif
 

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -51,6 +51,25 @@ typedef struct _htkeys {
     /* Number of used entries in dk_entries. */
     Py_ssize_t nentries;
 
+#ifdef Py_GIL_DISABLED
+    /* Number of lock-free readers currently walking this specific table.
+       Advisory only: freeing is gated by MultiDictObject.active_readers
+       (see md_reader_enter()/md_reader_exit()/md_retire() in
+       hashtable.h), this field is a defensive assertion that the gate
+       actually worked, not itself load-bearing for safety. Relaxed
+       ordering is enough because it is only ever inspected after that
+       gate has already been observed closed. */
+    Py_ssize_t readers;
+
+    /* Intrusive link for MultiDictObject.retired: a table moves here
+       instead of being freed immediately if active_readers was nonzero
+       at retirement time, and is only actually freed once a later
+       resize observes the gate closed. Writer-only (always touched
+       under the owning MultiDict's critical section), so it is a plain
+       (non-atomic) field. */
+    struct _htkeys* retired_next;
+#endif
+
     /* Actual hash table of dk_size entries. It holds indices in dk_entries,
        or DKIX_EMPTY(-1) or DKIX_DUMMY(-2).
 
@@ -243,18 +262,24 @@ estimate_log2_keysize(Py_ssize_t n)
  * for the rationale of using log2_index_bytes=3 instead of 0.
  */
 static const htkeys_t empty_htkeys = {
-    0, /* log2_size */
-    3, /* log2_index_bytes */
-    0, /* usable (immutable) */
-    0, /* nentries */
-    {DKIX_EMPTY,
-     DKIX_EMPTY,
-     DKIX_EMPTY,
-     DKIX_EMPTY,
-     DKIX_EMPTY,
-     DKIX_EMPTY,
-     DKIX_EMPTY,
-     DKIX_EMPTY}, /* indices */
+    .log2_size = 0,
+    .log2_index_bytes = 3,
+    .usable = 0, /* immutable */
+    .nentries = 0,
+#ifdef Py_GIL_DISABLED
+    /* Never retired or freed (every resize path special-cases
+       `keys != &empty_htkeys`), so these are never touched. */
+    .readers = 0,
+    .retired_next = NULL,
+#endif
+    .indices = {DKIX_EMPTY,
+                DKIX_EMPTY,
+                DKIX_EMPTY,
+                DKIX_EMPTY,
+                DKIX_EMPTY,
+                DKIX_EMPTY,
+                DKIX_EMPTY,
+                DKIX_EMPTY},
 };
 
 static inline Py_ssize_t
@@ -301,6 +326,10 @@ htkeys_new(uint8_t log2_size)
     keys->log2_index_bytes = log2_bytes;
     keys->nentries = 0;
     keys->usable = usable;
+#ifdef Py_GIL_DISABLED
+    keys->readers = 0;
+    keys->retired_next = NULL;
+#endif
     memset(&keys->indices[0], 0xff, ((size_t)1 << log2_bytes));
     memset(
         &keys->indices[(size_t)1 << log2_bytes], 0, sizeof(entry_t) * usable);

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -52,7 +52,7 @@ typedef struct _htkeys {
     Py_ssize_t nentries;
 
 #ifdef Py_GIL_DISABLED
-    Py_ssize_t readers;
+    Py_ssize_t num_readers;
 
     struct _htkeys* retired_next;
 #endif
@@ -254,7 +254,7 @@ static const htkeys_t empty_htkeys = {
     .usable = 0, /* immutable */
     .nentries = 0,
 #ifdef Py_GIL_DISABLED
-    .readers = 0,
+    .num_readers = 0,
     .retired_next = NULL,
 #endif
     .indices = {DKIX_EMPTY,
@@ -312,7 +312,7 @@ htkeys_new(uint8_t log2_size)
     keys->nentries = 0;
     keys->usable = usable;
 #ifdef Py_GIL_DISABLED
-    keys->readers = 0;
+    keys->num_readers = 0;
     keys->retired_next = NULL;
 #endif
     memset(&keys->indices[0], 0xff, ((size_t)1 << log2_bytes));

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -54,7 +54,7 @@ typedef struct _htkeys {
 #ifdef Py_GIL_DISABLED
     /* Number of lock-free readers currently walking this specific table.
        Advisory only: freeing is gated by MultiDictObject.active_readers
-       (see md_reader_enter()/md_reader_exit()/md_retire() in
+       (see _md_reader_enter()/_md_reader_exit()/_md_retire() in
        hashtable.h), this field is a defensive assertion that the gate
        actually worked, not itself load-bearing for safety. Relaxed
        ordering is enough because it is only ever inspected after that

--- a/multidict/_multilib/htkeys.h
+++ b/multidict/_multilib/htkeys.h
@@ -358,9 +358,24 @@ htkeys_build_indices(htkeys_t* keys, entry_t* ep, Py_ssize_t n, bool update)
     size_t mask = htkeys_mask(keys);
     for (Py_ssize_t ix = 0; ix != n; ix++, ep++) {
         Py_hash_t hash = ep->hash;
+#ifdef Py_GIL_DISABLED
+        /* Unconditionally, not just when update: under free threading
+           a marked entry copied in here can belong to an entirely
+           different, concurrently-suspended _md_replace()/_md_update()
+           call (on some other key) that this resize's own update flag
+           knows nothing about -- see the comment in
+           _md_check_consistency(). Indexing it by its temporary marked
+           hash would place it somewhere its real hash's probe sequence
+           never looks, making it permanently unfindable once the
+           owning call unmarks it back. */
+        if (hash < 0) {
+            hash &= PY_SSIZE_T_MAX;
+        }
+#else
         if (update && hash < 0) {
             hash &= PY_SSIZE_T_MAX;
         }
+#endif
         size_t i = hash & mask;
         for (size_t perturb = hash; htkeys_get_index(keys, i) != DKIX_EMPTY;) {
             perturb >>= HT_PERTURB_SHIFT;

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -1720,9 +1720,6 @@ fail:
 static inline int
 multidict_keysview_contains(_Multidict_ViewObject* self, PyObject* key)
 {
-    /* md_contains() with pret == NULL is lock-free on its own (see the
-       comment on md_contains() in hashtable.h); no critical section
-       needed here. */
     return md_contains(self->md, key, NULL);
 }
 

--- a/multidict/_multilib/views.h
+++ b/multidict/_multilib/views.h
@@ -1720,11 +1720,10 @@ fail:
 static inline int
 multidict_keysview_contains(_Multidict_ViewObject* self, PyObject* key)
 {
-    int ret;
-    Py_BEGIN_CRITICAL_SECTION(self->md);
-    ret = md_contains(self->md, key, NULL);
-    Py_END_CRITICAL_SECTION();
-    return ret;
+    /* md_contains() with pret == NULL is lock-free on its own (see the
+       comment on md_contains() in hashtable.h); no critical section
+       needed here. */
+    return md_contains(self->md, key, NULL);
 }
 
 static inline PyObject*

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1891,7 +1891,7 @@ def test_contains_lock_free_thread_safety() -> None:
     md_contains() with pret == NULL) is now genuinely lock-free -- it
     does not take self's critical section at all, unlike every other
     single-item operation, which still does. Its safety instead comes
-    from md_reader_enter()/md_reader_exit() (a coarse active_readers
+    from _md_reader_enter()/_md_reader_exit() (a coarse active_readers
     gate) plus per-table retirement: a resize/shrink/clear no longer
     frees the old hash table immediately, only once no lock-free reader
     could still be walking it. This drives many resizes concurrently
@@ -1911,6 +1911,55 @@ def test_contains_lock_free_thread_safety() -> None:
     def reader(_n: int) -> None:
         for i in range(3000):
             str(i % 500) in d
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        futures = [executor.submit(mutator, i) for i in range(8)]
+        futures += [executor.submit(reader, i) for i in range(8)]
+        for f in futures:
+            f.result()
+
+    assert len(d) == 500
+
+
+@pytest.mark.c_extension
+def test_get_lock_free_thread_safety() -> None:
+    """Concurrent get()/getone()/__getitem__ alongside heavy add()/pop()
+    churn must not crash.
+
+    Regression test for the free-threaded build: on CPython 3.14+,
+    get()/getone()/__getitem__ (md_get_one() with pret == NULL) are now
+    genuinely lock-free, falling back to a critical section only when a
+    candidate entry's identity or value can't be safely referenced
+    (PyUnstable_TryIncRef() fails, or the field changed mid-read). On
+    3.13 -- which has no public API for a third-party extension to
+    safely try-incref an object that might concurrently be reaching
+    refcount zero (PyUnstable_TryIncRef()/PyUnstable_EnableTryIncRef()
+    were only added in 3.14) -- it always takes the critical section,
+    same as before this file added any lock-free reading of entry
+    contents. Either way this must not crash: it drives many entry
+    inserts/deletes concurrently with many get() calls to exercise
+    both the lock-free fast path (3.14+) and the locked fallback
+    (3.13, or a 3.14+ TryIncRef failure). Deliberately uses only
+    add()/pop() on the mutating side, not __setitem__: __setitem__'s
+    replace path has a separate, pre-existing, unrelated race that
+    this test is not about and should not trip. This is a
+    C-extension-only concern: the pure-Python implementation has no
+    locking of its own to regress."""
+    d: MultiDict[int] = MultiDict((str(i), i) for i in range(500))
+
+    def mutator(n: int) -> None:
+        for i in range(3000):
+            key = f"m{n}-{i}"
+            d.add(key, i)
+            d.pop(key, None)
+
+    def reader(_n: int) -> None:
+        for i in range(3000):
+            key = str(i % 500)
+            d.get(key)
+            d.getone(key, None)
+            with contextlib.suppress(KeyError):
+                d[key]
 
     with ThreadPoolExecutor(max_workers=16) as executor:
         futures = [executor.submit(mutator, i) for i in range(8)]

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1882,6 +1882,45 @@ def test_view_set_ops_thread_safety() -> None:
     assert len(d) == len(list(d.items()))
 
 
+@pytest.mark.c_extension
+def test_contains_lock_free_thread_safety() -> None:
+    """Concurrent __contains__ alongside heavy add()/pop() churn must not
+    crash.
+
+    Regression test for the free-threaded build: __contains__ (via
+    md_contains() with pret == NULL) is now genuinely lock-free -- it
+    does not take self's critical section at all, unlike every other
+    single-item operation, which still does. Its safety instead comes
+    from md_reader_enter()/md_reader_exit() (a coarse active_readers
+    gate) plus per-table retirement: a resize/shrink/clear no longer
+    frees the old hash table immediately, only once no lock-free reader
+    could still be walking it. This drives many resizes concurrently
+    with many __contains__ calls specifically to exercise that
+    retire/drain path, not just the (always safe) case where
+    active_readers happens to be 0 at retirement time. This is a
+    C-extension-only concern: the pure-Python implementation has no
+    locking of its own to regress."""
+    d: MultiDict[int] = MultiDict((str(i), i) for i in range(500))
+
+    def mutator(n: int) -> None:
+        for i in range(3000):
+            key = f"m{n}-{i}"
+            d.add(key, i)
+            d.pop(key, None)
+
+    def reader(_n: int) -> None:
+        for i in range(3000):
+            str(i % 500) in d
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        futures = [executor.submit(mutator, i) for i in range(8)]
+        futures += [executor.submit(reader, i) for i in range(8)]
+        for f in futures:
+            f.result()
+
+    assert len(d) == 500
+
+
 def test_subclassed_multidict(
     any_multidict_class: type[MultiDict[str]],
 ) -> None:

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1970,6 +1970,73 @@ def test_get_lock_free_thread_safety() -> None:
     assert len(d) == 500
 
 
+@pytest.mark.c_extension
+def test_setitem_update_thread_safety() -> None:
+    """Concurrent __setitem__()/update() on colliding keys, alongside
+    concurrent add()/pop() churn that drives frequent resizes, must not
+    corrupt state or crash.
+
+    Regression test for several related, pre-existing free-threaded-build
+    races in the replace path (__setitem__()/update()/extend()/merge()),
+    found while stress-testing with an artificially widened suspension
+    window (see the PR description for how). The replace path finds a
+    key's entry, temporarily marks its hash (the sign bit) to track
+    progress across a scan that can span more than one match, mutates the
+    entry, then restores the mark once done -- and every step of that can
+    transiently suspend the critical section, exactly like the read-path
+    and _md_resize() races fixed earlier. A concurrent resize triggered by
+    an entirely different thread's add()/pop() could then observe or
+    mishandle that temporarily-marked state, corrupting the table (wrong
+    bucket placement, a different key's mark overwritten, a stale
+    entries-array pointer used after the table it pointed into was freed).
+    This is a C-extension-only concern: the pure-Python implementation has
+    no locking of its own to regress."""
+    nkeys = 30
+    d: MultiDict[object] = MultiDict((str(i), i) for i in range(nkeys))
+
+    def setitem_worker(n: int) -> None:
+        for i in range(1500):
+            d[str(i % nkeys)] = (n, i)
+
+    def dup_worker(n: int) -> None:
+        # Exercises the duplicate-collapsing path in __setitem__: add a
+        # genuine duplicate, then replace it, which must delete the dup.
+        for i in range(800):
+            key = str(i % nkeys)
+            d.add(key, ("dup", n, i))
+            d[key] = ("collapsed", n, i)
+
+    def update_worker(n: int) -> None:
+        for i in range(800):
+            d.update({str(i % nkeys): (n, i), str((i + 1) % nkeys): (n, i)})
+
+    def churn_worker(n: int) -> None:
+        for i in range(1200):
+            key = f"churn-{n}-{i}"
+            d.add(key, i)
+            d.pop(key, None)
+
+    def reader_worker(_n: int) -> None:
+        for i in range(1200):
+            key = str(i % nkeys)
+            d.get(key)
+            with contextlib.suppress(KeyError):
+                d[key]
+            key in d
+
+    with ThreadPoolExecutor(max_workers=28) as executor:
+        futures = [executor.submit(setitem_worker, i) for i in range(6)]
+        futures += [executor.submit(dup_worker, i) for i in range(4)]
+        futures += [executor.submit(update_worker, i) for i in range(4)]
+        futures += [executor.submit(churn_worker, i) for i in range(8)]
+        futures += [executor.submit(reader_worker, i) for i in range(6)]
+        for f in futures:
+            f.result()
+
+    assert len(d) == nkeys
+    assert len(d) == len(list(d.items()))
+
+
 def test_subclassed_multidict(
     any_multidict_class: type[MultiDict[str]],
 ) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

First slice of the lock-free read path deferred out of #1438: instead
of a critical section, `__contains__` now protects itself with a
reader-counted table retirement scheme, and the hash table a lock-free
reader might still be walking is kept alive until it's safe to free.

Two counters, gated entirely behind `Py_GIL_DISABLED`:

- `MultiDictObject.active_readers`: a coarse "some lock-free reader is
  in flight on this object" gate, bumped before a reader ever
  dereferences a keys table and dropped once it's done
  (`_md_reader_enter()`/`_md_reader_exit()`).
- `htkeys_t.readers`: a per-table count, advisory only, used purely as
  a defensive assertion once the coarse gate is already known closed.
  It is not itself load-bearing for safety: an embedded refcount can't
  safely announce "about to use this" without a bootstrap hazard,
  since the increment itself would dereference memory that might
  already be freed by the time it runs.

`_md_retire()`/`_md_drain_retired()`: a resize/shrink/clear no longer
frees the outgoing table immediately, only once `active_readers` reads
0 at a point synchronized (`seq_cst` on both the `md->keys` swap and
the `active_readers` ops -- anything weaker leaves a real,
architecture-dependent race, the same shape as Dekker's algorithm). A
table that can't be freed yet moves to a per-object retired list and
is freed opportunistically the next time the object resizes.

`_md_shrink()` gets a second implementation under `Py_GIL_DISABLED`:
the existing one compacts the currently-published table in place,
which races a lock-free reader walking the very memory being
rewritten. The free-threaded version reuses `_md_resize()` at the
current size instead (build a new table, swap, retire the old one),
which already has the right shape; the GIL build keeps the original
in-place version unchanged.

`md_clone_from_ht()` gets a matching fix: it `memcpy`s another live
table's header wholesale, which was copying that table's in-flight
reader count and retirement link along with everything else.

`md_contains()` with `pret == NULL` (`__contains__`'s actual call
shape) is the first lock-free consumer: `entry->identity`/`hash` are
write-once-at-insertion and never mutated again outside `getall()`'s
already-critical-section-only `MD_HASH_MARK` toggling, so this walk
needs nothing beyond the table's own lifetime protection -- no atomic
entry-field stores or `TryIncRef` machinery required, unlike `get()`'s
value read (out of scope here; deferred as its own follow-up). The
critical sections around `multidict_sq_contains` and
`multidict_keysview_contains` are removed accordingly; view
set-algebra callers of `md_contains(pret != NULL)` keep their existing
critical sections untouched.

Also fixes a small, pre-existing, unrelated bug noticed while
rewriting `md_contains()`: `identity` was decref'd once on a match,
then decref'd again via `goto fail` if `_md_ensure_key()` failed
afterward.

Renamed seven helpers in `hashtable.h` (`_md_reader_enter`,
`_md_reader_exit`, `_md_retire`, `_md_drain_retired`, `_md_calc_key`,
`_md_finder_slot`, `_md_finder_index`) to use the `_md_` prefix the
file already uses for internal-only helpers, since none of them have
callers outside the file.

`getall()` and the view set-algebra methods stay under the critical
section: `md_find_next()`/`md_finder_cleanup()` mark visited entries
by mutating `entry->hash` in place (`MD_HASH_MARK`), which races any
concurrent access to those entries the same way `_md_shrink()`'s
in-place compaction did. Fixing that needs moving the visited-tracking
to a call-local structure instead of shared entry state -- a
self-contained follow-up, not attempted here. `get()`/`getone()`/
`__getitem__` likewise stay locked, needing atomic stores at every
entry-mutation site plus `PyUnstable_TryIncRef` on read.

## Are there changes in behavior for the user?

No behavior change for single-threaded code or the default GIL build.
On the free-threaded build, `__contains__` no longer takes a critical
section.

## Is it a substantial burden for the maintainers to support this?

Some: this introduces the reclamation scheme the rest of the lock-free
read work will build on, so it's more surface than a typical PR, but
it's confined to `hashtable.h` and gated entirely behind
`Py_GIL_DISABLED`; no behavior change on the GIL build and no new
public API.

## Related issue number

N/A, no linked issue.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
- [x] `make doc-spelling` passes and any new technical words are added to `docs/spelling_wordlist.txt`

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: `pytest -q` on the default GIL build (1834 passed) and on a
free-threaded `3.13.7t` build, both release and
`MULTIDICT_DEBUG_BUILD=1` (1829 passed, 5 skipped each), re-verified
after each structural change (retirement scheme, `_md_shrink`
rewrite, `md_contains` conversion, the rename) and again after
rebasing onto master's #1440.

Added `test_contains_lock_free_thread_safety`, driving heavy
concurrent `add()`/`pop()` churn against concurrent `in` checks
specifically to exercise the retire/drain path, not just the
(always-safe) case where `active_readers` happens to already be 0 at
retirement time.

Same honest caveat as on #1438's second regression test: I could not
force a crash on a deliberately-unprotected version of `md_contains`
by stress-testing it (release build, debug build, a heavier
standalone script) -- this allocator doesn't poison freed memory, so
a stale read tends to return coherent-looking bytes rather than
crash. The race is real by construction (verified by manually
disabling the protection and reviewing the resulting code path), just
not reliably reproducible empirically in this environment.

`make doc-spelling` passes clean (the pre-existing "fallbacks"
wordlist gap from #1438 was fixed by #1439, already on master).

Drafted with Claude Code (Sonnet 5); reviewed by andrew.svetlov@gmail.com.
</details>