### PR TITLE
Drain md->retired from reader exit, not just resize/clear

### DIFF
--- a/CHANGES/1443.bugfix.rst
+++ b/CHANGES/1443.bugfix.rst
@@ -1,0 +1,10 @@
+Fixed an unbounded memory leak on the free-threaded build where a retired
+hash table could sit on ``md->retired`` for the rest of the object's
+lifetime under sustained concurrent read traffic: only a later
+resize/``clear()`` ever drained it, and if the active-readers gate never
+happened to land on exactly 0 at the moment one of those ran, nothing
+else would ever free it. Reader exit now opportunistically drains
+``md->retired`` itself, and retiring a table pushes it onto that list
+before checking whether it can be freed immediately, closing a window
+where a concurrent reader's own check could otherwise run between the
+two and observe nothing to reclaim -- by :user:`asvetlov`.

--- a/CHANGES/1443.bugfix.rst
+++ b/CHANGES/1443.bugfix.rst
@@ -1,10 +1,4 @@
 Fixed an unbounded memory leak on the free-threaded build where a retired
 hash table could sit on ``md->retired`` for the rest of the object's
-lifetime under sustained concurrent read traffic: only a later
-resize/``clear()`` ever drained it, and if the active-readers gate never
-happened to land on exactly 0 at the moment one of those ran, nothing
-else would ever free it. Reader exit now opportunistically drains
-``md->retired`` itself, and retiring a table pushes it onto that list
-before checking whether it can be freed immediately, closing a window
-where a concurrent reader's own check could otherwise run between the
-two and observe nothing to reclaim -- by :user:`asvetlov`.
+lifetime under sustained concurrent read traffic instead of being freed
+-- by :user:`asvetlov`.

--- a/multidict/_multilib/atomic_helpers.h
+++ b/multidict/_multilib/atomic_helpers.h
@@ -63,6 +63,28 @@ atomic_load_ptr(void* const* obj)
     return __atomic_load_n(obj, __ATOMIC_SEQ_CST);
 }
 
+static inline void*
+atomic_exchange_ptr(void** obj, void* value)
+{
+    return __atomic_exchange_n(obj, value, __ATOMIC_SEQ_CST);
+}
+
+/* Weak CAS: may fail spuriously even when *obj == *expected, so callers
+   must retry in a loop (the standard pattern; see its stdatomic.h and
+   MSVC siblings below for the same contract). On failure, *expected is
+   updated to the observed current value, so a retry loop can reuse it
+   without an extra load. */
+static inline int
+atomic_compare_exchange_ptr(void** obj, void** expected, void* desired)
+{
+    return __atomic_compare_exchange_n(obj,
+                                       expected,
+                                       desired,
+                                       1 /* weak */,
+                                       __ATOMIC_SEQ_CST,
+                                       __ATOMIC_SEQ_CST);
+}
+
 static inline void
 atomic_store_ptr(void** obj, void* value)
 {
@@ -120,6 +142,27 @@ static inline void
 atomic_store_ptr(void** obj, void* value)
 {
     atomic_store_explicit((void* _Atomic*)obj, value, memory_order_seq_cst);
+}
+
+static inline void*
+atomic_exchange_ptr(void** obj, void* value)
+{
+    return atomic_exchange_explicit(
+        (void* _Atomic*)obj, value, memory_order_seq_cst);
+}
+
+/* Weak CAS: may fail spuriously even when *obj == *expected, so callers
+   must retry in a loop. On failure, *expected is updated to the
+   observed current value, so a retry loop can reuse it without an
+   extra load. */
+static inline int
+atomic_compare_exchange_ptr(void** obj, void** expected, void* desired)
+{
+    return atomic_compare_exchange_weak_explicit((void* _Atomic*)obj,
+                                                 expected,
+                                                 desired,
+                                                 memory_order_seq_cst,
+                                                 memory_order_seq_cst);
 }
 
 #elif defined(_MSC_VER)
@@ -192,6 +235,31 @@ static inline void
 atomic_store_ptr(void** obj, void* value)
 {
     (void)_InterlockedExchangePointer((void* volatile*)obj, value);
+}
+
+static inline void*
+atomic_exchange_ptr(void** obj, void* value)
+{
+    return _InterlockedExchangePointer((void* volatile*)obj, value);
+}
+
+/* Weak-CAS contract for parity with the GCC/C11 backends above (see
+   their comments): on failure *expected is updated to the value
+   observed at the exchange point, so a caller's retry loop can reuse
+   it without an extra load. MSVC's intrinsic is already a strong CAS;
+   exposing it as "weak" costs nothing since a spurious-failure retry
+   loop handles a strong CAS's success/failure outcomes too. */
+static inline int
+atomic_compare_exchange_ptr(void** obj, void** expected, void* desired)
+{
+    void* initial = *expected;
+    void* prev = _InterlockedCompareExchangePointer(
+        (void* volatile*)obj, desired, initial);
+    if (prev == initial) {
+        return 1;
+    }
+    *expected = prev;
+    return 0;
 }
 
 #else

--- a/multidict/_multilib/atomic_helpers.h
+++ b/multidict/_multilib/atomic_helpers.h
@@ -69,11 +69,6 @@ atomic_exchange_ptr(void** obj, void* value)
     return __atomic_exchange_n(obj, value, __ATOMIC_SEQ_CST);
 }
 
-/* Weak CAS: may fail spuriously even when *obj == *expected, so callers
-   must retry in a loop (the standard pattern; see its stdatomic.h and
-   MSVC siblings below for the same contract). On failure, *expected is
-   updated to the observed current value, so a retry loop can reuse it
-   without an extra load. */
 static inline int
 atomic_compare_exchange_ptr(void** obj, void** expected, void* desired)
 {
@@ -151,10 +146,6 @@ atomic_exchange_ptr(void** obj, void* value)
         (void* _Atomic*)obj, value, memory_order_seq_cst);
 }
 
-/* Weak CAS: may fail spuriously even when *obj == *expected, so callers
-   must retry in a loop. On failure, *expected is updated to the
-   observed current value, so a retry loop can reuse it without an
-   extra load. */
 static inline int
 atomic_compare_exchange_ptr(void** obj, void** expected, void* desired)
 {
@@ -243,12 +234,6 @@ atomic_exchange_ptr(void** obj, void* value)
     return _InterlockedExchangePointer((void* volatile*)obj, value);
 }
 
-/* Weak-CAS contract for parity with the GCC/C11 backends above (see
-   their comments): on failure *expected is updated to the value
-   observed at the exchange point, so a caller's retry loop can reuse
-   it without an extra load. MSVC's intrinsic is already a strong CAS;
-   exposing it as "weak" costs nothing since a spurious-failure retry
-   loop handles a strong CAS's success/failure outcomes too. */
 static inline int
 atomic_compare_exchange_ptr(void** obj, void** expected, void* desired)
 {

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -249,6 +249,41 @@ of the whole object's num_active_readers reaching 0 would reintroduce the
 same bootstrap race the coarse gate exists to close (see the design
 discussion; true per-table precision under sustained concurrent read
 load needs epoch tagging, which this does not attempt).
+
+_md_reader_exit()'s own num_active_readers decrement (E above) is a
+seq_cst atomic_fetch_add_ssize(), which hands back the pre-decrement
+count for free. When that count was 1, this reader's decrement is the
+one that brings the global gate to 0, at the exact same linearization
+point a writer's atomic_load_ssize(&md->num_active_readers) == 0 check
+would observe. The safety argument above never distinguished who
+performs that check; it only depends on num_active_readers reaching 0
+under seq_cst. So the reader may drain md->retired right there instead
+of leaving every table on it stranded until some future writer happens
+to retire another one and observe the same zero (see md->retired below
+for why a concurrent drain from this path is safe against a writer
+retiring into the same list at the same time).
+
+md->retired is a lock-free stack (Treiber-style), not a plain
+writer-owned list: with readers now able to drain it too, pushes
+(_md_retire()) and pop-alls (_md_drain_retired()) can run concurrently
+with each other, on different threads, with no lock in common. A
+pop-all is a single atomic_exchange_ptr() that swaps the whole chain
+out for NULL and hands the caller sole ownership of whatever it
+returns; any push racing that exchange either lands before it (and
+gets swept up in the same pop) or after it (and starts a fresh chain
+from NULL), never in between, because there is no "in between" for a
+single atomic RMW. A push cannot use that same trick: it has to link
+the new node's ->retired_next to the current head before publishing
+the node, and if it read that head with a plain load, a pop-all could
+slip in after the load and free the very chain the push is about to
+link to, publishing a node whose ->retired_next dangles. The
+atomic_compare_exchange_ptr() loop in _md_retire() closes that window
+instead of merely narrowing it: the head is only published once the
+CAS confirms nothing changed it since the read that fed
+->retired_next, and if something did (a pop-all ran, or another
+push), the loop rereads the new head and relinks before retrying, so
+->retired_next is never stale at the moment the node actually becomes
+visible.
 */
 
 /* Every write to md->keys that a lock-free reader could observe must
@@ -291,12 +326,19 @@ _md_reader_enter(MultiDictObject* md)
 }
 
 static inline void
+_md_drain_retired(MultiDictObject* md);
+
+static inline void
 _md_reader_exit(MultiDictObject* md, htkeys_t* keys)
 {
     if (keys != &empty_htkeys) {
         atomic_fetch_add_ssize_relaxed(&keys->num_readers, -1);
     }
-    atomic_fetch_add_ssize(&md->num_active_readers, -1);
+    Py_ssize_t prev_active_readers =
+        atomic_fetch_add_ssize(&md->num_active_readers, -1);
+    if (prev_active_readers == 1) {
+        _md_drain_retired(md);
+    }
 }
 
 static inline void
@@ -315,17 +357,22 @@ _md_free_retired(htkeys_t* keys)
     htkeys_free(keys);
 }
 
+/* Pop the entire md->retired chain in one atomic RMW, so a concurrent
+   push (see _md_retire()'s CAS loop) can never observe a torn or
+   partially-drained list: it either lands before this exchange (and
+   gets swept into the chain returned here) or after it (and starts a
+   fresh chain from the NULL this exchange just installed). Callers
+   must already have established atomic_load_ssize(&md->num_active_readers)
+   == 0 at a seq_cst point of their own (see the reader- and
+   writer-side call sites), which is what makes it safe to actually
+   free what this pops, not just to pop it. */
 static inline void
 _md_drain_retired(MultiDictObject* md)
 {
-    if (md->retired == NULL) {
-        return;
-    }
     if (atomic_load_ssize(&md->num_active_readers) != 0) {
         return;
     }
-    htkeys_t* t = md->retired;
-    md->retired = NULL;
+    htkeys_t* t = (htkeys_t*)atomic_exchange_ptr((void**)&md->retired, NULL);
     while (t != NULL) {
         htkeys_t* next = t->retired_next;
         assert(atomic_load_ssize_relaxed(&t->num_readers) == 0);
@@ -341,12 +388,48 @@ _md_retire(MultiDictObject* md, htkeys_t* keys)
         return;
     }
     _md_drain_retired(md);
-    if (atomic_load_ssize(&md->num_active_readers) == 0) {
-        _md_free_retired(keys);
-    } else {
-        keys->retired_next = md->retired;
-        md->retired = keys;
+
+    /* Push before checking whether the gate is already at 0, never
+       after: a "check gate, then either free now or push" order (what
+       this used to do) leaves a window between that check and the push
+       during which a concurrent reader's own zero-check (see
+       _md_reader_exit()) can run, see nothing on md->retired yet, and
+       walk away -- with active_readers back at 0 and no other
+       resize/clear coming, nothing will ever call _md_drain_retired()
+       on this object again, so a table pushed into that window is
+       stranded for the object's remaining lifetime, exactly the
+       unbounded growth in aio-libs/multidict#1443.
+
+       Pushing first closes it: keys is linked into md->retired (a seq_cst
+       CAS, so a happens-before edge to any load that observes it)
+       before this thread's own drain call below ever reads
+       num_active_readers. Whichever zero-check turns out to be the
+       last one to run after that push -- this one, or the check inside
+       some reader's own _md_drain_retired() call after a later
+       zero-decrement -- is guaranteed to see keys already linked in:
+       a push that already happened cannot be observed as "not yet
+       pushed" by a check that runs after it, and _md_drain_retired()
+       only ever pops the chain when its own check reads 0, never
+       leaving a live table behind unpopped once some check does see 0.
+
+       Link-then-CAS, not link-then-store: a reader's
+       _md_drain_retired() can pop the whole chain (via
+       atomic_exchange_ptr) concurrently with this push. A plain store
+       here could publish keys with ->retired_next pointing at a chain
+       a concurrent pop-all just freed. The CAS only succeeds when
+       old_head is still the current head at the moment keys is
+       published; on failure it retries with the head a concurrent
+       pop-all or push actually left behind. */
+    htkeys_t* old_head =
+        (htkeys_t*)atomic_load_ptr((void* const*)&md->retired);
+    for (;;) {
+        keys->retired_next = old_head;
+        if (atomic_compare_exchange_ptr(
+                (void**)&md->retired, (void**)&old_head, keys)) {
+            break;
+        }
     }
+    _md_drain_retired(md);
 }
 
 #if PY_VERSION_HEX >= 0x030e0000

--- a/multidict/_multilib/hashtable.h
+++ b/multidict/_multilib/hashtable.h
@@ -357,15 +357,6 @@ _md_free_retired(htkeys_t* keys)
     htkeys_free(keys);
 }
 
-/* Pop the entire md->retired chain in one atomic RMW, so a concurrent
-   push (see _md_retire()'s CAS loop) can never observe a torn or
-   partially-drained list: it either lands before this exchange (and
-   gets swept into the chain returned here) or after it (and starts a
-   fresh chain from the NULL this exchange just installed). Callers
-   must already have established atomic_load_ssize(&md->num_active_readers)
-   == 0 at a seq_cst point of their own (see the reader- and
-   writer-side call sites), which is what makes it safe to actually
-   free what this pops, not just to pop it. */
 static inline void
 _md_drain_retired(MultiDictObject* md)
 {
@@ -389,37 +380,6 @@ _md_retire(MultiDictObject* md, htkeys_t* keys)
     }
     _md_drain_retired(md);
 
-    /* Push before checking whether the gate is already at 0, never
-       after: a "check gate, then either free now or push" order (what
-       this used to do) leaves a window between that check and the push
-       during which a concurrent reader's own zero-check (see
-       _md_reader_exit()) can run, see nothing on md->retired yet, and
-       walk away -- with active_readers back at 0 and no other
-       resize/clear coming, nothing will ever call _md_drain_retired()
-       on this object again, so a table pushed into that window is
-       stranded for the object's remaining lifetime, exactly the
-       unbounded growth in aio-libs/multidict#1443.
-
-       Pushing first closes it: keys is linked into md->retired (a seq_cst
-       CAS, so a happens-before edge to any load that observes it)
-       before this thread's own drain call below ever reads
-       num_active_readers. Whichever zero-check turns out to be the
-       last one to run after that push -- this one, or the check inside
-       some reader's own _md_drain_retired() call after a later
-       zero-decrement -- is guaranteed to see keys already linked in:
-       a push that already happened cannot be observed as "not yet
-       pushed" by a check that runs after it, and _md_drain_retired()
-       only ever pops the chain when its own check reads 0, never
-       leaving a live table behind unpopped once some check does see 0.
-
-       Link-then-CAS, not link-then-store: a reader's
-       _md_drain_retired() can pop the whole chain (via
-       atomic_exchange_ptr) concurrently with this push. A plain store
-       here could publish keys with ->retired_next pointing at a chain
-       a concurrent pop-all just freed. The CAS only succeeds when
-       old_head is still the current head at the moment keys is
-       published; on failure it retries with the head a concurrent
-       pop-all or push actually left behind. */
     htkeys_t* old_head =
         (htkeys_t*)atomic_load_ptr((void* const*)&md->retired);
     for (;;) {

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -5,6 +5,7 @@ import gc
 import operator
 import platform
 import sys
+import threading
 import time
 import weakref
 from collections import deque
@@ -1989,8 +1990,14 @@ def test_reader_exit_drains_retired_thread_safety() -> None:
     then relies solely on later reader exits, with no further mutation,
     to reclaim it. Before the fix this leaves the weakrefs alive forever;
     after it, some reader's own exit drains the table once the gate
-    happens to fall to 0. This is a C-extension-only concern: the
-    pure-Python implementation has no retirement scheme to regress."""
+    happens to fall to 0. Each reader signals readiness only after a
+    warm-up batch of reads, then keeps going straight into its main
+    loop with no further blocking; clear() waits for every signal
+    before running, so it cannot land before a reader has actually
+    started (a plain submit() only queues the call, it says nothing
+    about whether the thread has run yet). This is a C-extension-only
+    concern: the pure-Python implementation has no retirement scheme to
+    regress."""
 
     class Marker:
         pass
@@ -2005,12 +2012,19 @@ def test_reader_exit_drains_retired_thread_safety() -> None:
     # `assert` below regardless of what multidict does.
     del markers, i, m
 
-    def reader(_n: int) -> None:
-        for i in range(50_000):
+    ready_events = [threading.Event() for _ in range(16)]
+
+    def reader(_n: int, ready: threading.Event) -> None:
+        for i in range(200):
+            str(i % 200) in d
+        ready.set()
+        for i in range(20_000):
             str(i % 200) in d
 
-    with ThreadPoolExecutor(max_workers=8) as executor:
-        futures = [executor.submit(reader, i) for i in range(8)]
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        futures = [executor.submit(reader, i, ready_events[i]) for i in range(16)]
+        for ready in ready_events:
+            ready.wait()
         d.clear()
         for f in futures:
             f.result()

--- a/tests/test_multidict.py
+++ b/tests/test_multidict.py
@@ -1971,6 +1971,55 @@ def test_get_lock_free_thread_safety() -> None:
 
 
 @pytest.mark.c_extension
+def test_reader_exit_drains_retired_thread_safety() -> None:
+    """A retired hash table must eventually be freed by reader traffic
+    alone, with no further mutation. Regression test for
+    aio-libs/multidict#1443.
+
+    md->retired only used to be drained inside _md_retire(), i.e. as a
+    side effect of some *later* resize/clear checking whether the
+    active-readers gate had reached 0. _md_reader_exit() never triggered
+    a drain itself, so under read traffic frequent enough that the gate
+    rarely lands on exactly 0 at the moment some other resize/clear
+    happens to check it, a table already on md->retired could sit there
+    for the rest of the object's life. This drives many reader threads
+    continuously across a single clear() (so the active-readers gate is
+    essentially always nonzero at the instant clear() checks it, forcing
+    the table onto md->retired instead of freeing it immediately) and
+    then relies solely on later reader exits, with no further mutation,
+    to reclaim it. Before the fix this leaves the weakrefs alive forever;
+    after it, some reader's own exit drains the table once the gate
+    happens to fall to 0. This is a C-extension-only concern: the
+    pure-Python implementation has no retirement scheme to regress."""
+
+    class Marker:
+        pass
+
+    d: MultiDict[Marker] = MultiDict()
+    markers = [Marker() for _ in range(200)]
+    refs = [weakref.ref(m) for m in markers]
+    for i, m in enumerate(markers):
+        d.add(str(i), m)
+    # A for loop's variables outlive the loop in their enclosing scope, so
+    # `i`/`m` would otherwise keep the last marker alive right through the
+    # `assert` below regardless of what multidict does.
+    del markers, i, m
+
+    def reader(_n: int) -> None:
+        for i in range(50_000):
+            str(i % 200) in d
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(reader, i) for i in range(8)]
+        d.clear()
+        for f in futures:
+            f.result()
+
+    gc.collect()
+    assert all(r() is None for r in refs)
+
+
+@pytest.mark.c_extension
 def test_setitem_update_thread_safety() -> None:
     """Concurrent __setitem__()/update() on colliding keys, alongside
     concurrent add()/pop() churn that drives frequent resizes, must not


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

On the free-threaded build, a resize/`clear()` retires its old hash table onto `md->retired` instead of freeing it immediately when a lock-free reader might still be using it, and only `_md_retire()` ever drained that list, as a side effect of a later resize/`clear()` checking whether the active-readers gate had reached 0. `_md_reader_exit()` never triggered a drain itself, so under read traffic frequent enough that the gate rarely lands on exactly 0 at the moment some other resize/`clear()` happens to check it, a retired table could sit on `md->retired` for the rest of the object's life: an unbounded memory leak under sustained concurrent read and write load.

`_md_reader_exit()` now drains `md->retired` itself when its own decrement brings the gate to 0. That makes `md->retired` a genuine lock-free stack (pushes from `_md_retire()` and pop-alls from `_md_drain_retired()` now run concurrently with each other, not just with readers walking a table), so pushing needs a CAS loop instead of a plain link, and `_md_retire()` has to push before checking whether the gate is already at 0 rather than after; checking first left a window where a concurrent reader's own check could run in between and find nothing yet to reclaim.

This is a C-extension-only, free-threaded-build-only concern; the pure-Python implementation has no retirement scheme to regress.

## Are there changes in behavior for the user?

No observable behavior change; this only affects internal memory reclamation timing on the free-threaded build.

## Is it a substantial burden for the maintainers to support this?

No. The change is localized to `_md_reader_exit()`/`_md_retire()`/`_md_drain_retired()` in `hashtable.h` plus two small pointer-atomic helpers in `atomic_helpers.h` (GCC/Clang, C11, and MSVC backends), with a dedicated regression test.

## Related issue number

Fixes #1443

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- N/A If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
- [x] `make doc-spelling` passes and any new technical words are added to `docs/spelling_wordlist.txt`

Drafted with Claude Code (Sonnet 5); reviewed by asvetlov.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: full suite passed on the free-threaded debug build (`MULTIDICT_DEBUG_BUILD=1`, Python 3.14.7 free-threaded, `python -X gil=0 -m pytest -q`), the free-threaded release build, the default GIL-enabled C extension build, and the pure-Python build (`MULTIDICT_NO_EXTENSIONS=1`).

New test (`test_reader_exit_drains_retired_thread_safety`) was verified to fail reliably (10/10 runs) against the pre-fix code and pass reliably (20/20 runs) against the fix.

Lint: `pre-commit run` (ruff, clang-format, mypy) passed on all changed files. `make doc-spelling` passed.
</details>
